### PR TITLE
Fix #5 - Follow up changes for Service API change

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/FlatFilePersistentStorage.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/FlatFilePersistentStorage.java
@@ -171,6 +171,6 @@ public class FlatFilePersistentStorage implements IPersistentStorage {
       }
     };
   }
-  
-  
+
+
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/NullPlatformStorageServiceProvider.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/NullPlatformStorageServiceProvider.java
@@ -3,6 +3,7 @@ package com.tc.objectserver.persistence;
 import org.terracotta.entity.ServiceConfiguration;
 import org.terracotta.entity.ServiceProvider;
 import org.terracotta.entity.ServiceProviderConfiguration;
+import org.terracotta.entity.ServiceProviderCleanupException;
 import org.terracotta.persistence.IPersistentStorage;
 
 import java.io.IOException;
@@ -36,6 +37,11 @@ public class NullPlatformStorageServiceProvider implements ServiceProvider {
 
     @Override
     public void close() throws IOException {
+        providers.clear();
+    }
+
+    @Override
+    public void clear() throws ServiceProviderCleanupException {
         providers.clear();
     }
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/Persistor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/Persistor.java
@@ -31,6 +31,7 @@ import org.terracotta.persistence.IPersistentStorage;
  */
 public class Persistor implements PrettyPrintable {
   private final IPersistentStorage persistentStorage;
+  private boolean wasDBClean;
 
   private volatile boolean started = false;
 
@@ -64,15 +65,7 @@ public class Persistor implements PrettyPrintable {
   public void start() {
     sequenceManager = new SequenceManager(persistentStorage);
     clientStatePersistor = new ClientStatePersistor(sequenceManager, persistentStorage);
-
-    if (!this.clusterStatePersistor.isDBClean()) {
-      this.clusterStatePersistor.clear();
-      this.entityPersistor.clear();
-      this.transactionOrderPersistor.clearAllRecords();
-      this.sequenceManager.clear();
-      this.clientStatePersistor.clear();
-    }
-    
+    wasDBClean = this.clusterStatePersistor.isDBClean();
     started = true;
   }
 
@@ -106,6 +99,10 @@ public class Persistor implements PrettyPrintable {
     if (!started) {
       throw new IllegalStateException("Persistor is not yet started.");
     }
+  }
+
+  public boolean wasDBClean() {
+    return wasDBClean;
   }
 
   @Override

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/TestClusterStatePersistor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/TestClusterStatePersistor.java
@@ -77,7 +77,7 @@ public class TestClusterStatePersistor extends ClusterStatePersistor {
       public <K, V> KeyValueStorage<K, V> destroyKeyValueStorage(String alias) {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
       }
-      
+
     });
   }
 

--- a/dso-l2/src/main/java/com/tc/services/BuiltInServiceProvider.java
+++ b/dso-l2/src/main/java/com/tc/services/BuiltInServiceProvider.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import org.terracotta.entity.ServiceConfiguration;
 
 import com.tc.objectserver.api.ManagedEntity;
+import org.terracotta.entity.ServiceProviderCleanupException;
 
 
 /**
@@ -55,4 +56,16 @@ public interface BuiltInServiceProvider extends Closeable {
    * @return A collection of the types of services which can be returned by the receiver.
    */
   Collection<Class<?>> getProvidedServiceTypes();
+
+  /**
+   * Clears up state for this ServiceProvider including any persisted state
+   *
+   * Generally platform calls this method during platform initialization so there won't be any entities using
+   * underlying services
+   *
+   * If there are any failures when clearing state, this method should inform Platform by throwing {@link ServiceProviderCleanupException}
+   *
+   * @throws ServiceProviderCleanupException if there are any failures
+   */
+  void clear() throws ServiceProviderCleanupException;
 }

--- a/dso-l2/src/main/java/com/tc/services/CommunicatorService.java
+++ b/dso-l2/src/main/java/com/tc/services/CommunicatorService.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.terracotta.entity.ClientCommunicator;
 import org.terracotta.entity.ServiceConfiguration;
+import org.terracotta.entity.ServiceProviderCleanupException;
 
 
 class ResponseWaiter implements Future<Void> {
@@ -124,5 +125,10 @@ public class CommunicatorService implements BuiltInServiceProvider, DSOChannelMa
   public void close() {
     clientAccounts.values().stream().forEach(a->a.close());
     clientAccounts.clear();
+  }
+
+  @Override
+  public void clear() throws ServiceProviderCleanupException {
+    // nothing to do
   }
 }

--- a/dso-l2/src/main/java/com/tc/services/TerracottaServiceProviderRegistry.java
+++ b/dso-l2/src/main/java/com/tc/services/TerracottaServiceProviderRegistry.java
@@ -21,6 +21,7 @@ package com.tc.services;
 import org.terracotta.config.TcConfiguration;
 import org.terracotta.entity.ServiceProvider;
 import org.terracotta.entity.ServiceConfiguration;
+import org.terracotta.entity.ServiceProviderCleanupException;
 
 
 /**
@@ -73,4 +74,6 @@ public interface TerracottaServiceProviderRegistry {
    * @return instance of service
    */
   <T> T getService(long consumerId, ServiceConfiguration<T> config);
+
+  void clearServiceProvidersState();
 }

--- a/dso-l2/src/main/java/com/tc/services/TerracottaServiceProviderRegistryImpl.java
+++ b/dso-l2/src/main/java/com/tc/services/TerracottaServiceProviderRegistryImpl.java
@@ -20,6 +20,7 @@ package com.tc.services;
 
 import org.terracotta.config.TcConfiguration;
 import org.terracotta.entity.ServiceProvider;
+import org.terracotta.entity.ServiceProviderCleanupException;
 import org.terracotta.entity.ServiceProviderConfiguration;
 
 import com.tc.logging.TCLogger;
@@ -27,7 +28,6 @@ import com.tc.logging.TCLogging;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.ServiceLoader;
 import java.util.Set;
 import org.terracotta.entity.ServiceConfiguration;
 
@@ -85,6 +85,25 @@ public class TerracottaServiceProviderRegistryImpl implements TerracottaServiceP
         }
     }
     return null;
+  }
+
+  @Override
+  public void clearServiceProvidersState() {
+    for(ServiceProvider serviceProvider : serviceProviders) {
+      try {
+        serviceProvider.clear();
+      } catch (ServiceProviderCleanupException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    for(BuiltInServiceProvider builtInServiceProvider : builtInServiceProviders) {
+      try {
+        builtInServiceProvider.clear();
+      } catch (ServiceProviderCleanupException e) {
+        throw new RuntimeException(e);
+      }
+    }
   }
 
   private void registerNewServiceProvider(ServiceProvider service) {

--- a/dso-l2/src/test/java/com/tc/server/TestServiceProvider.java
+++ b/dso-l2/src/test/java/com/tc/server/TestServiceProvider.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import org.terracotta.entity.ServiceConfiguration;
 import org.terracotta.entity.ServiceProvider;
 import org.terracotta.entity.ServiceProviderConfiguration;
+import org.terracotta.entity.ServiceProviderCleanupException;
 
 /**
  *
@@ -49,6 +50,11 @@ public class TestServiceProvider implements ServiceProvider {
   @Override
   public void close() throws IOException {
 
+  }
+
+  @Override
+  public void clear() throws ServiceProviderCleanupException {
+    // nothing to do
   }
   
 }


### PR DESCRIPTION
Implement clear() method for all ServiceProvider and IPersistentStorage implementations
Clear all Services state if dirty db is set