### PR TITLE
Issue 28: Moved ITopologyEventCollector client callsites to channel methods

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollector.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollector.java
@@ -57,29 +57,15 @@ public class ManagementTopologyEventCollector implements ITopologyEventCollector
   @Override
   public synchronized void clientDidConnect(ClientID client) {
     // Ensure that this client isn't already connected.
-    // XXX: At this time, there is a bug where we sometimes see the same client connect multiple times, typically around
-    // passive fail-over.
-    boolean isBroken = true;
-    if (!isBroken) {
-      Assert.assertFalse(this.connectedClients.contains(client));
-      // Now, add it to the connected set.
-      this.connectedClients.add(client);
-    } else {
-      // As a work-around, only add the client if it isn't already in the list.
-      if (!this.connectedClients.contains(client)) {
-        this.connectedClients.add(client);
-      }
-    }
+    Assert.assertFalse(this.connectedClients.contains(client));
+    // Now, add it to the connected set.
+    this.connectedClients.add(client);
   }
 
   @Override
   public synchronized void clientDidDisconnect(ClientID client) {
     // Ensure that this client was already connected.
-    // XXX: At this time, there is a bug where we sometimes see disconnections from clients which were not connected.
-    boolean isBroken = true;
-    if (!isBroken) {
-      Assert.assertTrue(this.connectedClients.contains(client));
-    }
+    Assert.assertTrue(this.connectedClients.contains(client));
     // Now, remove it from the connected set.
     this.connectedClients.remove(client);
   }

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ChannelLifeCycleHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ChannelLifeCycleHandler.java
@@ -140,14 +140,14 @@ public class ChannelLifeCycleHandler extends AbstractEventHandler<NodeStateEvent
 
   @Override
   public void channelRemoved(MessageChannel channel) {
+    // Note that the remote node ID always refers to a client, in this path.
+    ClientID clientID = (ClientID) channel.getRemoteNodeID();
     // We want all the messages in the system from this client to reach its destinations before processing this request.
     // esp. hydrate stage and process transaction stage. This goo is for that.
-    final NodeStateEventContext disconnectEvent = new NodeStateEventContext(NodeStateEventContext.REMOVE,
-                                                                            channel.getRemoteNodeID(), channel.getProductId());
+    final NodeStateEventContext disconnectEvent = new NodeStateEventContext(NodeStateEventContext.REMOVE, clientID, channel.getProductId());
     NodeID inBandSchedulerKey = channel.getRemoteNodeID();
     InBandMoveToNextSink<NodeStateEventContext> context1 = new InBandMoveToNextSink<>(disconnectEvent, null, channelSink, inBandSchedulerKey, false); // single threaded so no need to flush
     InBandMoveToNextSink<VoltronEntityMessage> context2 = new InBandMoveToNextSink<>(null, context1, processTransactionSink, inBandSchedulerKey, false);  // threaded on client nodeid so no need to flush
     hydrateSink.addSpecialized(context2);
   }
-
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ChannelLifeCycleHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ChannelLifeCycleHandler.java
@@ -84,8 +84,6 @@ public class ChannelLifeCycleHandler extends AbstractEventHandler<NodeStateEvent
     // We want to track this if it is an L1 (ClientID) disconnecting.
     if (NodeID.CLIENT_NODE_TYPE == nodeID.getNodeType()) {
       ClientID clientID = (ClientID) nodeID;
-      // Record that the client disconnected.
-      this.eventCollector.clientDidDisconnect(clientID);
       // Broadcast this message.
       broadcastClientClusterMembershipMessage(ClusterMembershipMessage.EventType.NODE_DISCONNECTED, clientID, productId);
     }
@@ -100,8 +98,6 @@ public class ChannelLifeCycleHandler extends AbstractEventHandler<NodeStateEvent
     // We want to track this if it is an L1 (ClientID) connecting.
     if (NodeID.CLIENT_NODE_TYPE == nodeID.getNodeType()) {
       ClientID clientID = (ClientID) nodeID;
-      // Record that the client connected.
-      this.eventCollector.clientDidConnect(clientID);
       // Broadcast this message.
       broadcastClientClusterMembershipMessage(ClusterMembershipMessage.EventType.NODE_CONNECTED, clientID, productId);
     }
@@ -136,6 +132,8 @@ public class ChannelLifeCycleHandler extends AbstractEventHandler<NodeStateEvent
   public void channelCreated(MessageChannel channel) {
     ClientID clientID = new ClientID(channel.getChannelID().toLong());
     channelSink.addMultiThreaded(new NodeStateEventContext(NodeStateEventContext.CREATE, clientID, channel.getProductId()));
+    // Record that the client connected.
+    this.eventCollector.clientDidConnect(clientID);
   }
 
   @Override
@@ -149,5 +147,7 @@ public class ChannelLifeCycleHandler extends AbstractEventHandler<NodeStateEvent
     InBandMoveToNextSink<NodeStateEventContext> context1 = new InBandMoveToNextSink<>(disconnectEvent, null, channelSink, inBandSchedulerKey, false); // single threaded so no need to flush
     InBandMoveToNextSink<VoltronEntityMessage> context2 = new InBandMoveToNextSink<>(null, context1, processTransactionSink, inBandSchedulerKey, false);  // threaded on client nodeid so no need to flush
     hydrateSink.addSpecialized(context2);
+    // Record that the client disconnected.
+    this.eventCollector.clientDidDisconnect(clientID);
   }
 }


### PR DESCRIPTION
-this avoids the problem where the events would also be called for the replicated information, on the passive
-we can also now re-enable the assertions to verify event call symmetry in ManagementTopologyEventCollector