### PR TITLE
Active passive cleanup

### DIFF
--- a/dso-l2/src/main/java/com/tc/l2/api/ReplicatedClusterStateManager.java
+++ b/dso-l2/src/main/java/com/tc/l2/api/ReplicatedClusterStateManager.java
@@ -32,4 +32,6 @@ public interface ReplicatedClusterStateManager {
 
   public void setCurrentState(State currentState);
 
+  public Iterable<NodeID> getPassives();
+
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
@@ -22,6 +22,9 @@ package com.tc.objectserver.api;
 import org.terracotta.entity.ClientDescriptor;
 import com.tc.net.NodeID;
 import com.tc.object.EntityID;
+import org.terracotta.entity.EntityMessage;
+import org.terracotta.entity.EntityResponse;
+import org.terracotta.entity.MessageCodec;
 
 
 /**
@@ -33,9 +36,17 @@ public interface ManagedEntity {
   public EntityID getID();
   
   public long getVersion();
+ /** 
+  * Schedules the request with the entity on the execution queue.
+  * 
+  * @param <M> payload of the request
+  * @param request translated request for execution on the server
+  */ 
+  void addInvokeRequest(ServerEntityRequest request, byte[] extendedData);
   
-  public void addRequest(ServerEntityRequest request);
+  void processSyncMessage(ServerEntityRequest sync, byte[] payload, int concurrencyKey);
   
+  void addLifecycleRequest(ServerEntityRequest create, byte[] data);
   /**
    * Called to handle the reconnect for a specific client instance living on a specific node.
    * This is called after restart or fail-over to re-associate a formerly connected client with its server-side entities.

--- a/dso-l2/src/main/java/com/tc/objectserver/api/ServerEntityRequest.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/api/ServerEntityRequest.java
@@ -39,8 +39,6 @@ public interface ServerEntityRequest {
    */
   ClientDescriptor getSourceDescriptor();
 
-  byte[] getPayload();
-
   void complete();
 
   void complete(byte[] value);
@@ -50,12 +48,4 @@ public interface ServerEntityRequest {
   void received();
 
   boolean requiresReplication();
-
-  /**
-   * NOTE:  This method is only used for one kind of sync message so we probably need to refactor this to avoid these 
-   * tendrils of specialization.
-   * 
-   * @return The concurrency key set on the request
-   */
-  int getConcurrencyKey();
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/AbstractServerEntityRequest.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/AbstractServerEntityRequest.java
@@ -94,6 +94,7 @@ public abstract class AbstractServerEntityRequest implements ServerEntityRequest
       message.send();
     });
     done = true;
+    this.notifyAll();
   }
 
   @Override
@@ -124,6 +125,7 @@ public abstract class AbstractServerEntityRequest implements ServerEntityRequest
       }
     });
     done = true;
+    this.notifyAll();
   }
   
   @Override
@@ -141,6 +143,7 @@ public abstract class AbstractServerEntityRequest implements ServerEntityRequest
       }
     });
     done = true;
