### PR TITLE
Two passive sync fix

### DIFF
--- a/dso-l1/src/test/java/com/tc/object/ClientEntityManagerTest.java
+++ b/dso-l1/src/test/java/com/tc/object/ClientEntityManagerTest.java
@@ -461,7 +461,7 @@ public class ClientEntityManagerTest extends TestCase {
       throw new UnsupportedOperationException();
     }
     @Override
-    public NodeID getSource() {
+    public ClientID getSource() {
       throw new UnsupportedOperationException();
     }
     @Override

--- a/dso-l2/src/main/java/com/tc/objectserver/api/ServerEntityRequest.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/api/ServerEntityRequest.java
@@ -18,18 +18,23 @@
  */
 package com.tc.objectserver.api;
 
+import com.tc.net.ClientID;
 import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.exception.EntityException;
 
 import com.tc.net.NodeID;
 import com.tc.object.tx.TransactionID;
+import java.util.Set;
 
 
 public interface ServerEntityRequest {
 
   ServerEntityAction getAction();
-
-  NodeID getNodeID();
+/**
+ * the source of this request.  Always a client.
+ * @return origin of the request
+ */
+  ClientID getNodeID();
   
   TransactionID getTransaction();
   
@@ -46,6 +51,10 @@ public interface ServerEntityRequest {
   void failure(EntityException e);
 
   void received();
-
-  boolean requiresReplication();
+/**
+ * Provide the nodes which need to be replicated to for this request
+ * @param passives current set of passive nodes
+ * @return the passives that this request needs to be replicated to
+ */  
+  Set<NodeID> replicateTo(Set<NodeID> passives);
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/AbstractServerEntityRequest.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/AbstractServerEntityRequest.java
@@ -20,6 +20,7 @@ package com.tc.objectserver.entity;
 
 import com.tc.entity.VoltronEntityAppliedResponse;
 import com.tc.entity.VoltronEntityReceivedResponse;
+import com.tc.net.ClientID;
 import com.tc.net.NodeID;
 import com.tc.net.protocol.tcm.MessageChannel;
 import com.tc.net.protocol.tcm.TCMessageType;
@@ -27,8 +28,10 @@ import com.tc.object.EntityDescriptor;
 import com.tc.object.tx.TransactionID;
 import com.tc.objectserver.api.ServerEntityAction;
 import com.tc.objectserver.api.ServerEntityRequest;
+import java.util.Collections;
 
 import java.util.Optional;
+import java.util.Set;
 
 import org.terracotta.exception.EntityException;
 
@@ -37,13 +40,13 @@ public abstract class AbstractServerEntityRequest implements ServerEntityRequest
   private final ServerEntityAction action;
   private final TransactionID transaction;
   private final TransactionID oldest;
-  private final NodeID  src;
+  private final ClientID  src;
   private final EntityDescriptor descriptor;
   private final boolean requiresReplication;
   
   private boolean done = false;
 
-  public AbstractServerEntityRequest(EntityDescriptor descriptor, ServerEntityAction action, TransactionID transaction, TransactionID oldest, NodeID src, boolean requiresReplication) {
+  public AbstractServerEntityRequest(EntityDescriptor descriptor, ServerEntityAction action, TransactionID transaction, TransactionID oldest, ClientID src, boolean requiresReplication) {
     this.action = action;
     this.transaction = transaction;
     this.oldest = oldest;
@@ -71,12 +74,12 @@ public abstract class AbstractServerEntityRequest implements ServerEntityRequest
   }
 
   @Override
-  public boolean requiresReplication() {
-    return this.requiresReplication;
+  public Set<NodeID> replicateTo(Set<NodeID> current) {
+    return requiresReplication ? current : Collections.emptySet();
   }
 
   @Override
-  public NodeID getNodeID() {
+  public ClientID getNodeID() {
     return src;
   }
 

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ActiveToPassiveReplication.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ActiveToPassiveReplication.java
@@ -107,11 +107,15 @@ public class ActiveToPassiveReplication implements PassiveReplicationBroker, Gro
       @Override
       public void run() {    
         // start passive sync message
+        logger.debug("starting sync for " + newNode);
         replicate.addSingleThreaded(PassiveSyncMessage.createStartSyncMessage().target(newNode));
         for (ManagedEntity entity : entities) {
-            entity.sync(newNode);
+          logger.debug("starting sync for entity " + newNode + "/" + entity.getID());
+          entity.sync(newNode);
+          logger.debug("ending sync for entity " + newNode + "/" + entity.getID());
         }
     //  passive sync done message.  causes passive to go into passive standby mode
+        logger.debug("ending sync " + newNode);
         replicate.addSingleThreaded(PassiveSyncMessage.createEndSyncMessage().target(newNode));
       }
     });

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ClientEntityStateManagerImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ClientEntityStateManagerImpl.java
@@ -86,7 +86,7 @@ public class ClientEntityStateManagerImpl implements ClientEntityStateManager {
     }
 
     @Override
-    public NodeID getSource() {
+    public ClientID getSource() {
       return clientID;
     }
 

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/EntityManagerImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/EntityManagerImpl.java
@@ -43,7 +43,9 @@ import com.tc.services.TerracottaServiceProviderRegistry;
 import com.tc.util.Assert;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.terracotta.entity.EntityResponse;
@@ -189,7 +191,7 @@ public class EntityManagerImpl implements EntityManager {
       return this.action;
     }
     @Override
-    public NodeID getNodeID() {
+    public ClientID getNodeID() {
       return ClientID.NULL_ID;
     }
     @Override
@@ -228,9 +230,9 @@ public class EntityManagerImpl implements EntityManager {
     }
 
     @Override
-    public boolean requiresReplication() {
+    public Set<NodeID> replicateTo(Set<NodeID> passives) {
       // These are internal requests so they are never replicated.
-      return false;
+      return Collections.emptySet();
     }
     
     public synchronized void waitForCompletion() {

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ReplicatedEntityRequestImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ReplicatedEntityRequestImpl.java
@@ -18,6 +18,7 @@
  */
 package com.tc.objectserver.entity;
 
+import com.tc.net.ClientID;
 import com.tc.net.NodeID;
 import com.tc.net.protocol.tcm.MessageChannel;
 import com.tc.object.EntityDescriptor;
@@ -43,9 +44,9 @@ public class ReplicatedEntityRequestImpl extends AbstractServerEntityRequest {
   private byte[] returnValue = null;
   private EntityException failure = null;
 
-  public ReplicatedEntityRequestImpl(EntityDescriptor descriptor, ServerEntityAction action, TransactionID transaction, TransactionID oldest, NodeID nodes) {
+  public ReplicatedEntityRequestImpl(EntityDescriptor descriptor, ServerEntityAction action, TransactionID transaction, TransactionID oldest, ClientID src) {
     // This replication argument (the "true") is redundant, in this case.
-    super(descriptor, action, transaction, oldest, nodes, true);
+    super(descriptor, action, transaction, oldest, src, false);
   }
 
   @Override
@@ -68,11 +69,6 @@ public class ReplicatedEntityRequestImpl extends AbstractServerEntityRequest {
   @Override
   public ClientDescriptor getSourceDescriptor() {
     return client;
-  }
-
-  @Override
-  public boolean requiresReplication() {
-    return false;
   }
 
 //  TODO:  fix implementation once we decide what we want

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ServerEntityRequestImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ServerEntityRequestImpl.java
@@ -19,18 +19,16 @@
 
 package com.tc.objectserver.entity;
 
+import com.tc.net.ClientID;
 import com.tc.net.NodeID;
 import com.tc.net.protocol.tcm.MessageChannel;
 import com.tc.object.EntityDescriptor;
 import com.tc.object.tx.TransactionID;
 import com.tc.objectserver.api.ServerEntityAction;
-import com.tc.util.Assert;
 
 import java.util.Optional;
+import java.util.Set;
 import org.terracotta.entity.ClientDescriptor;
-import org.terracotta.entity.EntityMessage;
-import org.terracotta.entity.EntityResponse;
-import org.terracotta.entity.MessageCodec;
 import org.terracotta.exception.EntityException;
 
 
@@ -40,16 +38,11 @@ import org.terracotta.exception.EntityException;
  */
 public class ServerEntityRequestImpl extends AbstractServerEntityRequest {
   protected final Optional<MessageChannel> returnChannel;
-  // TODO:  Using this flag is a bit of a hack but so is ServerEntityRequest.getConcurrencyKey so hopefully we can find a
-  // less general way of asking about this so we won't need this flag to re-specialize it.
-  private final boolean doesDeclareConcurrencyKey;
 
-  // TODO:  Coalesce these constructors once we handle this doesDeclareConcurrencyKey in a better way.
   public ServerEntityRequestImpl(EntityDescriptor descriptor, ServerEntityAction action,  
-      TransactionID transaction, TransactionID oldest, NodeID src, boolean requiresReplication, Optional<MessageChannel> returnChannel) {
+      TransactionID transaction, TransactionID oldest, ClientID src, boolean requiresReplication, Optional<MessageChannel> returnChannel) {
     super(descriptor, action, transaction, oldest, src, requiresReplication);
     this.returnChannel = returnChannel;
-    this.doesDeclareConcurrencyKey = false;
   }
 
   @Override

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
@@ -23,6 +23,7 @@ import com.tc.async.api.ConfigurationContext;
 import com.tc.async.api.EventHandlerException;
 import com.tc.entity.ResendVoltronEntityMessage;
 import com.tc.entity.VoltronEntityMessage;
+import com.tc.net.ClientID;
 import com.tc.net.NodeID;
 import com.tc.net.protocol.tcm.MessageChannel;
 import com.tc.object.EntityDescriptor;
@@ -67,7 +68,7 @@ public class ProcessTransactionHandler {
   private final AbstractEventHandler<VoltronEntityMessage> voltronHandler = new AbstractEventHandler<VoltronEntityMessage>() {
     @Override
     public void handleEvent(VoltronEntityMessage message) throws EventHandlerException {
-      NodeID sourceNodeID = message.getSource();
+      ClientID sourceNodeID = message.getSource();
       EntityDescriptor descriptor = message.getEntityDescriptor();
       ServerEntityAction action = decodeMessageType(message.getVoltronType());
       byte[] extendedData = message.getExtendedData();
@@ -124,7 +125,7 @@ public class ProcessTransactionHandler {
   }
 // TODO:  Make sure that the ReplicatedTransactionHandler is flushed before 
 //   adding any new messages to the PTH
-  private synchronized void addMessage(NodeID sourceNodeID, EntityDescriptor descriptor, ServerEntityAction action, byte[] extendedData, TransactionID transactionID, boolean doesRequireReplication, TransactionID oldestTransactionOnClient) {
+  private synchronized void addMessage(ClientID sourceNodeID, EntityDescriptor descriptor, ServerEntityAction action, byte[] extendedData, TransactionID transactionID, boolean doesRequireReplication, TransactionID oldestTransactionOnClient) {
     // Version error or duplicate creation requests will manifest as exceptions here so catch them so we can send them back
     //  over the wire as an error in the request.
     EntityID entityID = descriptor.getEntityID();
@@ -236,7 +237,7 @@ public class ProcessTransactionHandler {
   }
 
   private void executeResend(ResendVoltronEntityMessage message) {
-    NodeID sourceNodeID = message.getSource();
+    ClientID sourceNodeID = message.getSource();
     EntityDescriptor descriptor = message.getEntityDescriptor();
     ServerEntityAction action = decodeMessageType(message.getVoltronType());
     byte[] extendedData = message.getExtendedData();

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ServerEntityRequestImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ServerEntityRequestImplTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import com.tc.entity.VoltronEntityAppliedResponse;
 import com.tc.entity.VoltronEntityReceivedResponse;
+import com.tc.net.ClientID;
 import com.tc.net.NodeID;
 import com.tc.net.protocol.tcm.MessageChannel;
 import com.tc.net.protocol.tcm.TCMessageType;
@@ -48,8 +49,7 @@ public class ServerEntityRequestImplTest {
   private VoltronEntityAppliedResponse responseMessage;
   private EntityDescriptor entityDescriptor;
   private TransactionID transactionID;
-  private NodeID nodeID;
-  private byte[] payload;
+  private ClientID nodeID;
 
   @Before
   public void setUp() throws Exception {
@@ -58,8 +58,7 @@ public class ServerEntityRequestImplTest {
     messageChannel = mockMessageChannel(requestAckMessage, responseMessage);
     entityDescriptor = new EntityDescriptor(new EntityID("foo", "bar"), new ClientInstanceID(1), 1);
     transactionID = new TransactionID(1);
-    nodeID = mock(NodeID.class);
-    payload = new byte[0];
+    nodeID = mock(ClientID.class);
   }
 
   @Test

--- a/tc-messaging/src/main/java/com/tc/entity/NetworkVoltronEntityMessageImpl.java
+++ b/tc-messaging/src/main/java/com/tc/entity/NetworkVoltronEntityMessageImpl.java
@@ -22,7 +22,6 @@ package com.tc.entity;
 import com.tc.bytes.TCByteBuffer;
 import com.tc.io.TCByteBufferOutputStream;
 import com.tc.net.ClientID;
-import com.tc.net.NodeID;
 import com.tc.net.protocol.tcm.MessageChannel;
 import com.tc.net.protocol.tcm.MessageMonitor;
 import com.tc.net.protocol.tcm.TCMessageHeader;
@@ -46,7 +45,7 @@ public class NetworkVoltronEntityMessageImpl extends DSOMessageBase implements N
   private TransactionID oldestTransactionPending;
 
   @Override
-  public NodeID getSource() {
+  public ClientID getSource() {
     Assert.assertNotNull(this.clientID);
     return this.clientID;
   }

--- a/tc-messaging/src/main/java/com/tc/entity/ResendVoltronEntityMessage.java
+++ b/tc-messaging/src/main/java/com/tc/entity/ResendVoltronEntityMessage.java
@@ -36,7 +36,7 @@ import java.io.IOException;
  * is required, but it is sent as part of a larger message, not as a stand-alone message.
  */
 public class ResendVoltronEntityMessage implements VoltronEntityMessage, TCSerializable<ResendVoltronEntityMessage> {
-  private NodeID source;
+  private ClientID source;
   private TransactionID transactionID;
   private EntityDescriptor entityDescriptor;
   private Type type;
@@ -48,7 +48,7 @@ public class ResendVoltronEntityMessage implements VoltronEntityMessage, TCSeria
     // to make TCSerializable happy
   }
 
-  public ResendVoltronEntityMessage(NodeID source, TransactionID transactionID, EntityDescriptor entityDescriptor, Type type, boolean requiresReplication, byte[] extendedData, TransactionID oldestTransactionPending) {
+  public ResendVoltronEntityMessage(ClientID source, TransactionID transactionID, EntityDescriptor entityDescriptor, Type type, boolean requiresReplication, byte[] extendedData, TransactionID oldestTransactionPending) {
     this.source = source;
     this.transactionID = transactionID;
     this.entityDescriptor = entityDescriptor;
@@ -59,7 +59,7 @@ public class ResendVoltronEntityMessage implements VoltronEntityMessage, TCSeria
   }
 
   @Override
-  public NodeID getSource() {
+  public ClientID getSource() {
     Assert.assertNotNull(this.source);
     return this.source;
   }

--- a/tc-messaging/src/main/java/com/tc/entity/VoltronEntityMessage.java
+++ b/tc-messaging/src/main/java/com/tc/entity/VoltronEntityMessage.java
@@ -19,7 +19,7 @@
 
 package com.tc.entity;
 
-import com.tc.net.NodeID;
+import com.tc.net.ClientID;
 import com.tc.object.EntityDescriptor;
 import com.tc.object.tx.TransactionID;
 
@@ -71,7 +71,7 @@ public interface VoltronEntityMessage {
     APPLIED,
   }
   
-  NodeID getSource();
+  ClientID getSource();
   
   TransactionID getTransactionID();
   

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
@@ -61,7 +61,7 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
   
   EntityDescriptor descriptor;
     
-  NodeID src;
+  ClientID src;
   TransactionID tid;
   TransactionID oldest;
 
@@ -85,14 +85,14 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
     super(RESPONSE, mid);
   }  
 //  a true replicated message
-  public ReplicationMessage(EntityDescriptor descriptor, NodeID src, 
+  public ReplicationMessage(EntityDescriptor descriptor, ClientID src, 
       TransactionID tid, TransactionID oldest, 
       ReplicationType action, byte[] payload, int concurrency) {
     super(action.ordinal() >= ReplicationType.SYNC_BEGIN.ordinal() ? SYNC : REPLICATE);
     initialize(descriptor, src, tid, oldest, action, payload, concurrency);
   }
   
-  protected final void initialize(EntityDescriptor descriptor, NodeID src, 
+  protected final void initialize(EntityDescriptor descriptor, ClientID src, 
       TransactionID tid, TransactionID oldest, 
       ReplicationType action, byte[] payload, int concurrency) {
     Assert.assertNotNull(tid);
@@ -136,7 +136,7 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
     return payload;
   }
   
-  public NodeID getSource() {
+  public ClientID getSource() {
     return src;
   }
   
@@ -171,7 +171,7 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
       if (type == NodeID.CLIENT_NODE_TYPE) {
         this.src = new ClientID().deserializeFrom(in);
       } else if (type == NodeID.SERVER_NODE_TYPE) {
-        this.src = new ServerID().deserializeFrom(in);
+        throw new AssertionError("node type is incorrect");
       }
       this.tid = new TransactionID(in.readLong());
       this.oldest = new TransactionID(in.readLong());


### PR DESCRIPTION
ManagedEntityImpl$PassiveSyncServerEntityRequest holds the target passive in the wrong place.  This resulted in resets getting sent to every passive every time a new passive connects.  This did not work in 2 passive scenarios.  ServerEntityRequest still needs to be refactored a bit to make clear that a request result should be sent to a passive or a client but that should be a different branch.