### PR TITLE
Add zip format to kit

### DIFF
--- a/terracotta-kit/src/assemble/distribution.xml
+++ b/terracotta-kit/src/assemble/distribution.xml
@@ -22,6 +22,7 @@ The Initial Developer of the Covered Software is
   <formats>
     <format>dir</format>
     <format>tar.gz</format>
+    <format>zip</format>
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>
   <fileSets>


### PR DESCRIPTION
For some use cases (windows, automated tests) the zip format is friendlier than a tarball