### PR TITLE
Built-in registration is now distinct from external implementation registration

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -177,7 +177,6 @@ import com.tc.objectserver.locks.LockResponseContext;
 import com.tc.objectserver.persistence.ClientStatePersistor;
 import com.tc.objectserver.persistence.FlatFileStorageProviderConfiguration;
 import com.tc.objectserver.persistence.FlatFileStorageServiceProvider;
-import com.tc.objectserver.persistence.PersistentStorageServiceConfiguration;
 import com.tc.objectserver.persistence.Persistor;
 import com.tc.objectserver.persistence.NullPlatformStorageServiceProvider;
 import com.tc.objectserver.persistence.NullPlatformStorageProviderConfiguration;
@@ -461,11 +460,11 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
         flatFileService.close();
         throw new AssertionError("bad flat file initialization");
       }
-      serviceRegistry.registerBuiltin(flatFileService);
+      serviceRegistry.registerExternal(flatFileService);
     } else {
       NullPlatformStorageServiceProvider nullPlatformStorageServiceProvider = new NullPlatformStorageServiceProvider();
       nullPlatformStorageServiceProvider.initialize(new NullPlatformStorageProviderConfiguration());
-      serviceRegistry.registerBuiltin(nullPlatformStorageServiceProvider);
+      serviceRegistry.registerExternal(nullPlatformStorageServiceProvider);
     }
 
     // The platform gets the reserved consumerID 0.

--- a/dso-l2/src/main/java/com/tc/services/BuiltInServiceProvider.java
+++ b/dso-l2/src/main/java/com/tc/services/BuiltInServiceProvider.java
@@ -1,0 +1,55 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Entity API.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.services;
+
+import java.io.Closeable;
+import java.util.Collection;
+
+import org.terracotta.entity.ServiceConfiguration;
+
+
+/**
+ * This service provider implementation differs from the one used by user-provided services and is used exclusively by those
+ * services which are provided by the platform implementation, itself.
+ * This interface is correspondingly richer since it is part of the platform and exposes these details to built-in services
+ * which are also part of the platform implementation.
+ * The public ServiceProvider implementation is much more restricted in that user-provided services are not allowed to know
+ * as many detail of the platform internals.
+ * 
+ * This has no explicit initialization routine as it is expected that the implementation will be initialized with rich
+ * context, inline, prior to being registered with the platform's provider registry.
+ */
+public interface BuiltInServiceProvider extends Closeable {
+  /**
+   * Get an instance of service from the provider.
+   *
+   * @param consumerID The unique ID used to name-space the returned service
+   * @param configuration Service configuration which is to be used
+   * @return service instance
+   */
+  <T> T getService(long consumerID, ServiceConfiguration<T> configuration);
+
+  /**
+   * Since a service provider can know how to build more than one type of service, this method allows the platform to query
+   * the extent of that capability.  Returned is a collection of service types which can be returned by getService.
+   *
+   * @return A collection of the types of services which can be returned by the receiver.
+   */
+  Collection<Class<?>> getProvidedServiceTypes();
+}

--- a/dso-l2/src/main/java/com/tc/services/CommunicatorService.java
+++ b/dso-l2/src/main/java/com/tc/services/CommunicatorService.java
@@ -16,15 +16,12 @@
  *  Terracotta, Inc., a Software AG company
  *
  */
-
 package com.tc.services;
 
 import com.tc.net.NodeID;
 import com.tc.net.protocol.tcm.MessageChannel;
 import com.tc.object.net.DSOChannelManager;
 import com.tc.object.net.DSOChannelManagerEventListener;
-
-import org.terracotta.entity.ServiceProvider;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -36,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.terracotta.entity.ClientCommunicator;
 import org.terracotta.entity.ServiceConfiguration;
-import org.terracotta.entity.ServiceProviderConfiguration;
 
 
 class ResponseWaiter implements Future<Void> {
@@ -84,7 +80,7 @@ class ResponseWaiter implements Future<Void> {
   }
 }
 
