### PR TITLE
[TAB-6554] Replace platform persistence with null persistor if platform is not restartable

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/InMemoryKeyValueStorage.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/InMemoryKeyValueStorage.java
@@ -1,0 +1,68 @@
+package com.tc.objectserver.persistence;
+
+import org.terracotta.persistence.KeyValueStorage;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author vmad
+ */
+public class InMemoryKeyValueStorage<K, V> implements KeyValueStorage<K, V> {
+
+    private final Map<K, V> delegate = new ConcurrentHashMap<>();
+
+    @Override
+    public Set<K> keySet() {
+        return delegate.keySet();
+    }
+
+    @Override
+    public Collection<V> values() {
+        return delegate.values();
+    }
+
+    @Override
+    public long size() {
+        return delegate.size();
+    }
+
+    @Override
+    public void put(K key, V value) {
+        put(key, value, (byte)0);
+    }
+
+    @Override
+    public void put(K key, V value, byte metadata) {
+        delegate.put(key, value);
+    }
+
+    @Override
+    public V get(K key) {
+        return delegate.get(key);
+    }
+
+    @Override
+    public boolean remove(K key) {
+        return delegate.remove(key) != null;
+    }
+
+    @Override
+    public void removeAll(Collection<K> keys) {
+        for(K key : keys) {
+            delegate.remove(key);
+        }
+    }
+
+    @Override
+    public boolean containsKey(K key) {
+        return delegate.containsKey(key);
+    }
+
+    @Override
+    public void clear() {
+        delegate.clear();
+    }
+}

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/NullPlatformPersistentStorage.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/NullPlatformPersistentStorage.java
@@ -1,0 +1,69 @@
+package com.tc.objectserver.persistence;
+
+import org.terracotta.persistence.IPersistentStorage;
+import org.terracotta.persistence.KeyValueStorage;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author vmad
+ */
+public class NullPlatformPersistentStorage implements IPersistentStorage {
+
+    final Map<String, String> properties = new ConcurrentHashMap<>();
+    final Map<String, KeyValueStorage<?, ?>> maps = new ConcurrentHashMap<>();
+
+    @Override
+    public void open() throws IOException {
+        //nothing to do
+    }
+
+    @Override
+    public void create() throws IOException {
+        //nothing to do
+    }
+
+    @Override
+    public void close() {
+        //nothing to do
+    }
+
+    @Override
+    public Transaction begin() {
+        return new Transaction() {
+            @Override
+            public void commit() {
+                //nothing to do
+            }
+
+            @Override
+            public void abort() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    @Override
+    public <K, V> KeyValueStorage<K, V> getKeyValueStorage(String alias, Class<K> keyClass, Class<V> valueClass) {
+        maps.putIfAbsent(alias, new InMemoryKeyValueStorage<K, V>());
+        return (KeyValueStorage<K, V>) maps.get(alias);
+    }
+
+    @Override
+    public <K, V> KeyValueStorage<K, V> createKeyValueStorage(String alias, Class<K> keyClass, Class<V> valueClass) {
+        maps.putIfAbsent(alias, new InMemoryKeyValueStorage<K, V>());
+        return (KeyValueStorage<K, V>) maps.get(alias);
+    }
+
+    @Override
+    public <K, V> KeyValueStorage<K, V> destroyKeyValueStorage(String alias) {
+        return (KeyValueStorage<K, V>) maps.remove(alias);
+    }
+}

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/NullPlatformStorageConfiguration.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/NullPlatformStorageConfiguration.java
@@ -1,0 +1,14 @@
+package com.tc.objectserver.persistence;
+
+import org.terracotta.entity.ServiceConfiguration;
+import org.terracotta.persistence.IPersistentStorage;
+
+/**
+ * @author vmad
+ */
+public class NullPlatformStorageConfiguration implements ServiceConfiguration<IPersistentStorage> {
+    @Override
+    public Class<IPersistentStorage> getServiceType() {
+        return IPersistentStorage.class;
+    }
+}

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/NullPlatformStorageProviderConfiguration.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/NullPlatformStorageProviderConfiguration.java
@@ -1,0 +1,14 @@
+package com.tc.objectserver.persistence;
+
+import org.terracotta.entity.ServiceProvider;
+import org.terracotta.entity.ServiceProviderConfiguration;
+
+/**
+ * @author vmad
+ */
+public class NullPlatformStorageProviderConfiguration implements ServiceProviderConfiguration {
+    @Override
+    public Class<? extends ServiceProvider> getServiceProviderType() {
+        return NullPlatformStorageServiceProvider.class;
+    }
+}

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/NullPlatformStorageServiceProvider.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/NullPlatformStorageServiceProvider.java
@@ -1,0 +1,41 @@
+package com.tc.objectserver.persistence;
+
+import org.terracotta.entity.ServiceConfiguration;
+import org.terracotta.entity.ServiceProvider;
+import org.terracotta.entity.ServiceProviderConfiguration;
+import org.terracotta.persistence.IPersistentStorage;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author vmad
+ */
+public class NullPlatformStorageServiceProvider implements ServiceProvider {
+    private final Map<Long, IPersistentStorage> providers = new ConcurrentHashMap<>();
+
+
+    @Override
+    public boolean initialize(ServiceProviderConfiguration serviceProviderConfiguration) {
+        return true;
+    }
+
+    @Override
+    public <T> T getService(long entityID, ServiceConfiguration<T> serviceConfiguration) {
+        providers.putIfAbsent(entityID, new NullPlatformPersistentStorage());
+        return serviceConfiguration.getServiceType().cast(providers.get(entityID));
+    }
+
+    @Override
+    public Collection<Class<?>> getProvidedServiceTypes() {
+        return Collections.singleton(IPersistentStorage.class);
+    }
+
+    @Override
+    public void close() throws IOException {
+        providers.clear();
+    }
+}


### PR DESCRIPTION
This PR introduces a new IPersistentStorage impl, NullPlatformPersistentStorage which doesn't persist any data and replaces platform persistence with this if platform is not restartable. We can change the name of this persistor if current one is confusing. 