### PR TITLE
Fix #33: Push client connection state to IMonitoringProducer, from Ma…

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -100,6 +100,11 @@
       </dependency>
       <dependency>
         <groupId>org.terracotta</groupId>
+        <artifactId>monitoring-support</artifactId>
+        <version>${terracotta-apis.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.terracotta</groupId>
         <artifactId>entity-server-api</artifactId>
         <version>${terracotta-apis.version}</version>
       </dependency>

--- a/dso-l2/pom.xml
+++ b/dso-l2/pom.xml
@@ -71,6 +71,10 @@
       <artifactId>standard-cluster-services</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>monitoring-support</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.terracotta.internal</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>

--- a/dso-l2/src/test/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollectorTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollectorTest.java
@@ -34,7 +34,7 @@ public class ManagementTopologyEventCollectorTest {
 
   @Before
   public void setUp() throws Exception {
-    this.collector = new ManagementTopologyEventCollector();
+    this.collector = new ManagementTopologyEventCollector(null);
   }
 
   @Test


### PR DESCRIPTION
…nagementTopologyEventCollector

-if any IMonitoringProducer implementation is found, on start-up, it is now given to ManagementTopologyEventCollector
-events related to client connect/disconnect are now used to manipulate the data registry subtree related to clients
-note that only a string representation of the clientID is currently stored.  In the future, this will be expanded to include other information related to the client, as we determine their value for monitoring use-cases