### PR TITLE
MGMT key deferred execution

### DIFF
--- a/common/src/main/java/com/tc/properties/TCPropertiesConsts.java
+++ b/common/src/main/java/com/tc/properties/TCPropertiesConsts.java
@@ -280,7 +280,7 @@ public interface TCPropertiesConsts {
    ********************************************************************************************************************/
   public static final String L2_STARTUPLOCK_RETRIES_ENABLED                                 = "l2.startuplock.retries.enabled";
   public static final String L2_ENABLE_LEGACY_PRODUCTION_MODE                               = "l2.enable.legacy.production.mode";
-
+  public static final String L2_ENTITY_DEFERMENT_QUEUE_SIZE                                 = "l2.entity.deferment.queue.size";
   /*********************************************************************************************************************
    * <code>
    * Section : L1 Server Array Properties

--- a/common/src/main/resources/com/tc/properties/tc.properties
+++ b/common/src/main/resources/com/tc/properties/tc.properties
@@ -194,6 +194,7 @@ l1.serverarray.objectCreationStrategy.groupAffinity.groupName = mirror-group1
 ###########################################################################################
 l2.enable.legacy.production.mode = false
 l2.startuplock.retries.enabled = false
+l2.entity.deferment.queue.size = 1024
 
 ###########################################################################################
 # Section                   : L1 Memory Manager Properties

--- a/dso-l2/pom.xml
+++ b/dso-l2/pom.xml
@@ -156,4 +156,22 @@
       </plugin>
     </plugins>
     </build>
+    
+   <profiles>
+    <profile>
+      <id>debug</id>
+      <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19</version>
+        <configuration>
+            <debugForkedProcess>true</debugForkedProcess>
+        </configuration>
+      </plugin>
+    </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
@@ -37,10 +37,11 @@ public interface ManagedEntity {
  /** 
   * Schedules the request with the entity on the execution queue.
   * 
-  * @param <M> payload of the request
   * @param request translated request for execution on the server
+   * @param extendedData payload of the invoke
+   * @param defaultKey default concurrency key if no concurrency strategy is installed
   */ 
-  void addInvokeRequest(ServerEntityRequest request, byte[] extendedData);
+  void addInvokeRequest(ServerEntityRequest request, byte[] extendedData, int defaultKey);
   
   void processSyncMessage(ServerEntityRequest sync, byte[] payload, int concurrencyKey);
   

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/NoopEntityMessage.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/NoopEntityMessage.java
@@ -1,0 +1,76 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.objectserver.entity;
+
+import com.tc.entity.VoltronEntityMessage;
+import com.tc.net.ClientID;
+import com.tc.object.EntityDescriptor;
+import com.tc.object.tx.TransactionID;
+
+/**
+ *  This message is use to flush the deferred entity queue.  It is placed in 
+ *  at the end of and exclusive entity message execution to flush the deferred queue.  
+ *  It runs the entire pipeline but is never scheduled on the request processor by 
+ *  ManagedEntityImpl.
+ */
+public class NoopEntityMessage implements VoltronEntityMessage {
+  
+  private final EntityDescriptor  descriptor;
+
+  public NoopEntityMessage(EntityDescriptor descriptor) {
+    this.descriptor = descriptor;
+  }
+  
+
+  @Override
+  public ClientID getSource() {
+    return ClientID.NULL_ID;
+  }
+
+  @Override
+  public TransactionID getTransactionID() {
+    return TransactionID.NULL_ID;
+  }
+
+  @Override
+  public EntityDescriptor getEntityDescriptor() {
+    return descriptor;
+  }
+
+  @Override
+  public boolean doesRequireReplication() {
+    return false;
+  }
+
+  @Override
+  public Type getVoltronType() {
+    return Type.NOOP;
+  }
+
+  @Override
+  public byte[] getExtendedData() {
+    return new byte[0];
+  }
+
+  @Override
+  public TransactionID getOldestTransactionOnClient() {
+    return TransactionID.NULL_ID;
+  }
+  
+}

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/PlatformEntity.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/PlatformEntity.java
@@ -50,7 +50,7 @@ public class PlatformEntity implements ManagedEntity {
   }
 
   @Override
-  public void addInvokeRequest(ServerEntityRequest request, byte[] payload) {
+  public void addInvokeRequest(ServerEntityRequest request, byte[] payload, int defaultKey) {
     processor.scheduleRequest(descriptor, request, payload, ()-> {request.complete();}, ConcurrencyStrategy.UNIVERSAL_KEY);
   }
 

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
@@ -48,6 +48,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Vector;
+import org.terracotta.entity.ConcurrencyStrategy;
 
 import org.terracotta.exception.EntityException;
 import org.terracotta.exception.EntityNotFoundException;
@@ -174,7 +175,9 @@ public class ProcessTransactionHandler {
         if (ServerEntityAction.DOES_EXIST == action) {
           serverEntityRequest.complete();
         } else if (ServerEntityAction.INVOKE_ACTION == action) {
-          entity.addInvokeRequest(serverEntityRequest, extendedData);
+          entity.addInvokeRequest(serverEntityRequest, extendedData, ConcurrencyStrategy.MANAGEMENT_KEY);
+        } else if (ServerEntityAction.NOOP == action) {
+          entity.addInvokeRequest(serverEntityRequest, extendedData, ConcurrencyStrategy.UNIVERSAL_KEY);
         } else {
           entity.addLifecycleRequest(serverEntityRequest, extendedData);
         }

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
@@ -270,6 +270,9 @@ public class ProcessTransactionHandler {
       case INVOKE_ACTION:
         action = ServerEntityAction.INVOKE_ACTION;
         break;
+      case NOOP:
+        action = ServerEntityAction.NOOP;
+        break;
       default:
         // Unknown request type.
         Assert.fail();

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -128,7 +128,7 @@ public class ReplicatedTransactionHandler {
             ServerEntityRequest request = make(rep);
             if (request != null) {
               if (request.getAction() == ServerEntityAction.INVOKE_ACTION) {
-                entity.get().addInvokeRequest(request, rep.getExtendedData());
+                entity.get().addInvokeRequest(request, rep.getExtendedData(), rep.getConcurrency());
               } else {
                 entity.get().addLifecycleRequest(request, rep.getExtendedData());
               }

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -633,7 +633,7 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
       }});
     ManagementTopologyEventCollector eventCollector = new ManagementTopologyEventCollector(serviceInterface);
     RequestProcessor processor = new RequestProcessor(requestProcessorSink);
-    EntityManagerImpl entityManager = new EntityManagerImpl(this.serviceRegistry, clientEntityStateManager, eventCollector, processor);
+    EntityManagerImpl entityManager = new EntityManagerImpl(this.serviceRegistry, clientEntityStateManager, eventCollector, processor, processTransactionStage_voltron.getSink());
     channelManager.addEventListener(clientEntityStateManager);
     processTransactionHandler.setLateBoundComponents(channelManager, entityManager);
     

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/EntityManagerImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/EntityManagerImplTest.java
@@ -19,6 +19,7 @@
 
 package com.tc.objectserver.entity;
 
+import com.tc.async.api.Sink;
 import org.junit.Before;
 import org.junit.Test;
 import org.terracotta.exception.EntityAlreadyExistsException;
@@ -48,7 +49,8 @@ public class EntityManagerImplTest {
         mock(TerracottaServiceProviderRegistry.class),
         mock(ClientEntityStateManager.class),
         mock(ITopologyEventCollector.class),
-        mock(RequestProcessor.class)
+        mock(RequestProcessor.class),
+        mock(Sink.class)
     );
     id = new EntityID(TestEntity.class.getName(), "foo");
     version = 1;

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
@@ -18,6 +18,9 @@
  */
 package com.tc.objectserver.entity;
 
+import com.tc.async.api.Sink;
+import com.tc.entity.VoltronEntityMessage;
+import com.tc.net.ClientID;
 import org.junit.Before;
 import org.junit.Test;
 import org.terracotta.TestEntity;
@@ -39,12 +42,17 @@ import com.tc.object.EntityID;
 import com.tc.objectserver.api.ServerEntityAction;
 import com.tc.objectserver.api.ServerEntityRequest;
 import com.tc.objectserver.core.api.ITopologyEventCollector;
+import com.tc.objectserver.core.api.ServerConfigurationContext;
 import com.tc.util.Assert;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.Set;
+import org.mockito.Matchers;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -56,6 +64,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.terracotta.entity.ConcurrencyStrategy;
 import org.terracotta.entity.EntityResponse;
 import org.terracotta.entity.MessageCodec;
 
@@ -65,6 +74,7 @@ public class ManagedEntityImplTest {
   private ClientInstanceID clientInstanceID;
   private long version;
   private ManagedEntityImpl managedEntity;
+  private Sink<VoltronEntityMessage> loopback;
   private ServiceRegistry serviceRegistry;
   private ServerEntityService<? extends ActiveServerEntity<EntityMessage, EntityResponse>, ? extends PassiveServerEntity<EntityMessage, EntityResponse>> serverEntityService;
   private ActiveServerEntity<EntityMessage, EntityResponse> activeServerEntity;
@@ -85,6 +95,8 @@ public class ManagedEntityImplTest {
     version = 1;
     entityDescriptor = new EntityDescriptor(entityID, clientInstanceID, version);
     serviceRegistry = mock(ServiceRegistry.class);
+    
+    loopback = mock(Sink.class);
 
     requestMulti = mock(RequestProcessor.class);
     activeServerEntity = mock(ActiveServerEntity.class);
@@ -95,7 +107,7 @@ public class ManagedEntityImplTest {
 
     // We will start this in a passive state, as the general test case.
     boolean isInActiveState = false;
-    managedEntity = new ManagedEntityImpl(entityID, version, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, (ServerEntityService<? extends ActiveServerEntity<EntityMessage, EntityResponse>, ? extends PassiveServerEntity<EntityMessage, EntityResponse>>)serverEntityService, isInActiveState);
+    managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, (ServerEntityService<? extends ActiveServerEntity<EntityMessage, EntityResponse>, ? extends PassiveServerEntity<EntityMessage, EntityResponse>>)serverEntityService, isInActiveState);
     clientDescriptor = new ClientDescriptorImpl(nodeID, entityDescriptor);
     Mockito.doAnswer(new Answer<Object>() {
       @Override
@@ -104,6 +116,7 @@ public class ManagedEntityImplTest {
         return null;
       }
     }).when(requestMulti).scheduleRequest(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt());
+    Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
   }
 
   @SuppressWarnings("unchecked")
@@ -207,6 +220,79 @@ public class ManagedEntityImplTest {
     
     verify(activeServerEntity).invoke(eq(clientDescriptor), any(EntityMessage.class));
     verify(invokeRequest).complete(returnValue);
+    verify(loopback).addSingleThreaded(Matchers.any(NoopEntityMessage.class));
+  }
+  
+  @Test
+  public void testExclusiveExecution() throws Exception {
+    MessageCodec codec = new MessageCodec() {
+      @Override
+      public EntityMessage deserialize(byte[] payload) throws MessageCodecException {
+        return new EntityMessage() {
+          @Override
+          public String toString() {
+            return new String(payload);
+          }
+        };
+      }
+
+      @Override
+      public EntityMessage deserializeForSync(int concurrencyKey, byte[] payload) throws MessageCodecException {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+      }
+
+      @Override
+      public byte[] serialize(EntityResponse response) throws MessageCodecException {
+        return new byte[0];
+      }
+    };
+    ConcurrencyStrategy basic = new ConcurrencyStrategy() {
+      @Override
+      public int concurrencyKey(EntityMessage message) {
+        String key = message.toString();
+        return Integer.parseInt(key);
+      }
+
+      @Override
+      public Set getKeysForSynchronization() {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+      }
+    };
+    when(activeServerEntity.getConcurrencyStrategy()).thenReturn(basic);
+    when(activeServerEntity.getMessageCodec()).thenReturn(codec);
+    managedEntity.addLifecycleRequest(mockPromoteToActiveRequest(), new byte[0]);
+    managedEntity.addLifecycleRequest(mockCreateEntityRequest(), new byte[0]);
+
+    Deque<Runnable> queued = new LinkedList<>();    
+    Mockito.doAnswer(new Answer<Object>() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        queued.add((Runnable)invocation.getArguments()[3]);
+        return null;
+      }
+    }).when(requestMulti).scheduleRequest(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt());
+    Mockito.doAnswer(new Answer<Object>() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        managedEntity.addInvokeRequest(mockNoopRequest(), null);
+        return null;
+      }
+    }).when(loopback).addSingleThreaded(Matchers.any());
+
+    managedEntity.addInvokeRequest(mockInvokeRequest(), Integer.toString(ConcurrencyStrategy.MANAGEMENT_KEY).getBytes());
+    for (int x=1;x<=24;x++) {
+      managedEntity.addInvokeRequest(mockInvokeRequest(), Integer.toString(x).getBytes());
+    }
+//  only thing in the queue should be the MGMT action    
+    Assert.assertTrue(queued.size() == 1);
+    Runnable r = queued.pop();
+    Assert.assertNotNull(r);
+// run the mgmt action so defer is cleared    
+    r.run();
+    verify(loopback).addSingleThreaded(Matchers.any(NoopEntityMessage.class));
+// see if deferred are flushed
+    Assert.assertTrue(queued.size() == 24);
+    
   }
 
   @Test
