### PR TITLE
Fix sync execution

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/AbstractServerEntityRequest.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/AbstractServerEntityRequest.java
@@ -151,18 +151,4 @@ public abstract class AbstractServerEntityRequest implements ServerEntityRequest
   protected boolean isDone() {
     return done;
   }  
-  
-  public synchronized void waitForDone() {
-    boolean interrupted = false;
-    while (!done) {
-      try {
-        wait();
-      } catch (InterruptedException ie) {
-        interrupted = true;
-      }
-    }
-    if (interrupted) {
-      Thread.currentThread().interrupt();
-    }
-  }
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -651,7 +651,6 @@ public class ManagedEntityImpl implements ManagedEntity {
         PassiveSyncServerEntityRequest req = new PassiveSyncServerEntityRequest(passive);
         // We don't actually use the message in the direct strategy so this is safe.
         executor.scheduleRequest(entityDescriptor, req, null, () -> invoke(req, null, concurrency), concurrency);
-        req.waitFor();
       }
   //  end passive sync for an entity
       executor.scheduleSync(PassiveSyncMessage.createEndEntityMessage(id, version), passive);
@@ -711,23 +710,6 @@ public class ManagedEntityImpl implements ManagedEntity {
     @Override
     public ClientDescriptor getSourceDescriptor() {
       return null;
-    }
-    
-    public synchronized void waitFor() {
-      try {
-        while (!isDone()) {
-          this.wait();
-        }
-      } catch (InterruptedException ie) {
-        //  TODO
-        throw new RuntimeException(ie);
-      }
-    }
-
-    @Override
-    public synchronized void complete() {
-      super.complete();
-      this.notifyAll();
     }
   }
   

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -128,7 +128,7 @@ public class ManagedEntityImpl implements ManagedEntity {
   @Override
   public void addInvokeRequest(final ServerEntityRequest request, byte[] payload, int defaultKey) {
     if (request.getAction() == ServerEntityAction.NOOP) {
-      scheduleInOrder(getEntityDescriptorForSource(request.getSourceDescriptor()), request, payload, ()->{logger.debug(runnables.queue.size());}, ConcurrencyStrategy.UNIVERSAL_KEY);
+      scheduleInOrder(getEntityDescriptorForSource(request.getSourceDescriptor()), request, payload, request::complete, ConcurrencyStrategy.UNIVERSAL_KEY);
       return;
     }
     Assert.assertTrue(request.getAction() == ServerEntityAction.INVOKE_ACTION);
@@ -501,8 +501,7 @@ public class ManagedEntityImpl implements ManagedEntity {
             for (NodeID passive : passives) {
               try {
                 byte[] message = runWithHelper(()->codec.serializeForSync(concurrencyKey, payload));
-                Future<Void> wait = executor.scheduleSync(PassiveSyncMessage.createPayloadMessage(id, version, concurrencyKey, message), passive);
-                wait.get();
+                executor.scheduleSync(PassiveSyncMessage.createPayloadMessage(id, version, concurrencyKey, message), passive).get();
               } catch (EntityUserException eu) {
               // TODO: do something reasoned here
                 throw new RuntimeException(eu);
@@ -519,7 +518,11 @@ public class ManagedEntityImpl implements ManagedEntity {
 //  start is handled by the sync request that triggered this action
         this.activeServerEntity.synchronizeKeyToPassive(syncChannel, concurrencyKey);
         for (NodeID passive : passives) {
-          executor.scheduleSync(PassiveSyncMessage.createEndEntityKeyMessage(id, version, concurrencyKey), passive);
+          try {
+            executor.scheduleSync(PassiveSyncMessage.createEndEntityKeyMessage(id, version, concurrencyKey), passive).get();
+          } catch (ExecutionException | InterruptedException e) {
+            throw new RuntimeException(e);
+          }
         }
         wrappedRequest.complete();
       }
@@ -636,24 +639,31 @@ public class ManagedEntityImpl implements ManagedEntity {
   @Override
   public void sync(NodeID passive) {
     if (!this.isDestroyed) {
-      executor.scheduleSync(PassiveSyncMessage.createStartEntityMessage(id, version, constructorInfo), passive);
-  // iterate through all the concurrency keys of an entity
-      EntityDescriptor entityDescriptor = new EntityDescriptor(this.id, ClientInstanceID.NULL_ID, this.version);
-  //  this is simply a barrier to make sure all actions are flushed before sync is started (hence, it has a null passive).
-      PassiveSyncServerEntityRequest barrier = new PassiveSyncServerEntityRequest(null);
-      executor.scheduleRequest(entityDescriptor, barrier, new byte[0], ()-> { 
-        assertNotNull(this.activeServerEntity);
-        assertNotNull(concurrencyStrategy);
-        barrier.complete(); 
-      }, ConcurrencyStrategy.MANAGEMENT_KEY);
-      barrier.waitFor();
-      for (Integer concurrency : concurrencyStrategy.getKeysForSynchronization()) {
-        PassiveSyncServerEntityRequest req = new PassiveSyncServerEntityRequest(passive);
-        // We don't actually use the message in the direct strategy so this is safe.
-        executor.scheduleRequest(entityDescriptor, req, null, () -> invoke(req, null, concurrency), concurrency);
+      try {
+    // wait for future is ok, occuring on sync executor thread
+        executor.scheduleSync(PassiveSyncMessage.createStartEntityMessage(id, version, constructorInfo), passive).get();
+    // iterate through all the concurrency keys of an entity
+        EntityDescriptor entityDescriptor = new EntityDescriptor(this.id, ClientInstanceID.NULL_ID, this.version);
+    //  this is simply a barrier to make sure all actions are flushed before sync is started (hence, it has a null passive).
+        PassiveSyncServerEntityRequest barrier = new PassiveSyncServerEntityRequest(null);
+    // wait for future is ok, occuring on sync executor thread
+        executor.scheduleRequest(entityDescriptor, barrier, new byte[0], ()-> { 
+          assertNotNull(this.activeServerEntity);
+          assertNotNull(concurrencyStrategy);
+          barrier.complete(); 
+        }, ConcurrencyStrategy.MANAGEMENT_KEY).get();
+
+        for (Integer concurrency : concurrencyStrategy.getKeysForSynchronization()) {
+          PassiveSyncServerEntityRequest req = new PassiveSyncServerEntityRequest(passive);
+          // We don't actually use the message in the direct strategy so this is safe.
+          executor.scheduleRequest(entityDescriptor, req, null, () -> invoke(req, null, concurrency), concurrency).get();
+        }
+    //  end passive sync for an entity
+    // wait for future is ok, occuring on sync executor thread
+        executor.scheduleSync(PassiveSyncMessage.createEndEntityMessage(id, version), passive).get();
+      } catch (ExecutionException | InterruptedException e) {
+        logger.warn("sync failed", e);
       }
-  //  end passive sync for an entity
-      executor.scheduleSync(PassiveSyncMessage.createEndEntityMessage(id, version), passive);
     }
   }  
 

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ActiveToPassiveReplicationTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ActiveToPassiveReplicationTest.java
@@ -1,0 +1,107 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.objectserver.entity;
+
+import com.tc.async.api.Sink;
+import com.tc.l2.msg.ReplicationEnvelope;
+import com.tc.l2.msg.ReplicationMessage;
+import com.tc.net.ServerID;
+import com.tc.net.groups.MessageID;
+import com.tc.objectserver.api.ManagedEntity;
+import com.tc.util.Assert;
+import java.util.Collections;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Matchers;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ *
+ * @author mscott
+ */
+public class ActiveToPassiveReplicationTest {
+  
+  ServerID passive;
+  private ActiveToPassiveReplication replication;
+  
+  
+  public ActiveToPassiveReplicationTest() {
+  }
+  
+  @BeforeClass
+  public static void setUpClass() {
+  }
+  
+  @AfterClass
+  public static void tearDownClass() {
+  }
+  
+  @Before
+  public void setUp() {
+    passive = mock(ServerID.class);
+    Iterable<ManagedEntity> entities = mock(Iterable.class);
+    Sink<ReplicationEnvelope> replicate = mock(Sink.class);
+    replication = new ActiveToPassiveReplication(Collections.singleton(passive), entities, replicate);
+  }
+  
+  @Test
+  public void testNodeLeft() throws Exception {
+    replication.enterActiveState();
+    replication.nodeJoined(passive);
+    ReplicationMessage msg = mock(ReplicationMessage.class);
+    MessageID id = new MessageID(1);
+    when(msg.getMessageID()).thenReturn(id);
+    ReplicationEnvelope env = mock(ReplicationEnvelope.class);
+    when(msg.target(Matchers.any(), Matchers.any())).thenReturn(env);
+    Future<Void> ack = replication.replicateMessage(msg, Collections.singleton(passive));
+    Thread target = Thread.currentThread();
+    Thread it = new Thread(()->{
+      try {
+        TimeUnit.MILLISECONDS.sleep(100);
+// remove the passive that is about to be waited on
+        replication.nodeLeft(passive);
+      } catch (InterruptedException i) {
+        
+      }
+    });
+    it.start();
+    try {
+      ack.get(1, TimeUnit.SECONDS);
+    } catch (InterruptedException ie) {
+      Assert.fail("test failed");
+    }
+    Assert.assertTrue(ack.isDone());
+  }
+  
+  @After
+  public void tearDown() {
+  }
+
+  // TODO add test methods here.
+  // The methods must be annotated with annotation @Test. For example:
+  //
+  // @Test
+  // public void hello() {}
+}

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
@@ -46,6 +46,7 @@ import com.tc.object.net.DSOChannelManager;
 import com.tc.object.tx.TransactionID;
 import com.tc.objectserver.api.EntityManager;
 import com.tc.objectserver.api.ManagedEntity;
+import com.tc.objectserver.api.ServerEntityRequest;
 import com.tc.objectserver.core.api.ITopologyEventCollector;
 import com.tc.objectserver.entity.ClientEntityStateManager;
 import com.tc.objectserver.entity.PlatformEntity;
@@ -61,6 +62,7 @@ import java.util.Queue;
 import java.util.Random;
 import org.junit.Test;
 import org.mockito.Matchers;
+import org.mockito.Mockito;
 import static org.mockito.Mockito.verify;
 
 
@@ -121,6 +123,10 @@ public class ReplicatedTransactionHandlerTest {
     when(msg.getEntityDescriptor()).thenReturn(descriptor);
     when(msg.getOldestTransactionOnClient()).thenReturn(TransactionID.NULL_ID);
     when(this.entityManager.getEntity(Matchers.any(), Matchers.anyInt())).thenReturn(Optional.of(entity));
+    Mockito.doAnswer(invocation->{
+      ((ServerEntityRequest)invocation.getArguments()[0]).complete(new byte[0]);
+      return null;
+    }).when(entity).addInvokeRequest(Matchers.any(), Matchers.any(), Matchers.eq(rand));
     this.loopbackSink.addSingleThreaded(msg);
     verify(entity).addInvokeRequest(Matchers.any(), Matchers.any(), Matchers.eq(rand));
     verify(groupManager).sendTo(Matchers.eq(sid), Matchers.any());


### PR DESCRIPTION
Fix issue #102. 

* Use futures to control flow after scheduling a request
* Control sync flow from the active rather than the passive by only sending the next message after completion of the previous sync message