### PR TITLE
Fix #104 - halt processing after a MessageCodecException

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -146,6 +146,8 @@ public class ManagedEntityImpl implements ManagedEntity {
         message = runWithHelper(()->codec.deserialize(payload));
       } catch (EntityUserException e) {
         request.failure(e);
+//  nothing more to do here, no message can be processed
+        return;
       }
       // If we are still ok and managed to deserialize the message, continue.
       if (null != message) {
@@ -158,7 +160,7 @@ public class ManagedEntityImpl implements ManagedEntity {
         final EntityMessage safeMessage = message;
         processInvokeRequest(request, payload, safeMessage, concurrencyKey);
       } else {
-        throw new RuntimeException("entity deserializer returned null while processing invoke request");
+        throw new RuntimeException("entity " + id + " deserializer returned null while processing invoke request");
       }
     }
   }

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
@@ -398,7 +398,6 @@ public class ManagedEntityImplTest {
     
   }
 
-  @Test (expected = RuntimeException.class)
   public void testCodecException() throws Exception {
     managedEntity.addLifecycleRequest(mockCreateEntityRequest(), null);
     managedEntity.addLifecycleRequest(mockPromoteToActiveRequest(), null);


### PR DESCRIPTION
The exception is returned to the client.  Halt processing on the server after exception.