### PR TITLE
Fix #19: Disable assertion in clientDidConnect while this is investig…

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollector.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollector.java
@@ -57,9 +57,19 @@ public class ManagementTopologyEventCollector implements ITopologyEventCollector
   @Override
   public synchronized void clientDidConnect(ClientID client) {
     // Ensure that this client isn't already connected.
-    Assert.assertFalse(this.connectedClients.contains(client));
-    // Now, add it to the connected set.
-    this.connectedClients.add(client);
+    // XXX: At this time, there is a bug where we sometimes see the same client connect multiple times, typically around
+    // passive fail-over.
+    boolean isBroken = true;
+    if (!isBroken) {
+      Assert.assertFalse(this.connectedClients.contains(client));
+      // Now, add it to the connected set.
+      this.connectedClients.add(client);
+    } else {
+      // As a work-around, only add the client if it isn't already in the list.
+      if (!this.connectedClients.contains(client)) {
+        this.connectedClients.add(client);
+      }
+    }
   }
 
   @Override

--- a/dso-l2/src/test/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollectorTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollectorTest.java
@@ -43,18 +43,23 @@ public class ManagementTopologyEventCollectorTest {
     this.collector.clientDidConnect(client);
     // We should fail to connect a second time.
     boolean didSucceed = false;
-    try {
-      this.collector.clientDidConnect(client);
-      didSucceed = true;
-    } catch (AssertionError e) {
-      // Expected.
+    // XXX:  Note that there is currently a bug where we need to permit this so this part of the test is disabled.
+    boolean isConnectCheckBroken = true;
+    if (!isConnectCheckBroken) {
+      try {
+        this.collector.clientDidConnect(client);
+        didSucceed = true;
+      } catch (AssertionError e) {
+        // Expected.
+      }
+      Assert.assertFalse(didSucceed);
     }
-    Assert.assertFalse(didSucceed);
+    // Now, disconnect.
     this.collector.clientDidDisconnect(client);
     // We should fail to disconnect a second time.
     // XXX:  Note that there is currently a bug where we need to permit this so this part of the test is disabled.
-    boolean isBroken = true;
-    if (!isBroken) {
+    boolean isDisconnectCheckBroken = true;
+    if (!isDisconnectCheckBroken) {
       didSucceed = false;
       try {
         this.collector.clientDidDisconnect(client);


### PR DESCRIPTION
…ated

-this assertion was intermittently failing in acitve-passive fail-over testing but this isn't a new problem, only a new observation (the introduction of the check is what triggered the problem)
-either this is a long-standing bug which we need to resolve before re-enabling the assertions in this class or this is an incorrect assumption of when the events come in or when we are supposed to call into the event collector.  In any case, this is not a new regression being caught so we can disable the assertion while this problem is investigated