-public class CommunicatorService implements ServiceProvider, DSOChannelManagerEventListener {
+public class CommunicatorService implements BuiltInServiceProvider, DSOChannelManagerEventListener {
   private final ConcurrentMap<NodeID, ClientAccount> clientAccounts = new ConcurrentHashMap<>();
 
   public CommunicatorService(DSOChannelManager dsoChannelManager) {
@@ -113,15 +109,9 @@ public class CommunicatorService implements ServiceProvider, DSOChannelManagerEv
 
 
   @Override
-  public boolean initialize(ServiceProviderConfiguration configuration) {
-    ///Nothing here
-    return true;
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
   public <T> T getService(long consumerID, ServiceConfiguration<T> configuration) {
-    return configuration.getServiceType().cast(new EntityClientCommunicatorService(clientAccounts));
+    EntityClientCommunicatorService service = new EntityClientCommunicatorService(clientAccounts);
+    return configuration.getServiceType().cast(service);
   }
 
   @Override
@@ -134,6 +124,4 @@ public class CommunicatorService implements ServiceProvider, DSOChannelManagerEv
     clientAccounts.values().stream().forEach(a->a.close());
     clientAccounts.clear();
   }
-  
-  
 }

--- a/dso-l2/src/main/java/com/tc/services/EntityClientCommunicatorService.java
+++ b/dso-l2/src/main/java/com/tc/services/EntityClientCommunicatorService.java
@@ -16,7 +16,6 @@
  *  Terracotta, Inc., a Software AG company
  *
  */
-
 package com.tc.services;
 
 import com.google.common.util.concurrent.Futures;
@@ -25,10 +24,10 @@ import com.tc.object.EntityDescriptor;
 import com.tc.objectserver.entity.ClientDescriptorImpl;
 import org.terracotta.entity.ClientCommunicator;
 import org.terracotta.entity.ClientDescriptor;
-import org.terracotta.entity.ServiceConfiguration;
 
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
+
 
 public class EntityClientCommunicatorService implements ClientCommunicator {
   private final ConcurrentMap<NodeID, ClientAccount> clientAccounts;

--- a/dso-l2/src/main/java/com/tc/services/TerracottaServiceProviderRegistry.java
+++ b/dso-l2/src/main/java/com/tc/services/TerracottaServiceProviderRegistry.java
@@ -16,14 +16,13 @@
  *  Terracotta, Inc., a Software AG company
  *
  */
-
 package com.tc.services;
 
 import org.terracotta.config.TcConfiguration;
+import org.terracotta.entity.ServiceProvider;
+import org.terracotta.entity.ServiceConfiguration;
 import org.terracotta.entity.ServiceRegistry;
 
-import org.terracotta.entity.ServiceConfiguration;
-import org.terracotta.entity.ServiceProvider;
 
 /**
  * Platform level service provider registry which has instances of all the service provider at the platform level.
@@ -41,12 +40,21 @@ public interface TerracottaServiceProviderRegistry {
   void initialize(String serverName, TcConfiguration configuration);
 
   /**
-   * Method to register platform level service provider which don't have life-cycle using SPI interface.
+   * Method to register platform level service provider which don't have life-cycle using SPI interface but otherwise act
+   * like user-provided services.
    * Note that this serviceProvider will also be initialized with the same configuration used to initialize the registry.
    *
    * @param serviceProvider platform service provider
    */
-  void registerBuiltin(ServiceProvider serviceProvider);
+  void registerExternal(ServiceProvider serviceProvider);
+
+  /**
+   * Method to register platform level service provider which don't have life-cycle using SPI interface and know about the
+   * internal details of the implementation.
+   *
+   * @param serviceProvider platform service provider
+   */
+  void registerBuiltin(BuiltInServiceProvider serviceProvider);
 
   /**
    * Creates a entity level service registry which has list of service instances managed by the service providers

--- a/dso-l2/src/main/java/com/tc/services/TerracottaServiceProviderRegistryImpl.java
+++ b/dso-l2/src/main/java/com/tc/services/TerracottaServiceProviderRegistryImpl.java
@@ -16,13 +16,11 @@
  *  Terracotta, Inc., a Software AG company
  *
  */
-
 package com.tc.services;
 
 import org.terracotta.config.TcConfiguration;
 import org.terracotta.entity.ServiceProvider;
 import org.terracotta.entity.ServiceProviderConfiguration;
-import org.terracotta.entity.ServiceRegistry;
 
 import com.tc.logging.TCLogger;
 import com.tc.logging.TCLogging;
@@ -40,6 +38,7 @@ public class TerracottaServiceProviderRegistryImpl implements TerracottaServiceP
   // We need to hold on to the configuration when we are initialized so we can give it to services registered later as
   //  built-ins.
   private final Set<ServiceProvider> serviceProviders = new HashSet<>();
+  private final Set<BuiltInServiceProvider> builtInServiceProviders = new HashSet<>();
 
   @Override
   public void initialize(String serverName, TcConfiguration configuration) {
@@ -76,13 +75,19 @@ public class TerracottaServiceProviderRegistryImpl implements TerracottaServiceP
   }
 
   @Override
-  public  void registerBuiltin(ServiceProvider service) {
+  public  void registerExternal(ServiceProvider service) {
     registerNewServiceProvider(service);
   }
 
   @Override
-  public ServiceRegistry subRegistry(long consumerID) {
-    return new DelegatingServiceRegistry(consumerID, serviceProviders.toArray(new ServiceProvider[serviceProviders.size()]));
+  public  void registerBuiltin(BuiltInServiceProvider service) {
+    logger.info("Registering built-in service " + service);
+    builtInServiceProviders.add(service);
+  }
+
+  @Override
+  public DelegatingServiceRegistry subRegistry(long consumerID) {
+    return new DelegatingServiceRegistry(consumerID, serviceProviders.toArray(new ServiceProvider[serviceProviders.size()]), builtInServiceProviders.toArray(new BuiltInServiceProvider[builtInServiceProviders.size()]));
   }
 
   @Override


### PR DESCRIPTION
For now, this largely just creates a parallel registration and look-up path but creates the groundwork for allowing these to split in more meaningful ways, over time