@@ -334,6 +420,13 @@ public class ManagedEntityImplTest {
   private ServerEntityRequest mockReleaseRequest(com.tc.net.ClientID requester) {
     ServerEntityRequest request = mockRequestForAction(ServerEntityAction.RELEASE_ENTITY);
     when(request.getNodeID()).thenReturn(requester);
+    return request;
+  }
+    
+  private ServerEntityRequest mockNoopRequest() {
+    ServerEntityRequest request = mock(ServerEntityRequest.class);
+    when(request.getSourceDescriptor()).thenReturn(new ClientDescriptorImpl(ClientID.NULL_ID, entityDescriptor));
+    when(request.getAction()).thenReturn(ServerEntityAction.NOOP);
     return request;
   }
   

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ProcessTransactionHandlerTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ProcessTransactionHandlerTest.java
@@ -91,7 +91,7 @@ public class ProcessTransactionHandlerTest {
     this.clientEntityStateManager = new ClientEntityStateManagerImpl(loopbackSink);
     this.eventCollector = mock(ITopologyEventCollector.class);
     RequestProcessor processor = new RequestProcessor(this.requestProcessorSink);
-    EntityManagerImpl entityManager = new EntityManagerImpl(this.terracottaServiceProviderRegistry, clientEntityStateManager, eventCollector, processor);
+    EntityManagerImpl entityManager = new EntityManagerImpl(this.terracottaServiceProviderRegistry, clientEntityStateManager, eventCollector, processor, loopbackSink);
     channelManager.addEventListener(clientEntityStateManager);
     processTransactionHandler.setLateBoundComponents(channelManager, entityManager);
   }

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
@@ -1,0 +1,256 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.objectserver.handler;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.After;
+import org.junit.Before;
+
+import com.tc.async.api.EventHandler;
+import com.tc.async.api.EventHandlerException;
+import com.tc.async.api.Sink;
+import com.tc.async.api.SpecializedEventContext;
+import com.tc.entity.NetworkVoltronEntityMessage;
+import com.tc.entity.VoltronEntityAppliedResponse;
+import com.tc.entity.VoltronEntityMessage;
+import com.tc.entity.VoltronEntityReceivedResponse;
+import com.tc.l2.msg.ReplicationMessage;
+import com.tc.l2.state.StateManager;
+import com.tc.net.ClientID;
+import com.tc.net.ServerID;
+import com.tc.net.groups.GroupManager;
+import com.tc.net.protocol.tcm.MessageChannel;
+import com.tc.net.protocol.tcm.TCMessageType;
+import com.tc.object.ClientInstanceID;
+import com.tc.object.EntityDescriptor;
+import com.tc.object.EntityID;
+import com.tc.object.net.DSOChannelManager;
+import com.tc.object.tx.TransactionID;
+import com.tc.objectserver.api.EntityManager;
+import com.tc.objectserver.api.ManagedEntity;
+import com.tc.objectserver.core.api.ITopologyEventCollector;
+import com.tc.objectserver.entity.ClientEntityStateManager;
+import com.tc.objectserver.entity.PlatformEntity;
+import com.tc.objectserver.persistence.EntityPersistor;
+import com.tc.objectserver.persistence.TransactionOrderPersistor;
+import com.tc.services.TerracottaServiceProviderRegistry;
+import com.tc.stats.Stats;
+import com.tc.util.Assert;
+
+import java.util.LinkedList;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Random;
+import org.junit.Test;
+import org.mockito.Matchers;
+import static org.mockito.Mockito.verify;
+
+
+public class ReplicatedTransactionHandlerTest {
+  private TerracottaServiceProviderRegistry terracottaServiceProviderRegistry;
+  private EntityPersistor entityPersistor;
+  private TransactionOrderPersistor transactionOrderPersistor;
+  private ReplicatedTransactionHandler rth;
+  private ClientID source;
+  private ForwardingSink loopbackSink;
+  private RunnableSink requestProcessorSink;
+  private ClientEntityStateManager clientEntityStateManager;
+  private ITopologyEventCollector eventCollector;
+  private StateManager stateManager;
+  private EntityManager entityManager;
+  private GroupManager groupManager;
+  
+  
+  @Before
+  public void setUp() throws Exception {
+    this.terracottaServiceProviderRegistry = mock(TerracottaServiceProviderRegistry.class);
+    this.entityPersistor = mock(EntityPersistor.class);
+    this.transactionOrderPersistor = mock(TransactionOrderPersistor.class);
+    this.stateManager = mock(StateManager.class);
+    this.entityManager = mock(EntityManager.class);
+    this.groupManager = mock(GroupManager.class);
+    when(entityManager.getEntity(Matchers.eq(PlatformEntity.PLATFORM_ID), Matchers.eq(PlatformEntity.VERSION))).thenReturn(Optional.of(mock(ManagedEntity.class)));
+    this.rth = new ReplicatedTransactionHandler(stateManager, this.transactionOrderPersistor, this.entityManager, this.entityPersistor, this.groupManager);
+    this.source = mock(ClientID.class);
+    
+    MessageChannel messageChannel = mock(MessageChannel.class);
+    when(messageChannel.createMessage(TCMessageType.VOLTRON_ENTITY_APPLIED_RESPONSE)).thenReturn(mock(VoltronEntityAppliedResponse.class));
+    when(messageChannel.createMessage(TCMessageType.VOLTRON_ENTITY_RECEIVED_RESPONSE)).thenReturn(mock(VoltronEntityReceivedResponse.class));
+    
+    DSOChannelManager channelManager = mock(DSOChannelManager.class);
+    when(channelManager.getActiveChannel(this.source)).thenReturn(messageChannel);
+    
+    this.loopbackSink = new ForwardingSink(this.rth.getEventHandler());
+    this.requestProcessorSink = new RunnableSink();
+    
+    this.eventCollector = mock(ITopologyEventCollector.class);
+    channelManager.addEventListener(clientEntityStateManager);
+  }
+  
+  @Test
+  public void testEntityGetsConcurrencyKey() throws Exception {
+    EntityID eid = new EntityID("foo", "bar");
+    EntityDescriptor descriptor = new EntityDescriptor(eid, ClientInstanceID.NULL_ID, 1);
+    ServerID sid = new ServerID("test", "test".getBytes());
+    ManagedEntity entity = mock(ManagedEntity.class);
+    ReplicationMessage msg = mock(ReplicationMessage.class);
+    int rand = new Random().nextInt();
+    when(msg.getConcurrency()).thenReturn(rand);
+    when(msg.getType()).thenReturn(ReplicationMessage.REPLICATE);
+    when(msg.getReplicationType()).thenReturn(ReplicationMessage.ReplicationType.INVOKE_ACTION);
+    when(msg.getEntityID()).thenReturn(eid);
+    when(msg.messageFrom()).thenReturn(sid);
+    when(msg.getEntityDescriptor()).thenReturn(descriptor);
+    when(msg.getOldestTransactionOnClient()).thenReturn(TransactionID.NULL_ID);
+    when(this.entityManager.getEntity(Matchers.any(), Matchers.anyInt())).thenReturn(Optional.of(entity));
+    this.loopbackSink.addSingleThreaded(msg);
+    verify(entity).addInvokeRequest(Matchers.any(), Matchers.any(), Matchers.eq(rand));
+    verify(groupManager).sendTo(Matchers.eq(sid), Matchers.any());
+  }
+  
+  @After
+  public void tearDown() throws Exception {
+    this.rth.getEventHandler().destroy();
+  }
+  
+
+
+
+  /**
+   * This is pulled out as its own helper since the mocked EntityIDs aren't .equals() each other so using the same
+   * instance gives convenient de facto equality.
+   */
+  private EntityID createMockEntity(String entityName) {
+    EntityID entityID = mock(EntityID.class);
+    // We will use the TestEntity since we only want to proceed with the check, not actually create it (this is from entity-api).
+    when(entityID.getClassName()).thenReturn("org.terracotta.TestEntity");
+    when(entityID.getEntityName()).thenReturn(entityName);
+    return entityID;
+  }
+
+  private NetworkVoltronEntityMessage createMockRequest(VoltronEntityMessage.Type type, EntityID entityID, TransactionID transactionID) {
+    NetworkVoltronEntityMessage request = mock(NetworkVoltronEntityMessage.class);
+    when(request.getSource()).thenReturn(this.source);
+    when(request.getVoltronType()).thenReturn(type);
+    EntityDescriptor entityDescriptor = mock(EntityDescriptor.class);
+    when(entityDescriptor.getClientSideVersion()).thenReturn((long) 1);
+    when(entityDescriptor.getEntityID()).thenReturn(entityID);
+    when(request.getEntityDescriptor()).thenReturn(entityDescriptor);
+    when(request.getTransactionID()).thenReturn(transactionID);
+    when(request.getOldestTransactionOnClient()).thenReturn(new TransactionID(0));
+    return request;
+  }
+
+
+  private static abstract class NoStatsSink<T> implements Sink<T> {
+    @Override
+    public void enableStatsCollection(boolean enable) {
+      throw new UnsupportedOperationException();
+    }
+    @Override
+    public boolean isStatsCollectionEnabled() {
+      throw new UnsupportedOperationException();
+    }
+    @Override
+    public Stats getStats(long frequency) {
+      throw new UnsupportedOperationException();
+    }
+    @Override
+    public Stats getStatsAndReset(long frequency) {
+      throw new UnsupportedOperationException();
+    }
+    @Override
+    public void resetStats() {
+      throw new UnsupportedOperationException();
+    }
+    @Override
+    public void addSpecialized(SpecializedEventContext specialized) {
+      throw new UnsupportedOperationException();
+    }
+    @Override
+    public int size() {
+      throw new UnsupportedOperationException();
+    }
+    @Override
+    public void clear() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+
+  private static class RunnableSink extends NoStatsSink<Runnable> {
+    private final Queue<Runnable> runnableQueue;
+
+    public RunnableSink() {
+      this.runnableQueue = new LinkedList<>();
+    }
+
+    public void runUntilEmpty() {
+      while (!this.runnableQueue.isEmpty()) {
+        Runnable task = this.runnableQueue.poll();
+        task.run();
+      }
+    }
+    @Override
+    public void addSingleThreaded(Runnable context) {
+      throw new UnsupportedOperationException();
+    }
+    @Override
+    public void addMultiThreaded(Runnable context) {
+      this.runnableQueue.add(context);
+    }
+
+    @Override
+    public void setClosed(boolean closed) {
+      throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+  }
+
+  }
+
+
+  private static class ForwardingSink extends NoStatsSink<ReplicationMessage> {
+    private final EventHandler<ReplicationMessage> target;
+
+    public ForwardingSink(EventHandler<ReplicationMessage> voltronMessageHandler) {
+      this.target = voltronMessageHandler;
+    }
+
+    @Override
+    public void addSingleThreaded(ReplicationMessage context) {
+      try {
+        this.target.handleEvent(context);
+      } catch (EventHandlerException e) {
+        Assert.fail();
+      }
+    }
+    @Override
+    public void addMultiThreaded(ReplicationMessage context) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setClosed(boolean closed) {
+      throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+  }
+    
+    
+}
+}

--- a/tc-messaging/src/main/java/com/tc/entity/VoltronEntityMessage.java
+++ b/tc-messaging/src/main/java/com/tc/entity/VoltronEntityMessage.java
@@ -50,6 +50,10 @@ public interface VoltronEntityMessage {
      * Used when invoking a method on an existing entity.
      */
     INVOKE_ACTION,
+    /**
+     * noop for pipeline flushes
+     */
+    NOOP
   }
   
   enum Acks {

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
@@ -128,7 +128,7 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
     return descriptor.getClientSideVersion();
   }
   
-  public final ReplicationType getReplicationType() {
+  public ReplicationType getReplicationType() {
     return action;
   }
 


### PR DESCRIPTION
This PR makes MGMT_KEY more exclusive than before.  MGMT_KEY currently flushes all the request queues but does not prevent subsequently submitted requests from overrunning the event on the MGMT_KEY.  The provides a deferment queue so that new messages on this queue are not submitted request processor until after the MGMT_KEY event completes.

Also included in this PR is a bug fix in the passive execution pipeline.