### PR TITLE
Fix #91: crash the server if entity deserializer returns null

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -157,6 +157,8 @@ public class ManagedEntityImpl implements ManagedEntity {
           concurrencyStrategy.concurrencyKey(message) : defaultKey;
         final EntityMessage safeMessage = message;
         processInvokeRequest(request, payload, safeMessage, concurrencyKey);
+      } else {
+        throw new RuntimeException("entity deserializer returned null while processing invoke request");
       }
     }
   }
@@ -206,6 +208,8 @@ public class ManagedEntityImpl implements ManagedEntity {
         // If we are still ok and managed to deserialize the message, continue.
         if (null != message) {
           invoke(sync, message, concurrencyKey);
+        } else {
+          throw new RuntimeException("entity deserializer returned null while processing sync message");
         }
       }, concurrencyKey);
     } else {

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
@@ -397,7 +397,7 @@ public class ManagedEntityImplTest {
     
   }
 
-  @Test
+  @Test (expected = RuntimeException.class)
   public void testCodecException() throws Exception {
     managedEntity.addLifecycleRequest(mockCreateEntityRequest(), null);
     managedEntity.addLifecycleRequest(mockPromoteToActiveRequest(), null);


### PR DESCRIPTION
This PR brings changes to crash the server if entity MessageCodec.deserialize(...)/deserializeForSync(...) returns null. 