### PR TITLE
Remove slf4j implementation from the shaded jar

### DIFF
--- a/client-runtime/pom.xml
+++ b/client-runtime/pom.xml
@@ -32,6 +32,11 @@
             <artifactId>connection-impl</artifactId>
             <version>5.0.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>1.7.7</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -48,6 +53,12 @@
                         </goals>
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.slf4j:slf4j-log4j12</exclude>
+                                    <exclude>log4j:log4j</exclude>
+                                </excludes>
+                            </artifactSet>
                         </configuration>
                     </execution>
                 </executions>

--- a/terracotta-kit/src/assemble/README.txt
+++ b/terracotta-kit/src/assemble/README.txt
@@ -6,4 +6,5 @@ Contents
  Included in this kit are the following: 
    README.txt -- This file
    server -- Directory containing libraries, executables, and other supporting files for the Terracotta Server
-
+   client -- Directory containing the client runtime library that will allow your application to connect to the Terracotta server
+   client/lib -- Directory containing optional libraries to add to your client classpath (slf4j implementation for example)

--- a/terracotta-kit/src/assemble/distribution.xml
+++ b/terracotta-kit/src/assemble/distribution.xml
@@ -73,6 +73,13 @@ The Initial Developer of the Covered Software is
         <include>client-runtime*</include>
       </includes>
     </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/server-lib</directory>
+      <outputDirectory>/client/lib</outputDirectory>
+      <includes>
+        <include>slf4j-log4j12*</include>
+      </includes>
+    </fileSet>
     <!-- copy dependencies of terracotta (except itself) into /server/lib -->
     <fileSet>
       <directory>${project.build.directory}/server-lib</directory>


### PR DESCRIPTION
It's up to the consumers of the client runtime library to provide their slf4j implementation.
In a project using client-runtime, I'm currently encountering slf4j issues since it gets 2 impl. in the classpath.