### PR TITLE
Fix #78: Updated EntityClientCommunicatorService to use EntityResponse as its argument type

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
@@ -19,6 +19,7 @@
 package com.tc.objectserver.api;
 
 import org.terracotta.entity.ClientDescriptor;
+import org.terracotta.entity.MessageCodec;
 
 import com.tc.net.ClientID;
 import com.tc.net.NodeID;
@@ -62,4 +63,12 @@ public interface ManagedEntity {
    * @param passive target passive
    */
   void sync(NodeID passive);
+
+  /**
+   * Used when an external component (such as CommunicatorService) needs to translate to/from something specific to this
+   * entity's dialect.
+   * 
+   * @return The codec which can translate to/from this entity's message dialect.
+   */
+  MessageCodec<?, ?> getCodec();
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -33,7 +33,6 @@ import org.terracotta.entity.MessageCodecException;
 import org.terracotta.entity.PassiveServerEntity;
 import org.terracotta.entity.PassiveSynchronizationChannel;
 import org.terracotta.entity.ServerEntityService;
-import org.terracotta.entity.ServiceRegistry;
 
 import com.tc.net.ClientID;
 import com.tc.net.NodeID;
@@ -47,6 +46,7 @@ import com.tc.objectserver.core.api.ITopologyEventCollector;
 import com.tc.objectserver.core.api.ServerConfigurationContext;
 import com.tc.properties.TCPropertiesConsts;
 import com.tc.properties.TCPropertiesImpl;
+import com.tc.services.InternalServiceRegistry;
 import com.tc.util.Assert;
 import static com.tc.util.Assert.assertNotNull;
 import java.util.Collections;
@@ -78,7 +78,7 @@ public class ManagedEntityImpl implements ManagedEntity {
 
   private final EntityID id;
   private final long version;
-  private final ServiceRegistry registry;
+  private final InternalServiceRegistry registry;
   private final ClientEntityStateManager clientEntityStateManager;
   private final ITopologyEventCollector eventCollector;
   private final ServerEntityService<? extends ActiveServerEntity<EntityMessage, EntityResponse>, ? extends PassiveServerEntity<EntityMessage, EntityResponse>> factory;
@@ -99,7 +99,7 @@ public class ManagedEntityImpl implements ManagedEntity {
   //  when we promote to an active.
   private byte[] constructorInfo;
 
-  ManagedEntityImpl(EntityID id, long version, Sink<VoltronEntityMessage> loopback, ServiceRegistry registry, ClientEntityStateManager clientEntityStateManager, ITopologyEventCollector eventCollector,
+  ManagedEntityImpl(EntityID id, long version, Sink<VoltronEntityMessage> loopback, InternalServiceRegistry registry, ClientEntityStateManager clientEntityStateManager, ITopologyEventCollector eventCollector,
                     RequestProcessor process, ServerEntityService<? extends ActiveServerEntity<EntityMessage, EntityResponse>, ? extends PassiveServerEntity<EntityMessage, EntityResponse>> factory,
                     boolean isInActiveState) {
     this.id = id;
@@ -111,6 +111,7 @@ public class ManagedEntityImpl implements ManagedEntity {
     this.factory = factory;
     this.executor = process;
     this.isInActiveState = isInActiveState;
+    registry.setOwningEntity(this);
   }
 
   @Override

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -616,6 +616,13 @@ public class ManagedEntityImpl implements ManagedEntity {
     this.eventCollector.entityWasReloaded(this.getID(), this.isInActiveState);
   }
 
+  @Override
+  public MessageCodec<?, ?> getCodec() {
+    return (null != this.activeServerEntity)
+        ? this.activeServerEntity.getMessageCodec()
+        : this.passiveServerEntity.getMessageCodec();
+  }
+
   private static class PassiveSyncServerEntityRequest extends AbstractServerEntityRequest {
     private final NodeID passive;
     

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/PlatformEntity.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/PlatformEntity.java
@@ -25,8 +25,11 @@ import com.tc.object.EntityDescriptor;
 import com.tc.object.EntityID;
 import com.tc.objectserver.api.ManagedEntity;
 import com.tc.objectserver.api.ServerEntityRequest;
+import com.tc.util.Assert;
+
 import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.entity.ConcurrencyStrategy;
+import org.terracotta.entity.MessageCodec;
 
 
 public class PlatformEntity implements ManagedEntity {
@@ -72,5 +75,12 @@ public class PlatformEntity implements ManagedEntity {
   @Override
   public void sync(NodeID passive) {
   //  never sync
+  }
+
+  @Override
+  public MessageCodec<?, ?> getCodec() {
+    // The platform entity has no codec so calling this means there is an error elsewhere.
+    Assert.fail();
+    return null;
   }
 }

--- a/dso-l2/src/main/java/com/tc/services/BuiltInServiceProvider.java
+++ b/dso-l2/src/main/java/com/tc/services/BuiltInServiceProvider.java
@@ -23,6 +23,8 @@ import java.util.Collection;
 
 import org.terracotta.entity.ServiceConfiguration;
 
+import com.tc.objectserver.api.ManagedEntity;
+
 
 /**
  * This service provider implementation differs from the one used by user-provided services and is used exclusively by those
@@ -40,10 +42,11 @@ public interface BuiltInServiceProvider extends Closeable {
    * Get an instance of service from the provider.
    *
    * @param consumerID The unique ID used to name-space the returned service
+   * @param owningEntity The concrete entity which will own the server instance (may be null)
    * @param configuration Service configuration which is to be used
    * @return service instance
    */
-  <T> T getService(long consumerID, ServiceConfiguration<T> configuration);
+  <T> T getService(long consumerID, ManagedEntity owningEntity, ServiceConfiguration<T> configuration);
 
   /**
    * Since a service provider can know how to build more than one type of service, this method allows the platform to query

--- a/dso-l2/src/main/java/com/tc/services/CommunicatorService.java
+++ b/dso-l2/src/main/java/com/tc/services/CommunicatorService.java
@@ -22,6 +22,7 @@ import com.tc.net.NodeID;
 import com.tc.net.protocol.tcm.MessageChannel;
 import com.tc.object.net.DSOChannelManager;
 import com.tc.object.net.DSOChannelManagerEventListener;
+import com.tc.objectserver.api.ManagedEntity;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -109,8 +110,8 @@ public class CommunicatorService implements BuiltInServiceProvider, DSOChannelMa
 
 
   @Override
-  public <T> T getService(long consumerID, ServiceConfiguration<T> configuration) {
-    EntityClientCommunicatorService service = new EntityClientCommunicatorService(clientAccounts);
+  public <T> T getService(long consumerID, ManagedEntity owningEntity, ServiceConfiguration<T> configuration) {
+    EntityClientCommunicatorService service = new EntityClientCommunicatorService(clientAccounts, owningEntity);
     return configuration.getServiceType().cast(service);
   }
 

--- a/dso-l2/src/main/java/com/tc/services/DelegatingServiceRegistry.java
+++ b/dso-l2/src/main/java/com/tc/services/DelegatingServiceRegistry.java
@@ -92,7 +92,7 @@ public class DelegatingServiceRegistry implements InternalServiceRegistry {
     T service = null;
     if (null != serviceProviders) {
       for (BuiltInServiceProvider provider : serviceProviders) {
-        T oneService = provider.getService(this.consumerID, configuration);
+        T oneService = provider.getService(this.consumerID, this.owningEntity, configuration);
         if (null != oneService) {
           // TODO:  Determine how to rationalize multiple matches.  For now, we will force either 1 or 0.
           Assert.assertNull(service);

--- a/dso-l2/src/main/java/com/tc/services/EntityClientCommunicatorService.java
+++ b/dso-l2/src/main/java/com/tc/services/EntityClientCommunicatorService.java
@@ -21,7 +21,9 @@ package com.tc.services;
 import com.google.common.util.concurrent.Futures;
 import com.tc.net.NodeID;
 import com.tc.object.EntityDescriptor;
+import com.tc.objectserver.api.ManagedEntity;
 import com.tc.objectserver.entity.ClientDescriptorImpl;
+
 import org.terracotta.entity.ClientCommunicator;
 import org.terracotta.entity.ClientDescriptor;
 
@@ -31,9 +33,14 @@ import java.util.concurrent.Future;
 
 public class EntityClientCommunicatorService implements ClientCommunicator {
   private final ConcurrentMap<NodeID, ClientAccount> clientAccounts;
+  @SuppressWarnings("unused")
+  // Currently unused by will be accessed in a forthcoming change.
+  private final ManagedEntity owningEntity;
+  
 
-  public EntityClientCommunicatorService(ConcurrentMap<NodeID, ClientAccount> clientAccounts) {
+  public EntityClientCommunicatorService(ConcurrentMap<NodeID, ClientAccount> clientAccounts, ManagedEntity owningEntity) {
     this.clientAccounts = clientAccounts;
+    this.owningEntity = owningEntity;
   }
 
   @Override

--- a/dso-l2/src/main/java/com/tc/services/EntityClientCommunicatorService.java
+++ b/dso-l2/src/main/java/com/tc/services/EntityClientCommunicatorService.java
@@ -26,6 +26,9 @@ import com.tc.objectserver.entity.ClientDescriptorImpl;
 
 import org.terracotta.entity.ClientCommunicator;
 import org.terracotta.entity.ClientDescriptor;
+import org.terracotta.entity.EntityResponse;
+import org.terracotta.entity.MessageCodec;
+import org.terracotta.entity.MessageCodecException;
 
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
@@ -33,8 +36,6 @@ import java.util.concurrent.Future;
 
 public class EntityClientCommunicatorService implements ClientCommunicator {
   private final ConcurrentMap<NodeID, ClientAccount> clientAccounts;
-  @SuppressWarnings("unused")
-  // Currently unused by will be accessed in a forthcoming change.
   private final ManagedEntity owningEntity;
   
 
@@ -44,26 +45,35 @@ public class EntityClientCommunicatorService implements ClientCommunicator {
   }
 
   @Override
-  public void sendNoResponse(ClientDescriptor clientDescriptor, byte[] payload) {
+  public void sendNoResponse(ClientDescriptor clientDescriptor, EntityResponse message) throws MessageCodecException {
     // We are in internal code so downcast the descriptor.
     ClientDescriptorImpl rawDescriptor = (ClientDescriptorImpl)clientDescriptor;
     ClientAccount clientAccount = clientAccounts.get(rawDescriptor.getNodeID());
     if (clientAccount != null) {
       EntityDescriptor entityDescriptor = rawDescriptor.getEntityDescriptor();
+      byte[] payload = serialize(this.owningEntity.getCodec(), message);
       clientAccount.sendNoResponse(entityDescriptor, payload);
     }
   }
 
   @Override
-  public Future<Void> send(ClientDescriptor clientDescriptor, byte[] payload) {
+  public Future<Void> send(ClientDescriptor clientDescriptor, EntityResponse message) throws MessageCodecException {
     // We are in internal code so downcast the descriptor.
     ClientDescriptorImpl rawDescriptor = (ClientDescriptorImpl)clientDescriptor;
     ClientAccount clientAccount = clientAccounts.get(rawDescriptor.getNodeID());
     if (clientAccount != null) {
       EntityDescriptor entityDescriptor = rawDescriptor.getEntityDescriptor();
+      byte[] payload = serialize(this.owningEntity.getCodec(), message);
       return clientAccount.send(entityDescriptor, payload);
     } else {
       return Futures.immediateFuture(null);
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <R extends EntityResponse> byte[] serialize(MessageCodec<?, R> codec, EntityResponse response) throws MessageCodecException {
+    // We do this downcast, inline, instead of asking the codec (since a safer cast is all it could do, anyway).
+    // This should be safe as we received this object from an entity using this codec. 
+    return codec.serialize((R)response);
   }
 }

--- a/dso-l2/src/main/java/com/tc/services/InternalServiceRegistry.java
+++ b/dso-l2/src/main/java/com/tc/services/InternalServiceRegistry.java
@@ -1,0 +1,40 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.services;
+
+import com.tc.objectserver.api.ManagedEntity;
+
+import org.terracotta.entity.ServiceRegistry;
+
+
+/**
+ * An extension to ServiceRegistry used to expose late-binding of the entity which owns the service registry.
+ * 
+ * Note that not all registries are owned by ManagedEntity instances.
+ */
+public interface InternalServiceRegistry extends ServiceRegistry {
+  /**
+   * Sets the owner of the service registry in case it needs to know anything about or communicate with its owner.
+   * Note that this method may never be called on an instance, if it has a non-entity owner.  If it is called, however, it
+   * will not be null.
+   * 
+   * @param entity The owning entity (not null).
+   */
+  public void setOwningEntity(ManagedEntity entity);
+}

--- a/dso-l2/src/main/java/com/tc/services/TerracottaServiceProviderRegistry.java
+++ b/dso-l2/src/main/java/com/tc/services/TerracottaServiceProviderRegistry.java
@@ -21,7 +21,6 @@ package com.tc.services;
 import org.terracotta.config.TcConfiguration;
 import org.terracotta.entity.ServiceProvider;
 import org.terracotta.entity.ServiceConfiguration;
-import org.terracotta.entity.ServiceRegistry;
 
 
 /**
@@ -62,7 +61,7 @@ public interface TerracottaServiceProviderRegistry {
    * @param consumerID The unique ID which will be used to name-space services created by this sub-registry
    * @return Service registry which will be used by entities.
    */
-  ServiceRegistry subRegistry(long consumerID);
+  InternalServiceRegistry subRegistry(long consumerID);
 
   /**
    * Returns an instance of service provider given an a class. This method is not to be used by entities but by platform

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/EntityManagerImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/EntityManagerImplTest.java
@@ -29,12 +29,15 @@ import org.terracotta.TestEntity;
 import com.tc.object.EntityID;
 import com.tc.objectserver.api.EntityManager;
 import com.tc.objectserver.core.api.ITopologyEventCollector;
+import com.tc.services.InternalServiceRegistry;
 import com.tc.services.TerracottaServiceProviderRegistry;
 
 import static java.util.Optional.empty;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class EntityManagerImplTest {
   
@@ -45,8 +48,10 @@ public class EntityManagerImplTest {
 
   @Before
   public void setUp() throws Exception {
+    TerracottaServiceProviderRegistry registry = mock(TerracottaServiceProviderRegistry.class);
+    when(registry.subRegistry(any(Long.class))).thenReturn(mock(InternalServiceRegistry.class));
     entityManager = new EntityManagerImpl(
-        mock(TerracottaServiceProviderRegistry.class),
+        registry,
         mock(ClientEntityStateManager.class),
         mock(ITopologyEventCollector.class),
         mock(RequestProcessor.class),

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
@@ -227,7 +227,7 @@ public class ManagedEntityImplTest {
   
   @Test
   public void testExclusiveExecution() throws Exception {
-    MessageCodec codec = new MessageCodec() {
+    MessageCodec<EntityMessage, EntityResponse> codec = new MessageCodec<EntityMessage, EntityResponse>() {
       @Override
       public EntityMessage deserialize(byte[] payload) throws MessageCodecException {
         return new EntityMessage() {
@@ -248,7 +248,7 @@ public class ManagedEntityImplTest {
         return new byte[0];
       }
     };
-    ConcurrencyStrategy basic = new ConcurrencyStrategy() {
+    ConcurrencyStrategy<EntityMessage> basic = new ConcurrencyStrategy<EntityMessage>() {
       @Override
       public int concurrencyKey(EntityMessage message) {
         String key = message.toString();
@@ -256,7 +256,7 @@ public class ManagedEntityImplTest {
       }
 
       @Override
-      public Set getKeysForSynchronization() {
+      public Set<Integer> getKeysForSynchronization() {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
       }
     };

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
@@ -43,6 +43,7 @@ import com.tc.objectserver.api.ServerEntityAction;
 import com.tc.objectserver.api.ServerEntityRequest;
 import com.tc.objectserver.core.api.ITopologyEventCollector;
 import com.tc.objectserver.core.api.ServerConfigurationContext;
+import com.tc.services.InternalServiceRegistry;
 import com.tc.util.Assert;
 
 import java.io.ByteArrayOutputStream;
@@ -76,7 +77,7 @@ public class ManagedEntityImplTest {
   private long version;
   private ManagedEntityImpl managedEntity;
   private Sink<VoltronEntityMessage> loopback;
-  private ServiceRegistry serviceRegistry;
+  private InternalServiceRegistry serviceRegistry;
   private ServerEntityService<? extends ActiveServerEntity<EntityMessage, EntityResponse>, ? extends PassiveServerEntity<EntityMessage, EntityResponse>> serverEntityService;
   private ActiveServerEntity<EntityMessage, EntityResponse> activeServerEntity;
   private PassiveServerEntity<EntityMessage, EntityResponse> passiveServerEntity;
@@ -95,7 +96,7 @@ public class ManagedEntityImplTest {
     clientInstanceID = new ClientInstanceID(1);
     version = 1;
     entityDescriptor = new EntityDescriptor(entityID, clientInstanceID, version);
-    serviceRegistry = mock(ServiceRegistry.class);
+    serviceRegistry = mock(InternalServiceRegistry.class);
     
     loopback = mock(Sink.class);
 

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ProcessTransactionHandlerTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ProcessTransactionHandlerTest.java
@@ -18,6 +18,7 @@
  */
 package com.tc.objectserver.handler;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -49,6 +50,7 @@ import com.tc.objectserver.entity.RequestProcessor;
 import com.tc.objectserver.persistence.EntityData;
 import com.tc.objectserver.persistence.EntityPersistor;
 import com.tc.objectserver.persistence.TransactionOrderPersistor;
+import com.tc.services.InternalServiceRegistry;
 import com.tc.services.TerracottaServiceProviderRegistry;
 import com.tc.stats.Stats;
 import com.tc.util.Assert;
@@ -73,6 +75,7 @@ public class ProcessTransactionHandlerTest {
   @Before
   public void setUp() throws Exception {
     this.terracottaServiceProviderRegistry = mock(TerracottaServiceProviderRegistry.class);
+    when(this.terracottaServiceProviderRegistry.subRegistry(any(Long.class))).thenReturn(mock(InternalServiceRegistry.class));
     this.entityPersistor = mock(EntityPersistor.class);
     this.transactionOrderPersistor = mock(TransactionOrderPersistor.class);
     this.processTransactionHandler = new ProcessTransactionHandler(this.entityPersistor, this.transactionOrderPersistor);


### PR DESCRIPTION
-also updated the corresponding test to use this type and provide a mock codec for serialization