### PR TITLE
Handle re-sent create/destroy/doesExist/reconfigure messages

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
@@ -116,6 +116,8 @@ public class RequestProcessor implements StateChangeListener {
         actionCode = ReplicationMessage.ReplicationType.SYNC_ENTITY_CONCURRENCY_BEGIN;
         break;
       default:
+        // Unknown message type.
+        Assert.fail();
         break;
     }
 //  TODO: Evaluate what to replicate...right now, everything is replicated.  Evaluate whether

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
@@ -78,7 +78,7 @@ public class RequestProcessor implements StateChangeListener {
         ? passives.replicateMessage(createReplicationMessage(entity, request.getNodeID(), request.getAction(), 
             request.getTransaction(), request.getOldestTransactionOnClient(), payload, concurrencyKey), replicateTo)
         : NoReplicationBroker.NOOP_FUTURE;
-    EntityRequest entityRequest =  new EntityRequest(entity, request, call, concurrencyKey, token);
+    EntityRequest entityRequest =  new EntityRequest(entity, call, concurrencyKey, token);
     requestExecution.addMultiThreaded(entityRequest);
   }
   
@@ -127,14 +127,12 @@ public class RequestProcessor implements StateChangeListener {
   
   private static class EntityRequest implements MultiThreadedEventContext, Runnable {
     private final EntityDescriptor entity;
-    private final ServerEntityRequest request;
     private final Runnable invoke;
     private final Future<Void>  token;
     private final int key;
 
-    public EntityRequest(EntityDescriptor entity, ServerEntityRequest request, Runnable runnable, int key, Future<Void>  token) {
+    public EntityRequest(EntityDescriptor entity, Runnable runnable, int key, Future<Void>  token) {
       this.entity = entity;
-      this.request = request;
       this.invoke = runnable;
       this.token = token;
       this.key = key;
@@ -178,5 +176,4 @@ public class RequestProcessor implements StateChangeListener {
       return (key == ConcurrencyStrategy.MANAGEMENT_KEY);
     }
   }
-  
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
@@ -86,6 +86,9 @@ public class RequestProcessor implements StateChangeListener {
       ServerEntityAction type, TransactionID tid, TransactionID oldest, byte[] payload, int concurrency) {
     ReplicationMessage.ReplicationType actionCode = ReplicationMessage.ReplicationType.NOOP;
     switch (type) {
+      case DOES_EXIST:
+        actionCode = ReplicationMessage.ReplicationType.DOES_EXIST;
+        break;
       case CREATE_ENTITY:
         actionCode = ReplicationMessage.ReplicationType.CREATE_ENTITY;
         break;

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/EntityExistenceHelpers.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/EntityExistenceHelpers.java
@@ -1,0 +1,55 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.objectserver.handler;
+
+import java.util.Optional;
+
+import com.tc.object.EntityID;
+import com.tc.objectserver.api.EntityManager;
+import com.tc.objectserver.api.ManagedEntity;
+import com.tc.objectserver.persistence.EntityPersistor;
+
+import org.terracotta.exception.EntityException;
+import org.terracotta.exception.EntityNotFoundException;
+
+
+/**
+ * Contains helpers which implement the entity existence-related patterns common to both ProcessTransactionHandler and
+ * ReplicatedTransactionHandler.
+ */
+public class EntityExistenceHelpers {
+  public static void createEntity(EntityPersistor entityPersistor, EntityManager entityManager, EntityID entityID, long version, long consumerID, byte[] configuration) throws EntityException {
+    entityManager.createEntity(entityID, version, consumerID);
+    entityPersistor.entityCreated(entityID, version, consumerID, configuration);
+  }
+
+  public static void destroyEntity(EntityPersistor entityPersistor, EntityManager entityManager, EntityID entityID) throws EntityException {
+    entityManager.destroyEntity(entityID);
+    entityPersistor.entityDeleted(entityID);
+  }
+
+  public static void reconfigureEntity(EntityPersistor entityPersistor, EntityManager entityManager, EntityID entityID, long version, byte[] configuration) throws EntityException {
+    Optional<ManagedEntity> optionalEntity = entityManager.getEntity(entityID, version);
+    if (optionalEntity.isPresent()) {
+      entityPersistor.reconfigureEntity(entityID, version, configuration);
+    } else {
+      throw new EntityNotFoundException(entityID.getClassName(), entityID.getEntityName());
+    }
+  }
+}

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
@@ -137,23 +137,19 @@ public class ProcessTransactionHandler {
       if (ServerEntityAction.CREATE_ENTITY == action) {
         long clientSideVersion = descriptor.getClientSideVersion();
         long consumerID = this.entityPersistor.getNextConsumerID();
-        entityManager.createEntity(entityID, clientSideVersion, consumerID);
-        this.entityPersistor.entityCreated(entityID, clientSideVersion, consumerID, extendedData);
+        EntityExistenceHelpers.createEntity(this.entityPersistor, this.entityManager, entityID, clientSideVersion, consumerID, extendedData);
       }
-      Optional<ManagedEntity> optionalEntity = entityManager.getEntity(entityID, descriptor.getClientSideVersion());
       if (ServerEntityAction.RECONFIGURE_ENTITY == action) {
-        if (optionalEntity.isPresent()) {
-          this.entityPersistor.reconfigureEntity(entityID, descriptor.getClientSideVersion(), extendedData);
-        } else {
-          throw new EntityNotFoundException(entityID.getClassName(), entityID.getEntityName());
-        }
+        long clientSideVersion = descriptor.getClientSideVersion();
+        EntityExistenceHelpers.reconfigureEntity(this.entityPersistor, this.entityManager, entityID, clientSideVersion, extendedData);
       }
+      // At this point, we can now look up the actual managed entity.
+      Optional<ManagedEntity> optionalEntity = entityManager.getEntity(entityID, descriptor.getClientSideVersion());
       if (optionalEntity.isPresent()) {
         entity = optionalEntity.get();
       }
       if (ServerEntityAction.DESTROY_ENTITY == action) {
-        entityManager.destroyEntity(entityID);
-        this.entityPersistor.entityDeleted(entityID);
+        EntityExistenceHelpers.destroyEntity(this.entityPersistor, this.entityManager, entityID);
       }
     } catch (EntityException e) {
       uncaughtException = e;

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -29,6 +29,7 @@ import com.tc.logging.TCLogger;
 import com.tc.logging.TCLogging;
 import com.tc.net.NodeID;
 import com.tc.net.ServerID;
+import com.tc.net.groups.AbstractGroupMessage;
 import com.tc.net.groups.GroupException;
 import com.tc.net.groups.GroupManager;
 import com.tc.object.EntityID;
@@ -54,7 +55,7 @@ public class ReplicatedTransactionHandler {
   private static final TCLogger LOGGER = TCLogging.getLogger(ReplicatedTransactionHandler.class);
   private final EntityManager entityManager;
   private final EntityPersistor entityPersistor;
-  private final GroupManager groupManager;
+  private final GroupManager<AbstractGroupMessage> groupManager;
   private final TransactionOrderPersistor orderedTransactions;
   private final StateManager stateManager;
   private final ManagedEntity platform;
@@ -62,7 +63,7 @@ public class ReplicatedTransactionHandler {
   private final SyncState state = new SyncState();
   
   public ReplicatedTransactionHandler(StateManager state, TransactionOrderPersistor transactionOrderPersistor, 
-      EntityManager manager, EntityPersistor entityPersistor, GroupManager groupManager) {
+      EntityManager manager, EntityPersistor entityPersistor, GroupManager<AbstractGroupMessage> groupManager) {
     this.stateManager = state;
     this.entityManager = manager;
     this.entityPersistor = entityPersistor;

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/EntityData.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/EntityData.java
@@ -20,6 +20,9 @@ package com.tc.objectserver.persistence;
 
 import java.io.Serializable;
 
+import org.terracotta.exception.EntityException;
+
+
 /**
  * The data required to persist an entity in persistent storage.  It is broken down into key and value components to allow
  * for bulk retrieval of all entity data (this is why key data may be redundantly stored in the value) as well as quick
@@ -60,5 +63,26 @@ public class EntityData {
     public long consumerID;
     public String entityName;
     public byte[] configuration;
+  }
+
+  public static enum Operation implements Serializable {
+    CREATE,
+    DESTROY,
+    RECONFIGURE,
+    DOES_EXIST,
+  }
+
+  public static class JournalEntry implements Serializable {
+    private static final long serialVersionUID = 1L;
+    
+    // This data is meant to be written into a transaction journal so we need to record everything related to the activity.
+    public Operation operation;
+    public long transactionID;
+    // reconfigureResponse is only used to store the result of RECONFIGURE.
+    public byte[] reconfigureResponse;
+    // didFind is only used to store the result of DOES_EXIST.
+    public boolean didFind;
+    // The exception in CREATE/DESTROY is saved here, null on success.
+    public EntityException failure;
   }
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/EntityData.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/EntityData.java
@@ -26,9 +26,14 @@ import java.io.Serializable;
  * simple lookup in a key-value mapping.
  */
 public class EntityData {
+  /**
+   * Empty constructor required due to the inner classes being Serializable.
+   */
   private EntityData() {}
-  
+
   public static class Key implements Serializable {
+    private static final long serialVersionUID = 1L;
+    
     public String className;
     public String entityName;
     
@@ -46,8 +51,10 @@ public class EntityData {
       return isEqual;
     }
   }
-  
+
   public static class Value implements Serializable {
+    private static final long serialVersionUID = 1L;
+    
     public String className;
     public long version;
     public long consumerID;

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/EntityPersistor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/EntityPersistor.java
@@ -16,7 +16,6 @@
  *  Terracotta, Inc., a Software AG company
  *
  */
-
 package com.tc.objectserver.persistence;
 
 import com.tc.object.EntityID;
@@ -25,6 +24,7 @@ import com.tc.util.Assert;
 import java.util.Collection;
 import org.terracotta.persistence.IPersistentStorage;
 import org.terracotta.persistence.KeyValueStorage;
+
 
 /**
  * Stores the information relating to the entities currently alive on the platform into persistent storage.
@@ -54,6 +54,7 @@ public class EntityPersistor {
     }
   }
 
+  @SuppressWarnings("deprecation")
   public Collection<EntityData.Value> loadEntityData() {
     return this.entities.values();
   }

--- a/dso-l2/src/test/java/com/tc/objectserver/persistence/EntityPersistorTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/persistence/EntityPersistorTest.java
@@ -1,0 +1,85 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.objectserver.persistence;
+
+import com.tc.object.EntityID;
+import com.tc.test.TCTestCase;
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.terracotta.exception.EntityException;
+
+
+public class EntityPersistorTest extends TCTestCase {
+  private static final String TEMP_FILE = "temp_file";
+  private FlatFilePersistentStorage persistentStorage;
+  private EntityPersistor entityPersistor;
+
+  @Override
+  public void setUp() {
+    try {
+      this.persistentStorage = new FlatFilePersistentStorage(getTempFile(TEMP_FILE));
+      this.persistentStorage.create();
+    } catch (IOException e) {
+      fail(e);
+    }
+    this.entityPersistor = new EntityPersistor(this.persistentStorage);
+  }
+
+  /**
+   * Test that an empty persistor correctly returns as empty for all calls and can be cleared.
+   */
+  public void testQueryEmpty() throws EntityException {
+    // This should be safe and do nothing.
+    this.entityPersistor.clear();
+    
+    // We expect to get an empty collection.
+    Assert.assertTrue(0 == this.entityPersistor.loadEntityData().size());
+    
+    // The entity shouldn't be found.
+    EntityID id = new EntityID("class name", "entity name");
+    Assert.assertFalse(this.entityPersistor.containsEntity(id));
+  }
+
+  /**
+   * Test that a basic create/destroy works and can then be queried.
+   */
+  public void testSimpleCreateDestroy() throws EntityException {
+    EntityID id = new EntityID("class name", "entity name");
+       
+    // Query that it doesn't exist.
+    Assert.assertFalse(this.entityPersistor.containsEntity(id));
+    
+    // Create the entity.
+    long version = 1;
+    long consumerID = 1;
+    byte[] configuration = new byte[0];
+    this.entityPersistor.entityCreated(id, version, consumerID, configuration);
+    
+    // Query that it exists.
+    Assert.assertTrue(this.entityPersistor.containsEntity(id));
+    
+    // Destroy the entity.
+    this.entityPersistor.entityDeleted(id);
+    
+    // Query that it doesn't exist.
+    Assert.assertFalse(this.entityPersistor.containsEntity(id));
+  }
+}

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
@@ -45,6 +45,7 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
 
   public enum ReplicationType {
     NOOP,
+    DOES_EXIST,
     CREATE_ENTITY,
     RECONFIGURE_ENTITY,
     INVOKE_ACTION,


### PR DESCRIPTION
The general contract the platform provides for its entities is that the same message may be seen more than once, but always in the same order, relative to the messages around it.  They are expected to be able to handle these re-sent message, however.

The platform wasn't honouring that, internally, for its own message types.  This meant that a re-sent create, for example, would fail on re-send, giving the client an inconsistent response.

This change resolves that by recording the recent entity life-cycle messages in an event journal, in the EntityPersistor, so that they can be short-circuited to reply with the same response they originally gave, if they exist in the journal.