### PR TITLE
Bug fixes 2

### DIFF
--- a/common/src/main/java/com/tc/async/impl/OrderedSink.java
+++ b/common/src/main/java/com/tc/async/impl/OrderedSink.java
@@ -62,7 +62,7 @@ public class OrderedSink<T extends OrderedEventContext> implements Sink<T> {
     long seq = oc.getSequenceID();
     if (seq == 0) {
       if (pending.isEmpty()) {
-        logger.warn("Sequence reset. Message with ID " + (current)
+        logger.debug("Sequence reset. Message with ID " + (current)
             + " was last before reset");
         current = 0;
         sink.addSingleThreaded(oc);

--- a/dso-l1/src/main/java/com/tc/object/ClientBuilder.java
+++ b/dso-l1/src/main/java/com/tc/object/ClientBuilder.java
@@ -19,6 +19,7 @@
 package com.tc.object;
 
 import com.tc.async.api.Sink;
+import com.tc.async.api.StageManager;
 import com.tc.util.ProductID;
 import com.tc.logging.ClientIDLogger;
 import com.tc.logging.TCLogger;
@@ -85,6 +86,6 @@ public interface ClientBuilder {
 
   LongGCLogger createLongGCLogger(long gcTimeOut);
 
-  ClientEntityManager createClientEntityManager(ClientMessageChannel channel);
+  ClientEntityManager createClientEntityManager(ClientMessageChannel channel, StageManager stages);
 
 }

--- a/dso-l1/src/main/java/com/tc/object/DistributedObjectClient.java
+++ b/dso-l1/src/main/java/com/tc/object/DistributedObjectClient.java
@@ -375,7 +375,7 @@ public class DistributedObjectClient implements TCClient {
 
     DSO_LOGGER.debug("Created channel.");
 
-    this.clientEntityManager = this.clientBuilder.createClientEntityManager(this.channel);
+    this.clientEntityManager = this.clientBuilder.createClientEntityManager(this.channel, this.communicationStageManager);
     RequestReceiveHandler receivingHandler = new RequestReceiveHandler(this.clientEntityManager);
     Stage<VoltronEntityResponse> entityResponseStage = this.communicationStageManager.createStage(ClientConfigurationContext.VOLTRON_ENTITY_RESPONSE_STAGE, VoltronEntityResponse.class, receivingHandler, 1, maxSize);
 

--- a/dso-l1/src/main/java/com/tc/object/DistributedObjectClientFactory.java
+++ b/dso-l1/src/main/java/com/tc/object/DistributedObjectClientFactory.java
@@ -79,7 +79,10 @@ public class DistributedObjectClientFactory {
 
                                                                    @Override
                                                                    public Void call() throws Exception {
-                                                                     clientRef.get().shutdown();
+                                                                     DistributedObjectClient client = clientRef.get();
+                                                                     if (client != null) {
+                                                                       client.shutdown();
+                                                                     }
                                                                      return null;
                                                                    }
                                                                  });

--- a/dso-l1/src/main/java/com/tc/object/StandardClientBuilder.java
+++ b/dso-l1/src/main/java/com/tc/object/StandardClientBuilder.java
@@ -19,6 +19,7 @@
 package com.tc.object;
 
 import com.tc.async.api.Sink;
+import com.tc.async.api.StageManager;
 import com.tc.util.ProductID;
 import com.tc.logging.ClientIDLogger;
 import com.tc.logging.TCLogger;
@@ -120,8 +121,8 @@ public class StandardClientBuilder implements ClientBuilder {
   }
 
   @Override
-  public ClientEntityManager createClientEntityManager(ClientMessageChannel channel) {
-    return new ClientEntityManagerImpl(channel);
+  public ClientEntityManager createClientEntityManager(ClientMessageChannel channel, StageManager stages) {
+    return new ClientEntityManagerImpl(channel, stages);
   }
 
 }

--- a/dso-l1/src/main/java/com/tc/object/request/RequestReceiveHandler.java
+++ b/dso-l1/src/main/java/com/tc/object/request/RequestReceiveHandler.java
@@ -38,21 +38,23 @@ public class RequestReceiveHandler extends AbstractEventHandler<VoltronEntityRes
   @Override
   public void handleEvent(VoltronEntityResponse response) throws EventHandlerException {
     TransactionID transactionID = response.getTransactionID();
-    switch (response.getAckType()) {
-      case APPLIED:
-        VoltronEntityAppliedResponse appliedResponse = (VoltronEntityAppliedResponse) response;
-        EntityException failureException = appliedResponse.getFailureException();
-        if (failureException != null) {
-          this.handler.failed(transactionID, failureException);
-        } else {
-          this.handler.complete(transactionID, appliedResponse.getSuccessValue());
-        }
-        break;
-      case RECEIVED:
-        this.handler.received(transactionID);
-        break;
-        default:
-          Assert.fail();
+    if (!transactionID.isNull()) {
+      switch (response.getAckType()) {
+        case APPLIED:
+          VoltronEntityAppliedResponse appliedResponse = (VoltronEntityAppliedResponse) response;
+          EntityException failureException = appliedResponse.getFailureException();
+          if (failureException != null) {
+            this.handler.failed(transactionID, failureException);
+          } else {
+            this.handler.complete(transactionID, appliedResponse.getSuccessValue());
+          }
+          break;
+        case RECEIVED:
+          this.handler.received(transactionID);
+          break;
+          default:
+            Assert.fail();
+      }
     }
   }
 }

--- a/dso-l1/src/test/java/com/tc/object/ClientEntityManagerTest.java
+++ b/dso-l1/src/test/java/com/tc/object/ClientEntityManagerTest.java
@@ -18,6 +18,7 @@
  */
 package com.tc.object;
 
+import com.tc.async.api.StageManager;
 import org.junit.Assert;
 import org.junit.Test;
 import org.terracotta.entity.EntityClientEndpoint;
@@ -60,6 +61,7 @@ import org.mockito.stubbing.Answer;
 public class ClientEntityManagerTest extends TestCase {
   private ClientMessageChannel channel;
   private ClientEntityManager manager;
+  private StageManager stageMgr;
   
   private EntityID entityID;
   private EntityDescriptor entityDescriptor;
@@ -67,12 +69,17 @@ public class ClientEntityManagerTest extends TestCase {
   @Override
   public void setUp() throws Exception {
     this.channel = mock(ClientMessageChannel.class);
-    this.manager = new ClientEntityManagerImpl(this.channel);
+    this.stageMgr = mock(StageManager.class);
+    this.manager = new ClientEntityManagerImpl(this.channel, stageMgr);
     
     String entityClassName = "Class Name";
     String entityInstanceName = "Instance Name";
     this.entityID = new EntityID(entityClassName, entityInstanceName);
     this.entityDescriptor = new EntityDescriptor(this.entityID, new ClientInstanceID(1), 1);
+  }
+  
+  public void testResponseSinkFlush() throws Exception {
+    
   }
 
   // Test that a simple lookup will succeed.

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ActiveToPassiveReplication.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ActiveToPassiveReplication.java
@@ -84,7 +84,6 @@ public class ActiveToPassiveReplication implements PassiveReplicationBroker, Gro
   private void primePassives() {
     passives.forEach(i -> {
       if (passiveNodes.add(i)) {
-        logger.debug("sending reset to " + i);
         prime(i);
       }
     });
@@ -93,6 +92,7 @@ public class ActiveToPassiveReplication implements PassiveReplicationBroker, Gro
  * prime the message channel to a node by setting the starting ordering id to zero.
  */
   private Future<Void> prime(NodeID node) {
+    logger.info("Starting message sequence on " + node);
     ReplicationMessage resetOrderedSink = new ReplicationMessage();
     return replicateMessage(resetOrderedSink, Collections.singleton(node));
   }
@@ -100,10 +100,9 @@ public class ActiveToPassiveReplication implements PassiveReplicationBroker, Gro
   public void startPassiveSync(NodeID newNode) {
     Assert.assertTrue(activated);
     if (passiveNodes.add(newNode)) {
-      logger.debug("sending reset to " + newNode);
       prime(newNode);
     }
-    logger.debug("starting sync to " + newNode);
+    logger.info("Starting sync to " + newNode);
     executePassiveSync(newNode);
   }
   /**

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -88,10 +88,10 @@ public class ReplicatedTransactionHandler {
     public void handleEvent(ReplicationMessage message) throws EventHandlerException {
       try {
         processMessage(message);
-      } catch (EntityException e) {
+      } catch (Throwable t) {
         // We don't expect to see an exception executing a replicated message.
         // TODO:  Find a better way to handle this error.
-        throw Assert.failure("Unexpected exception executing replicated message", e);
+        throw Assert.failure("Unexpected exception executing replicated message", t);
       }
     }
 
@@ -205,6 +205,7 @@ public class ReplicatedTransactionHandler {
   private void requestPassiveSync() {
     NodeID node = stateManager.getActiveNodeID();
     try {
+      LOGGER.info("Requesting Passive Sync from " + node);
       groupManager.sendTo(node, new ReplicationMessageAck(ReplicationMessage.START));
     } catch (GroupException ge) {
       LOGGER.warn("can't request passive sync", ge);

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ChannelLifeCycleHandlerTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ChannelLifeCycleHandlerTest.java
@@ -52,7 +52,7 @@ public class ChannelLifeCycleHandlerTest {
     DSOChannelManager channelManager = mock(DSOChannelManager.class);
     HaConfig haConfig = mock(HaConfig.class);
     this.eventCollector = mock(ITopologyEventCollector.class);
-    this.handler = new ChannelLifeCycleHandler(commsManager, channelManager, haConfig, this.eventCollector);
+    this.handler = new ChannelLifeCycleHandler(commsManager, channelManager, haConfig);
     ServerConfigurationContext context = mock(ServerConfigurationContext.class);
     Stage<HydrateContext> stage = mock(Stage.class);
     when(stage.getSink()).thenReturn(mock(Sink.class));
@@ -76,6 +76,7 @@ public class ChannelLifeCycleHandlerTest {
     when(fakeChannel.getLocalAddress()).thenReturn(null);
     this.handler.channelRemoved(fakeChannel);
     // We expect NOT to receive the disconnect event in the event collector.
+    //  this test is no longer relevant but leave it as harmless
     verify(this.eventCollector, never()).clientDidDisconnect(any(MessageChannel.class), any(ClientID.class));
   }
 }


### PR DESCRIPTION
Logging changes

Flush the voltron response sink before sending resends.  If the response Sink is not flushed, a double remove can result.

Channel events should only be observed by the topology collector on the active.