+    this.notifyAll();
   }  
   
   protected EntityDescriptor getEntityDescriptor() {
@@ -150,4 +153,18 @@ public abstract class AbstractServerEntityRequest implements ServerEntityRequest
   protected boolean isDone() {
     return done;
   }  
+  
+  public synchronized void waitForDone() {
+    boolean interrupted = false;
+    while (!done) {
+      try {
+        wait();
+      } catch (InterruptedException ie) {
+        interrupted = true;
+      }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
+  }
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/AbstractServerEntityRequest.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/AbstractServerEntityRequest.java
@@ -38,18 +38,16 @@ public abstract class AbstractServerEntityRequest implements ServerEntityRequest
   private final TransactionID transaction;
   private final TransactionID oldest;
   private final NodeID  src;
-  private final byte[]  payload;
   private final EntityDescriptor descriptor;
   private final boolean requiresReplication;
   
   private boolean done = false;
 
-  public AbstractServerEntityRequest(EntityDescriptor descriptor, ServerEntityAction action, byte[] payload, TransactionID transaction, TransactionID oldest, NodeID src, boolean requiresReplication) {
+  public AbstractServerEntityRequest(EntityDescriptor descriptor, ServerEntityAction action, TransactionID transaction, TransactionID oldest, NodeID src, boolean requiresReplication) {
     this.action = action;
     this.transaction = transaction;
     this.oldest = oldest;
     this.src = src;
-    this.payload = payload;
     this.descriptor = descriptor;
     this.requiresReplication = requiresReplication;
   }
@@ -80,11 +78,6 @@ public abstract class AbstractServerEntityRequest implements ServerEntityRequest
   @Override
   public NodeID getNodeID() {
     return src;
-  }
-
-  @Override
-  public byte[] getPayload() {
-    return payload;
   }
 
   @Override

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/EntityManagerImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/EntityManagerImpl.java
@@ -73,7 +73,7 @@ public class EntityManagerImpl implements EntityManager {
     
     // Set the state of the manager.
     this.shouldCreateActiveEntities = true;
-    
+    processorPipeline.enterActiveState();
     // Walk all existing entities, recreating them as active.
     // NOTE:  While it would seem more direct (and not require adding new request types) to distinguish active/passive
     //  via ManagedEntity implementations, we would need to ensure that all pending requests for a ManagedEntity had

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/NoReplicationBroker.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/NoReplicationBroker.java
@@ -20,6 +20,7 @@ package com.tc.objectserver.entity;
 
 import com.tc.l2.msg.ReplicationMessage;
 import com.tc.net.NodeID;
+import com.tc.util.Assert;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -30,6 +31,8 @@ import java.util.concurrent.TimeoutException;
  * Stubbed implementation which provides no replication.
  */
 public class NoReplicationBroker implements PassiveReplicationBroker {
+  
+  private boolean isActive = false;
   
   public static final Future<Void> NOOP_FUTURE = new Future<Void>() {
       @Override
@@ -57,6 +60,13 @@ public class NoReplicationBroker implements PassiveReplicationBroker {
         return null;
       }
   };
+
+  @Override
+  public void enterActiveState() {
+// only happens once
+    Assert.assertFalse(isActive);
+    isActive = true;
+  }
 
   @Override
   public Set<NodeID> passives() {

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/PassiveReplicationBroker.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/PassiveReplicationBroker.java
@@ -26,4 +26,5 @@ import java.util.concurrent.Future;
 public interface PassiveReplicationBroker {
   Future<Void> replicateMessage(ReplicationMessage msg, Set<NodeID> passives);
   Set<NodeID> passives();
+  void enterActiveState();
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/PlatformEntity.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/PlatformEntity.java
@@ -1,0 +1,77 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.objectserver.entity;
+
+import com.tc.net.NodeID;
+import com.tc.object.ClientInstanceID;
+import com.tc.object.EntityDescriptor;
+import com.tc.object.EntityID;
+import com.tc.objectserver.api.ManagedEntity;
+import com.tc.objectserver.api.ServerEntityRequest;
+import org.terracotta.entity.ClientDescriptor;
+import org.terracotta.entity.ConcurrencyStrategy;
+
+/**
+ *
+ */
+public class PlatformEntity implements ManagedEntity {
+  public static EntityID PLATFORM_ID = new EntityID("platform", "root");
+  public static long VERSION = 1L;
+  private static EntityDescriptor descriptor = new EntityDescriptor(PLATFORM_ID, ClientInstanceID.NULL_ID, VERSION);
+  public final RequestProcessor processor;
+
+  public PlatformEntity(RequestProcessor processor) {
+    this.processor = processor;
+  }
+  
+  @Override
+  public EntityID getID() {
+    return PLATFORM_ID;
+  }
+
+  @Override
+  public long getVersion() {
+    return VERSION;
+  }
+
+  @Override
+  public void addInvokeRequest(ServerEntityRequest request, byte[] payload) {
+    processor.scheduleRequest(descriptor, request, payload, ()-> {request.complete();}, ConcurrencyStrategy.UNIVERSAL_KEY);
+  }
+
+  @Override
+  public void processSyncMessage(ServerEntityRequest sync, byte[] payload, int concurrencyKey) {
+    processor.scheduleRequest(descriptor, sync, payload, ()-> {sync.complete();}, ConcurrencyStrategy.MANAGEMENT_KEY);
+  }
+
+  @Override
+  public void addLifecycleRequest(ServerEntityRequest create, byte[] arg) {
+    processor.scheduleRequest(descriptor, create, arg, ()-> {create.complete();}, ConcurrencyStrategy.MANAGEMENT_KEY);
+  }
+
+  @Override
+  public void reconnectClient(NodeID nodeID, ClientDescriptor clientDescriptor, byte[] extendedReconnectData) {
+  // never reconnect
+  }
+
+  @Override
+  public void sync(NodeID passive) {
+  //  never sync
+  }
+}

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ReplicatedEntityRequestImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ReplicatedEntityRequestImpl.java
@@ -43,9 +43,9 @@ public class ReplicatedEntityRequestImpl extends AbstractServerEntityRequest {
   private byte[] returnValue = null;
   private EntityException failure = null;
 
-  public ReplicatedEntityRequestImpl(EntityDescriptor descriptor, ServerEntityAction action, byte[] payload, TransactionID transaction, TransactionID oldest, NodeID nodes) {
+  public ReplicatedEntityRequestImpl(EntityDescriptor descriptor, ServerEntityAction action, TransactionID transaction, TransactionID oldest, NodeID nodes) {
     // This replication argument (the "true") is redundant, in this case.
-    super(descriptor, action, payload, transaction, oldest, nodes, true);
+    super(descriptor, action, transaction, oldest, nodes, true);
   }
 
   @Override
@@ -89,10 +89,4 @@ public class ReplicatedEntityRequestImpl extends AbstractServerEntityRequest {
       }
     }
   }
-
-  @Override
-  public int getConcurrencyKey() {
-    Assert.fail("No concurrency key on this message type");
-    return 0;
-  }
-}
+ }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
@@ -29,16 +29,12 @@ import com.tc.object.EntityDescriptor;
 import com.tc.object.tx.TransactionID;
 import com.tc.objectserver.api.ServerEntityAction;
 import com.tc.objectserver.api.ServerEntityRequest;
-import com.tc.objectserver.entity.ManagedEntityImpl.ManagedEntityRequest;
 import com.tc.util.Assert;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import org.terracotta.entity.ConcurrencyStrategy;
-import org.terracotta.entity.EntityMessage;
-import org.terracotta.entity.EntityResponse;
-import org.terracotta.entity.MessageCodec;
 
 
 public class RequestProcessor implements StateChangeListener {
@@ -70,15 +66,14 @@ public class RequestProcessor implements StateChangeListener {
 //  do nothing
   }
   
-  public void scheduleRequest(ManagedEntityImpl impl, EntityDescriptor entity, ServerEntityRequest request, EntityMessage message, int concurrencyKey, MessageCodec<EntityMessage, EntityResponse> codec) {
+  public void scheduleRequest(EntityDescriptor entity, ServerEntityRequest request, byte[] payload, Runnable call, int concurrencyKey) {
     // Unless this is a message type we allow to choose its own concurrency key, we will use management (default for all internal operations).
     Set<NodeID> replicateTo = (isActive && passives != null && request.requiresReplication()) ? passives.passives() : Collections.emptySet();
     Future<Void> token = (!replicateTo.isEmpty())
         ? passives.replicateMessage(createReplicationMessage(entity, request.getNodeID(), request.getAction(), 
-            request.getTransaction(), request.getOldestTransactionOnClient(), request.getPayload(), concurrencyKey), replicateTo)
+            request.getTransaction(), request.getOldestTransactionOnClient(), payload, concurrencyKey), replicateTo)
         : NoReplicationBroker.NOOP_FUTURE;
-    ManagedEntityRequest managedRequest = new ManagedEntityRequest(request, codec);
-    EntityRequest entityRequest =  new EntityRequest(impl, entity, managedRequest, concurrencyKey, token, message);
+    EntityRequest entityRequest =  new EntityRequest(entity, request, call, concurrencyKey, token);
     requestExecution.addMultiThreaded(entityRequest);
   }
   
@@ -121,20 +116,18 @@ public class RequestProcessor implements StateChangeListener {
   }
   
   private static class EntityRequest implements MultiThreadedEventContext, Runnable {
-    private final ManagedEntityImpl impl;
     private final EntityDescriptor entity;
-    private final ManagedEntityRequest request;
+    private final ServerEntityRequest request;
+    private final Runnable invoke;
     private final Future<Void>  token;
     private final int key;
-    private final EntityMessage message;
 
-    public EntityRequest(ManagedEntityImpl impl, EntityDescriptor entity, ManagedEntityRequest managedRequest, int concurrencyIndex, Future<Void>  token, EntityMessage message) {
-      this.impl = impl;
+    public EntityRequest(EntityDescriptor entity, ServerEntityRequest request, Runnable runnable, int key, Future<Void>  token) {
       this.entity = entity;
-      this.request = managedRequest;
-      this.key = concurrencyIndex;
+      this.request = request;
+      this.invoke = runnable;
       this.token = token;
-      this.message = message;
+      this.key = key;
     }
 
     @Override
@@ -154,7 +147,7 @@ public class RequestProcessor implements StateChangeListener {
     void invoke()  {
       try {
         token.get();
-        impl.invoke(request, this.key, this.message);
+        invoke.run();
       } catch (InterruptedException interrupted) {
 //  shutdown logic?  uniterruptable?
         throw new RuntimeException(interrupted);

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ServerEntityRequestImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ServerEntityRequestImpl.java
@@ -28,6 +28,9 @@ import com.tc.util.Assert;
 
 import java.util.Optional;
 import org.terracotta.entity.ClientDescriptor;
+import org.terracotta.entity.EntityMessage;
+import org.terracotta.entity.EntityResponse;
+import org.terracotta.entity.MessageCodec;
 import org.terracotta.exception.EntityException;
 
 
@@ -37,26 +40,16 @@ import org.terracotta.exception.EntityException;
  */
 public class ServerEntityRequestImpl extends AbstractServerEntityRequest {
   protected final Optional<MessageChannel> returnChannel;
-  private final int concurrencyKey;
   // TODO:  Using this flag is a bit of a hack but so is ServerEntityRequest.getConcurrencyKey so hopefully we can find a
   // less general way of asking about this so we won't need this flag to re-specialize it.
   private final boolean doesDeclareConcurrencyKey;
 
   // TODO:  Coalesce these constructors once we handle this doesDeclareConcurrencyKey in a better way.
-  public ServerEntityRequestImpl(EntityDescriptor descriptor, ServerEntityAction action, byte[] payload, 
+  public ServerEntityRequestImpl(EntityDescriptor descriptor, ServerEntityAction action,  
       TransactionID transaction, TransactionID oldest, NodeID src, boolean requiresReplication, Optional<MessageChannel> returnChannel) {
-    super(descriptor, action, payload, transaction, oldest, src, requiresReplication);
+    super(descriptor, action, transaction, oldest, src, requiresReplication);
     this.returnChannel = returnChannel;
-    this.concurrencyKey = 0;
     this.doesDeclareConcurrencyKey = false;
-  }
-
-  public ServerEntityRequestImpl(EntityDescriptor descriptor, ServerEntityAction action, byte[] payload, 
-      TransactionID transaction, TransactionID oldest, NodeID src, boolean requiresReplication, Optional<MessageChannel> returnChannel, int concurrencyKey) {
-    super(descriptor, action, payload, transaction, oldest, src, requiresReplication);
-    this.returnChannel = returnChannel;
-    this.concurrencyKey = concurrencyKey;
-    this.doesDeclareConcurrencyKey = true;
   }
 
   @Override
@@ -86,19 +79,5 @@ public class ServerEntityRequestImpl extends AbstractServerEntityRequest {
   public ClientDescriptor getSourceDescriptor() {
     EntityDescriptor entityDescriptor = getEntityDescriptor();
     return new ClientDescriptorImpl(getNodeID(), entityDescriptor);
-  }
-
-  @Override
-  public int getConcurrencyKey() {
-    ServerEntityAction action = getAction();
-    Assert.assertTrue(this.doesDeclareConcurrencyKey);
-    // TODO:  Remove these assertions once we can determine a better way of communicating this information as this
-    // implementation knows too much about how it should be used (although only for the purposes of this validation).
-    Assert.assertTrue((ServerEntityAction.INVOKE_ACTION == action)
-        || (ServerEntityAction.REQUEST_SYNC_ENTITY == action)
-        || (ServerEntityAction.RECEIVE_SYNC_ENTITY_KEY_START == action)
-        || (ServerEntityAction.RECEIVE_SYNC_ENTITY_KEY_END == action)
-        || (ServerEntityAction.RECEIVE_SYNC_PAYLOAD == action));
-    return this.concurrencyKey;
   }
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
@@ -34,6 +34,7 @@ import com.tc.objectserver.api.EntityManager;
 import com.tc.objectserver.api.ManagedEntity;
 import com.tc.objectserver.api.ServerEntityAction;
 import com.tc.objectserver.api.ServerEntityRequest;
+import com.tc.objectserver.core.api.ServerConfigurationContext;
 import com.tc.objectserver.entity.ServerEntityRequestImpl;
 import com.tc.objectserver.persistence.EntityData;
 import com.tc.objectserver.persistence.EntityPersistor;
@@ -80,6 +81,10 @@ public class ProcessTransactionHandler {
     @Override
     protected void initialize(ConfigurationContext context) {
       super.initialize(context); 
+      ServerConfigurationContext server = (ServerConfigurationContext)context;
+      
+      server.getL2Coordinator().getReplicatedClusterStateManager().setCurrentState(server.getL2Coordinator().getStateManager().getCurrentState());
+      server.getL2Coordinator().getReplicatedClusterStateManager().goActiveAndSyncState();
 //  go right to active state.  this only gets initialized once ACTIVE-COORDINATOR is entered
       entityManager.enterActiveState();
     }

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
@@ -154,7 +154,7 @@ public class ProcessTransactionHandler {
     }
     
     // In the general case, however, we need to pass this as a real ServerEntityRequest, into the entityProcessor.
-    ServerEntityRequest serverEntityRequest = new ServerEntityRequestImpl(descriptor, action,  extendedData, transactionID, oldestTransactionOnClient, sourceNodeID, doesRequireReplication, safeGetChannel(sourceNodeID));
+    ServerEntityRequest serverEntityRequest = new ServerEntityRequestImpl(descriptor, action, transactionID, oldestTransactionOnClient, sourceNodeID, doesRequireReplication, safeGetChannel(sourceNodeID));
     // Before we pass this on to the entity or complete it, directly, we can send the received() ACK, since we now know the message order.
     if (null != oldestTransactionOnClient) {
       // This client still needs transaction order persistence.
@@ -172,8 +172,10 @@ public class ProcessTransactionHandler {
         // We special-case the DOES_EXIST check to complete without interacting with the entity.
         if (ServerEntityAction.DOES_EXIST == action) {
           serverEntityRequest.complete();
+        } else if (ServerEntityAction.INVOKE_ACTION == action) {
+          entity.addInvokeRequest(serverEntityRequest, extendedData);
         } else {
-          entity.addRequest(serverEntityRequest);
+          entity.addLifecycleRequest(serverEntityRequest, extendedData);
         }
       } else {
         serverEntityRequest.failure(new EntityNotFoundException(entityID.getClassName(), entityID.getEntityName()));

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -28,6 +28,7 @@ import com.tc.l2.state.StateManager;
 import com.tc.logging.TCLogger;
 import com.tc.logging.TCLogging;
 import com.tc.net.NodeID;
+import com.tc.net.ServerID;
 import com.tc.net.groups.GroupException;
 import com.tc.net.groups.GroupManager;
 import com.tc.object.EntityID;
@@ -36,10 +37,13 @@ import com.tc.objectserver.api.ManagedEntity;
 import com.tc.objectserver.api.ServerEntityAction;
 import com.tc.objectserver.api.ServerEntityRequest;
 import com.tc.objectserver.core.api.ServerConfigurationContext;
+import com.tc.objectserver.entity.PlatformEntity;
 import com.tc.objectserver.entity.ServerEntityRequestImpl;
 import com.tc.objectserver.persistence.EntityPersistor;
 import com.tc.objectserver.persistence.TransactionOrderPersistor;
 import com.tc.util.Assert;
+import java.util.Deque;
+import java.util.LinkedList;
 import java.util.Optional;
 
 import org.terracotta.exception.EntityException;
@@ -52,6 +56,9 @@ public class ReplicatedTransactionHandler {
   private final GroupManager groupManager;
   private final TransactionOrderPersistor orderedTransactions;
   private final StateManager stateManager;
+  private final ManagedEntity platform;
+  
+  private final SyncState state = new SyncState();
   
   public ReplicatedTransactionHandler(StateManager state, TransactionOrderPersistor transactionOrderPersistor, 
       EntityManager manager, EntityPersistor entityPersistor, GroupManager groupManager) {
@@ -60,6 +67,11 @@ public class ReplicatedTransactionHandler {
     this.entityPersistor = entityPersistor;
     this.groupManager = groupManager;
     this.orderedTransactions = transactionOrderPersistor;
+    try {
+      platform = entityManager.getEntity(PlatformEntity.PLATFORM_ID, PlatformEntity.VERSION).get();
+    } catch (EntityException ee) {
+      throw new RuntimeException(ee);
+    }
   }
 
   private final EventHandler<ReplicationMessage> eventHorizon = new AbstractEventHandler<ReplicationMessage>() {
@@ -78,6 +90,7 @@ public class ReplicatedTransactionHandler {
     protected void initialize(ConfigurationContext context) {
       ServerConfigurationContext scxt = (ServerConfigurationContext)context;
   //  when this spins up, send  request to active and ask for sync
+      scxt.getL2Coordinator().getReplicatedClusterStateManager().setCurrentState(scxt.getL2Coordinator().getStateManager().getCurrentState());
       requestPassiveSync();
     }
     
@@ -89,41 +102,41 @@ public class ReplicatedTransactionHandler {
   }
 
   private void processMessage(ReplicationMessage rep) throws EntityException {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Received replicated " + rep.getReplicationType() + " on " + rep.getEntityID() + "/" + rep.getConcurrency());
+    }
     if (rep.getType() == ReplicationMessage.REPLICATE) {
-      if (!rep.getOldestTransactionOnClient().isNull()) {
-        orderedTransactions.updateWithNewMessage(rep.getSource(), rep.getTransactionID(), rep.getOldestTransactionOnClient());
-      } else {
-        orderedTransactions.removeTrackingForClient(rep.getSource());
-      }
-      if (true) {
-        if (rep.getReplicationType() == ReplicationMessage.ReplicationType.CREATE_ENTITY) {
-          long consumerID = entityPersistor.getNextConsumerID();
-          entityManager.createEntity(rep.getEntityDescriptor().getEntityID(), rep.getVersion(), consumerID);
-          entityPersistor.entityCreated(rep.getEntityDescriptor().getEntityID(), rep.getVersion(), consumerID, rep.getExtendedData());
+      if (!state.defer(rep)) {
+        if (!rep.getOldestTransactionOnClient().isNull()) {
+          orderedTransactions.updateWithNewMessage(rep.getSource(), rep.getTransactionID(), rep.getOldestTransactionOnClient());
+        } else {
+          orderedTransactions.removeTrackingForClient(rep.getSource());
         }
-        Optional<ManagedEntity> entity = entityManager.getEntity(rep.getEntityDescriptor().getEntityID(),rep.getVersion());
+        if (true) {
+          if (rep.getReplicationType() == ReplicationMessage.ReplicationType.CREATE_ENTITY) {
+            long consumerID = entityPersistor.getNextConsumerID();
+            entityManager.createEntity(rep.getEntityDescriptor().getEntityID(), rep.getVersion(), consumerID);
+            entityPersistor.entityCreated(rep.getEntityDescriptor().getEntityID(), rep.getVersion(), consumerID, rep.getExtendedData());
+          }
+          Optional<ManagedEntity> entity = entityManager.getEntity(rep.getEntityDescriptor().getEntityID(),rep.getVersion());
 
-        if (rep.getReplicationType() == ReplicationMessage.ReplicationType.DESTROY_ENTITY) {
-          entityManager.destroyEntity(rep.getEntityDescriptor().getEntityID());
-          entityPersistor.entityDeleted(rep.getEntityDescriptor().getEntityID());
-        }
-        if (entity.isPresent()) {
-          ServerEntityRequest request = make(rep);
-          if (request != null) {
+          if (rep.getReplicationType() == ReplicationMessage.ReplicationType.DESTROY_ENTITY) {
+            entityManager.destroyEntity(rep.getEntityDescriptor().getEntityID());
+            entityPersistor.entityDeleted(rep.getEntityDescriptor().getEntityID());
+          }
+          if (entity.isPresent()) {
+            ServerEntityRequest request = make(rep);
+            if (request != null) {
               if (request.getAction() == ServerEntityAction.INVOKE_ACTION) {
                 entity.get().addInvokeRequest(request, rep.getExtendedData());
               } else {
                 entity.get().addLifecycleRequest(request, rep.getExtendedData());
               }
+            }
           }
         }
-      }
 //  when is the right time to send the ack?
-      try {
-        groupManager.sendTo(rep.messageFrom(), new ReplicationMessageAck(rep.getMessageID()));
-      } catch (GroupException ge) {
-//  Passive must have died.  Swallow the exception
-        LOGGER.info("passive died on ack", ge);
+        acknowledge(rep);
       }
       return;
     } else if (rep.getType() == ReplicationMessage.SYNC) {
@@ -136,6 +149,9 @@ public class ReplicatedTransactionHandler {
         LOGGER.info("passive died on ack", ge);
       }
       syncMessageReceived(rep);
+      return;
+    } else if (rep.getType() == ReplicationMessage.START) {
+      acknowledge(rep);
       return;
     }
 
@@ -153,6 +169,10 @@ public class ReplicatedTransactionHandler {
   
   private void syncMessageReceived(ReplicationMessage sync) {
     EntityID eid = sync.getEntityDescriptor().getEntityID();
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Sync Message " + sync.getReplicationType() + " for " + eid + "/" + sync.getConcurrency());
+    }
+    long version = sync.getVersion();
     if (!eid.equals(EntityID.NULL_ID)) {
       try {
         if (!this.entityManager.getEntity(eid, sync.getVersion()).isPresent()) {
@@ -165,34 +185,58 @@ public class ReplicatedTransactionHandler {
         LOGGER.warn("entity has already been created", state);
       }
     }
-
+    
+    Deque<ReplicationMessage> deferred = null;
+    ServerEntityRequestImpl request = make(sync);
+    
+    try {
+      Optional<ManagedEntity> entity = entityManager.getEntity(eid, version);
+      if (entity.isPresent()) {
+        entity.get().processSyncMessage(request, sync.getExtendedData(), sync.getConcurrency());
+      } else {
+        platform.processSyncMessage(request, sync.getExtendedData(), sync.getConcurrency());
+      }
+    } catch (EntityException ee) {
+      throw new RuntimeException(ee);
+    }
+    
     switch (sync.getReplicationType()) {
       case SYNC_END:
+        request.waitForDone();
         if (!stateManager.isActiveCoordinator()) {
           stateManager.moveToPassiveStandbyState();
         }
         break;
       case SYNC_BEGIN:
+        request.waitForDone();
+        break;
+      case SYNC_ENTITY_CONCURRENCY_BEGIN:
+        request.waitForDone();
+        state.start(eid, sync.getConcurrency());
+        break;
+      case SYNC_ENTITY_CONCURRENCY_END:
+        request.waitForDone();
+        deferred = state.end(eid, sync.getConcurrency());
         break;
       case SYNC_ENTITY_BEGIN:
       case SYNC_ENTITY_END:
-      case SYNC_ENTITY_CONCURRENCY_BEGIN:
-      case SYNC_ENTITY_CONCURRENCY_END:
+        request.waitForDone();
       case SYNC_ENTITY_CONCURRENCY_PAYLOAD:
-        try {
-          Optional<ManagedEntity> entity = entityManager.getEntity(eid,sync.getVersion());
-          if (entity.isPresent()) {
-              ServerEntityRequest request = make(sync);
-              if (request != null) {
-                entity.get().processSyncMessage(request, sync.getExtendedData(), sync.getConcurrency());
-              }
-          }
-        } catch (EntityException ee) {
-          throw new RuntimeException(ee);
-        }
         break;
       default:
         throw new AssertionError("not a sync message");
+    }
+    
+    if (deferred != null) {
+      while(!deferred.isEmpty()) {
+        ReplicationMessage r = deferred.pop();
+        r.setMessageOrginator(ServerID.NULL_ID);
+        try {
+          processMessage(r);
+        } catch (EntityException ee) {
+          throw new RuntimeException(ee);
+        }
+      }
     }
   }
     
@@ -200,12 +244,24 @@ public class ReplicatedTransactionHandler {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug("Making " + rep.getReplicationType() + " for " + 
           rep.getEntityDescriptor().getEntityID() + "/" + rep.getConcurrency());
-  }
+    }
     return new ServerEntityRequestImpl(rep.getEntityDescriptor(), decodeReplicationType(rep.getReplicationType()), rep.getTransactionID(), rep.getOldestTransactionOnClient(), rep.getSource(), false, Optional.empty());
+  }
+  
+  private void acknowledge(ReplicationMessage rep) {
+//  when is the right time to send the ack?
+    try {
+      groupManager.sendTo(rep.messageFrom(), new ReplicationMessageAck(rep.getMessageID()));
+    } catch (GroupException ge) {
+//  Passive must have died.  Swallow the exception
+      LOGGER.info("passive died on ack", ge);
+    }
   }
 
   private static ServerEntityAction decodeReplicationType(ReplicationMessage.ReplicationType networkType) {
     switch(networkType) {
+      case SYNC_BEGIN:
+      case SYNC_END:
       case NOOP:
         return ServerEntityAction.NOOP;
       case CREATE_ENTITY:
@@ -228,6 +284,73 @@ public class ReplicatedTransactionHandler {
         return ServerEntityAction.RECEIVE_SYNC_ENTITY_END;
       default:
         throw new AssertionError("bad replication type");
+    }
+  }  
+  
+ private class SyncState {
+    private LinkedList<ReplicationMessage> defer = new LinkedList<>();
+    
+    private EntityID syncing;
+    private int currentKey = -1;
+    private boolean destroyed = false;
+    
+    
+    public void start(EntityID eid, int concurrency) {
+      if (destroyed && !syncing.equals(eid)) {
+        destroyed = false;
+      }
+      syncing = eid;
+      currentKey = concurrency;
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Starting " + eid + "/" + currentKey);
+      }
+    }
+    
+    public Deque<ReplicationMessage> end(EntityID eid, int concurrency) {
+      try {
+        if (!eid.equals(syncing) || concurrency != currentKey) {
+          throw new AssertionError();
+        }
+        syncing = null;
+        concurrency = -1;
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("Ending " + eid + "/" + currentKey);
+        }
+        return defer;
+      } finally {
+        defer = new LinkedList<>();
+      }
+    }
+    
+    private boolean defer(ReplicationMessage rep) {
+      EntityID eid = rep.getEntityDescriptor().getEntityID();
+      if (syncing != null) {
+        if (eid.equals(syncing)) {
+          if (destroyed) {
+//  blackhole this request.  The entity has been destroyed. 
+            acknowledge(rep);
+            if (LOGGER.isDebugEnabled()) {
+              LOGGER.debug("Dropping " + rep.getReplicationType() + " for " + eid + "/" + rep.getConcurrency() + " due to destroy");
+            }
+            return true;
+          } else if (rep.getReplicationType() == ReplicationMessage.ReplicationType.DESTROY_ENTITY) {
+            defer.forEach(q->acknowledge(q));
+            defer.clear();
+            defer.add(rep);
+            if (LOGGER.isDebugEnabled()) {
+              LOGGER.debug("Destroying " + rep.getReplicationType() + " for " + eid + "/" + rep.getConcurrency());
+            }
+            destroyed = true;
+          } else if (currentKey == rep.getConcurrency()) {
+            if (LOGGER.isDebugEnabled()) {
+              LOGGER.debug("Deferring " + rep.getReplicationType() + " for " + eid + "/" + rep.getConcurrency());
+            }
+            defer.add(rep);
+            return true;
+          }
+        }
+      }
+      return false;
     }
   }  
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicationSender.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicationSender.java
@@ -29,8 +29,13 @@ import com.tc.logging.TCLogging;
 import com.tc.net.NodeID;
 import com.tc.net.groups.GroupException;
 import com.tc.net.groups.GroupManager;
+import com.tc.object.EntityID;
+import com.tc.objectserver.entity.ActiveToPassiveReplication;
+import com.tc.util.Assert;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -41,6 +46,7 @@ public class ReplicationSender extends AbstractEventHandler<ReplicationEnvelope>
   //  control structures must be fixed
   private final GroupManager group;
   private final Map<NodeID, AtomicLong> ordering = new HashMap<NodeID, AtomicLong>();
+  private final Map<NodeID, SyncState> filtering = new HashMap<NodeID, SyncState>();
   private static final TCLogger logger           = TCLogging.getLogger(ReplicationSender.class);
 
   public ReplicationSender(GroupManager group) {
@@ -54,18 +60,47 @@ public class ReplicationSender extends AbstractEventHandler<ReplicationEnvelope>
     if (msg == null) {
 // this is a flush of the replication channel.  shut it down and return;
       ordering.remove(nodeid);
+      filtering.remove(nodeid);
     } else {
       AtomicLong rOrder = ordering.get(nodeid);
+      SyncState syncing = null;
 
       if (rOrder == null) {
-        if (msg.getType() != ReplicationMessage.SYNC || msg.getReplicationType()!= SYNC_BEGIN) {
-          throw new AssertionError("bad message queue " + msg);
-        }
         rOrder = new AtomicLong();
         ordering.put(nodeid, rOrder);
+        
+        if (msg.getType() == ReplicationMessage.START) {
+//  do nothing, the server was in standby state when added          
+        } else if (msg.getReplicationType() == SYNC_BEGIN) {
+          filtering.put(nodeid, new SyncState());
+        } else {
+          throw new AssertionError("out of order message");
+        }
+      } else {
+        if (msg.getType() == ReplicationMessage.START || msg.getReplicationType() == SYNC_BEGIN) {
+          throw new AssertionError(msg.getEntityID() + "/" + msg.getConcurrency() + " " + rOrder.get());
+        }
+        syncing = filtering.get(nodeid);
       }
-      msg.setReplicationID(rOrder.incrementAndGet());
+      if (syncing != null) {
+//  there is an active sync going on, need to filter out messages that should not be replicated
+        if (!syncing.filter(msg)) {
+          if (logger.isDebugEnabled()) {
+            logger.debug(nodeid + ":Filtering " + msg.getReplicationType() + " for " + msg.getEntityDescriptor().getEntityID() + "/" + msg.getConcurrency());
+          }
+          if (msg.getType() == ReplicationMessage.REPLICATE) {
+            context.release();
+          }
+          return;
+        } else if (msg.getReplicationType() == ReplicationMessage.ReplicationType.SYNC_END) {
+          filtering.remove(nodeid);
+        }
+      }
       try {
+        msg.setReplicationID(rOrder.getAndIncrement());
+        if (logger.isDebugEnabled()) {
+          logger.debug(nodeid + ":Sending " + msg.getReplicationType() + " for " + msg.getEntityID() + "/" + msg.getConcurrency() + "-" + msg.getSequenceID());
+        }
         group.sendTo(nodeid, msg);
       }  catch (GroupException ge) {
         logger.info(msg, ge);
@@ -76,6 +111,98 @@ public class ReplicationSender extends AbstractEventHandler<ReplicationEnvelope>
   @Override
   protected void initialize(ConfigurationContext context) {
     super.initialize(context);
+  }
+  
+  private static class SyncState {
+    private final Set<EntityID> syncd = new HashSet<EntityID>();
+    private EntityID syncingID = EntityID.NULL_ID;
+    private final Set<Integer> syncdID = new HashSet<Integer>();
+    private int syncingConcurrency = -1;
+    
+    public boolean filter(ReplicationMessage msg) {
+      final EntityID eid = msg.getEntityDescriptor().getEntityID();
+        switch (msg.getReplicationType()) {
+          case SYNC_BEGIN:
+            return true;
+          case SYNC_ENTITY_BEGIN:
+            syncingID = eid;
+            syncdID.clear();
+            syncingConcurrency = 0;
+//  if the entity is created through the create message replication, the entity should not be sync'd
+//  set syncid to null so all messages until end get filtered out.  this should not be alot, it just got created
+            if (syncd.contains(syncingID)) {
+              syncingID = EntityID.NULL_ID;
+              return false;
+            }
+            return true;
+          case SYNC_ENTITY_CONCURRENCY_BEGIN:
+            if (syncingID == EntityID.NULL_ID) {
+              return false;
+            }
+            Assert.assertEquals(syncingID, eid);
+            Assert.assertEquals(syncingConcurrency, 0);
+            syncingConcurrency = msg.getConcurrency();
+            return true;
+          case SYNC_ENTITY_CONCURRENCY_PAYLOAD:
+            if (syncingID == EntityID.NULL_ID) {
+              return false;
+            }
+            return true;
+          case SYNC_ENTITY_CONCURRENCY_END:
+            if (syncingID == EntityID.NULL_ID) {
+              return false;
+            }
+            Assert.assertEquals(syncingConcurrency, msg.getConcurrency());
+            syncdID.add(syncingConcurrency);
+            syncingConcurrency = 0;
+            return true;
+          case SYNC_ENTITY_END:
+            Assert.assertEquals(syncingID, eid);
+            syncd.add(syncingID);
+            syncingID = EntityID.NULL_ID;
+            return true;
+          case SYNC_END:
+            return true;
+          case CREATE_ENTITY:
+            if (syncd.contains(eid) || eid.equals(syncingID)) {
+//  this entity is being or has been replicated, don't create it on the passive
+              return false;
+            } else {
+//  add this to the list of entities already syncd
+              syncd.add(eid);
+              return true;
+            }
+          case DESTROY_ENTITY:
+            if (syncd.contains(eid)) {
+              return true;
+            } else if (syncingID.equals(eid)) {
+ //  tricky.  this one needs to pass but only be applied after sync of this entity is complete
+              return true;
+            } else {
+ //  hasn't been syncd yet.  never sync it
+              syncd.add(eid);
+              return false;
+            }
+          case INVOKE_ACTION:
+            if (syncd.contains(eid)) {
+              return true;
+            } else if (syncingID.equals(eid)) {
+              if (syncingConcurrency == msg.getConcurrency()) {
+//  special case.  passive will apply this after sync of the key is complete
+                return true;
+              }
+              return syncdID.contains(msg.getConcurrency());
+            } else {
+// hasn't been sync'd yet.  state will be captured in sync
+              return false;
+            }
+          case NOOP:
+          case RELEASE_ENTITY:
+            return false;
+          default:
+            throw new AssertionError("unknown replication message:" + msg);
+        }
+    }
   }
   
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -873,7 +873,6 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
       public void l2StateChanged(StateChangedEvent sce) {
         rcs.setCurrentState(sce.getCurrentState());
         if (sce.movedToActive()) {
-          rcs.goActiveAndSyncState();
           startActiveMode();
           try {
             startL1Listener();

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -716,7 +716,7 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
 // setup replication    
     final Stage<ReplicationEnvelope> replicationDriver = stageManager.createStage(ServerConfigurationContext.ACTIVE_TO_PASSIVE_DRIVER_STAGE, ReplicationEnvelope.class, new ReplicationSender(groupCommManager), 1, maxStageSize);
     
-    final ActiveToPassiveReplication passives = new ActiveToPassiveReplication(processTransactionHandler.getEntityList(), replicationDriver.getSink());
+    final ActiveToPassiveReplication passives = new ActiveToPassiveReplication(l2Coordinator.getReplicatedClusterStateManager().getPassives(), processTransactionHandler.getEntityList(), replicationDriver.getSink());
     processor.setReplication(passives); 
 //  routing for passive to receive replication    
     Stage<ReplicationMessage> replicationStage = stageManager.createStage(ServerConfigurationContext.PASSIVE_REPLICATION_STAGE, ReplicationMessage.class, 
@@ -840,10 +840,10 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
     control.addStageToState(StateManager.PASSIVE_STANDBY, ServerConfigurationContext.PASSIVE_REPLICATION_STAGE);
 //  turn on the process transaction handler, the active to passive driver, and the replication ack handler, replication handler needs to be shutdown and empty for 
 //  active to start
-    control.addStageToState(StateManager.ACTIVE_COORDINATOR, ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
-    control.addStageToState(StateManager.ACTIVE_COORDINATOR, ServerConfigurationContext.CLIENT_HANDSHAKE_STAGE);
     control.addStageToState(StateManager.ACTIVE_COORDINATOR, ServerConfigurationContext.ACTIVE_TO_PASSIVE_DRIVER_STAGE);
     control.addStageToState(StateManager.ACTIVE_COORDINATOR, ServerConfigurationContext.PASSIVE_REPLICATION_ACK_STAGE);
+    control.addStageToState(StateManager.ACTIVE_COORDINATOR, ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
+    control.addStageToState(StateManager.ACTIVE_COORDINATOR, ServerConfigurationContext.CLIENT_HANDSHAKE_STAGE);
     return control;
   }
   

--- a/dso-l2/src/test/java/com/tc/classloader/ServiceLocatorTest.java
+++ b/dso-l2/src/test/java/com/tc/classloader/ServiceLocatorTest.java
@@ -206,13 +206,13 @@ public class ServiceLocatorTest {
 
   private <A extends EntityMessage, R extends EntityResponse> void handleService(URLClassLoader parent, ServiceRegistry registry, ServerEntityService<ActiveServerEntity<A, R>, ?> es) {
     ActiveServerEntity<A, R> activeEntity = es.createActiveEntity(registry, null);
-    MessageCodec<A, R> deserializer = activeEntity.getMessageCodec();
+    MessageCodec<A, R> codec = activeEntity.getMessageCodec();
     //get class name of IClassLoader type
-    String gpl = new String(deserializer.serialize(activeEntity.invoke(null, deserializer.deserialize("gpl".getBytes()))));
+    R gpl = activeEntity.invoke(null, codec.deserialize("gpl".getBytes()));
     //get class name of the entity loader
-    String gel = new String(deserializer.serialize(activeEntity.invoke(null, deserializer.deserialize("gel".getBytes()))));
+    R gel = activeEntity.invoke(null, codec.deserialize("gel".getBytes()));
     //get reference of the IClassloader loader
-    String plr = new String(deserializer.serialize(activeEntity.invoke(null, deserializer.deserialize("plr".getBytes()))));
+    R plr = activeEntity.invoke(null, codec.deserialize("plr".getBytes()));
     Assert.assertNotEquals("Entity classloader and parent(IClassLoader) loader should not be same", gpl, gel);
     //XXX works only because on same VM
     Assert.assertEquals("Same parent loader reference is used to load (Iclassloader)", plr,

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/RequestProcessorTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/RequestProcessorTest.java
@@ -176,7 +176,7 @@ public class RequestProcessorTest {
     when(broker.replicateMessage(Matchers.any(), Matchers.any())).thenReturn(NoReplicationBroker.NOOP_FUTURE);
     RequestProcessor instance = new RequestProcessor(dump);
     instance.setReplication(broker);
-    
+    instance.enterActiveState();
     instance.scheduleRequest(entity, descriptor, request, new ByteArrayMessage(request.getPayload()), ConcurrencyStrategy.UNIVERSAL_KEY, mock(MessageCodec.class));
 //  assume args from mocked request are passed.  just testing execution
     verify(broker).replicateMessage(Matchers.any(), Matchers.any());

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ServerEntityRequestImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ServerEntityRequestImplTest.java
@@ -76,7 +76,7 @@ public class ServerEntityRequestImplTest {
   @Test
   public void testCompleteCreate() throws Exception {
     boolean requiresReplication = true;
-    ServerEntityRequest serverEntityRequest = new ServerEntityRequestImpl(entityDescriptor, ServerEntityAction.CREATE_ENTITY, payload, transactionID, TransactionID.NULL_ID, nodeID, requiresReplication, Optional.of(messageChannel));
+    ServerEntityRequest serverEntityRequest = new ServerEntityRequestImpl(entityDescriptor, ServerEntityAction.CREATE_ENTITY, transactionID, TransactionID.NULL_ID, nodeID, requiresReplication, Optional.of(messageChannel));
 
     serverEntityRequest.complete();
     
@@ -104,6 +104,6 @@ public class ServerEntityRequestImplTest {
 
   private ServerEntityRequest buildInvoke() {
     boolean requiresReplication = true;
-    return new ServerEntityRequestImpl(entityDescriptor, ServerEntityAction.INVOKE_ACTION, payload, transactionID, TransactionID.NULL_ID, nodeID, requiresReplication, Optional.of(messageChannel));
+    return new ServerEntityRequestImpl(entityDescriptor, ServerEntityAction.INVOKE_ACTION, transactionID, TransactionID.NULL_ID, nodeID, requiresReplication, Optional.of(messageChannel));
   }
 }

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationEnvelope.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationEnvelope.java
@@ -27,10 +27,12 @@ public class ReplicationEnvelope {
   
   private final NodeID dest;
   private final ReplicationMessage msg;
+  private final Runnable waitRelease;
 
-  public ReplicationEnvelope(NodeID dest, ReplicationMessage msg) {
+  public ReplicationEnvelope(NodeID dest, ReplicationMessage msg, Runnable waitRelease) {
     this.dest = dest;
     this.msg = msg;
+    this.waitRelease = waitRelease;
   }
   
   public NodeID getDestination() {
@@ -39,5 +41,13 @@ public class ReplicationEnvelope {
   
   public ReplicationMessage getMessage() {
     return msg;
+  }
+  
+  public void release() {
+    if (waitRelease != null) {
+      waitRelease.run();
+    } else {
+      throw new AssertionError("not waiting");
+    }
   }
 }

--- a/tc-messaging/src/main/java/com/tc/object/EntityID.java
+++ b/tc-messaging/src/main/java/com/tc/object/EntityID.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  * @author twu
  */
 public class EntityID implements TCSerializable<EntityID> {
-  public static final EntityID NULL_ID = new EntityID("UKNONWN", "UNKNOWN");
+  public static final EntityID NULL_ID = new EntityID("UNKNOWN", "UNKNOWN");
   
   private final String className;
   private final String entityName;


### PR DESCRIPTION
This PR is a rollup of issues #6, #7, and #8.  Three major themes are covered.  

Replicated messages are filtered on the active side and replicated messages are queued during the sync of a key on the passive side and only executed once the sync of a key is complete.

invoke path through ManagedEntity has been refactored to be more specialized for different message types received.

State transition from PASSIVE_STANDBY to ACTIVE has been further refined to handle multiple passives.  When a PASSIVE transitions to ACTIVE, the new active must discover other servers that lost election but are in PASSIVE_STANDBY mode.  These servers can continue to receive replicated messages from the new active as they are in the same state as the new ACTIVE.

Also included are some minor bug fixes for message ordering in passive sync.


