### PR TITLE
Fix Destroy corner cases

### DIFF
--- a/connection-impl/src/main/java/com/terracotta/connection/entity/TerracottaEntityRef.java
+++ b/connection-impl/src/main/java/com/terracotta/connection/entity/TerracottaEntityRef.java
@@ -79,7 +79,7 @@ public class TerracottaEntityRef<T extends Entity, C> implements EntityRef<T, C>
         maintenanceModeService.readUnlockEntity(type, name);
       }
     };
-    
+        
     EntityClientEndpoint endpoint = null;
     try {
       ClientInstanceID clientInstanceID = new ClientInstanceID(this.nextClientInstanceID.getAndIncrement());

--- a/dso-l1/src/main/java/com/tc/object/ClientEntityManager.java
+++ b/dso-l1/src/main/java/com/tc/object/ClientEntityManager.java
@@ -57,13 +57,6 @@ public interface ClientEntityManager extends PrettyPrintable, RequestResponseHan
   public EntityClientEndpoint fetchEntity(EntityDescriptor entityDescriptor, Runnable closeHook) throws EntityException;
 
   /**
-   * Release the client's reference to the given entityID.
-   * 
-   * @param entityDescriptor the entity to release and the instance making the request.
-   */
-  void releaseEntity(EntityDescriptor entityDescriptor) throws EntityException;
-
-  /**
    * Handles a message received from the server. It will hand off the message to the client side entity if it exists.
    * otherwise it'll drop the message on the floor.
    *
@@ -83,9 +76,4 @@ public interface ClientEntityManager extends PrettyPrintable, RequestResponseHan
    * the side-effect of adding a reference to this server-side entity, from this client.
    */
   byte[] retrieve(EntityDescriptor entityDescriptor) throws EntityException;
-
-  /**
-   * This method is the opposite of "retrieve()":  ask the implementation to tell the remote side we no longer want the entity.
-   */
-  void release(EntityDescriptor entityDescriptor) throws EntityException;
 }

--- a/dso-l1/src/main/java/com/tc/object/ClientEntityManager.java
+++ b/dso-l1/src/main/java/com/tc/object/ClientEntityManager.java
@@ -75,5 +75,5 @@ public interface ClientEntityManager extends PrettyPrintable, RequestResponseHan
    * Called to retrieve the entityDescriptor, returning its instance configuration, if found.  Note that this call will have
    * the side-effect of adding a reference to this server-side entity, from this client.
    */
-  byte[] retrieve(EntityDescriptor entityDescriptor) throws EntityException;
+//  byte[] retrieve(EntityDescriptor entityDescriptor) throws EntityException;
 }

--- a/dso-l1/src/test/java/com/tc/object/ClientEntityManagerTest.java
+++ b/dso-l1/src/test/java/com/tc/object/ClientEntityManagerTest.java
@@ -178,9 +178,6 @@ public class ClientEntityManagerTest extends TestCase {
     
     // We expect that we found the entity.
     assertTrue(didFindEndpoint(fetcher));
-    
-    // Now, release it.
-    fetcher.close();
   }
 
   // Test fetch+release on failure.

--- a/dso-l1/src/test/java/com/tc/object/ClientEntityManagerTest.java
+++ b/dso-l1/src/test/java/com/tc/object/ClientEntityManagerTest.java
@@ -180,7 +180,7 @@ public class ClientEntityManagerTest extends TestCase {
     assertTrue(didFindEndpoint(fetcher));
     
     // Now, release it.
-    this.manager.releaseEntity(entityDescriptor);
+    fetcher.close();
   }
 
   // Test fetch+release on failure.
@@ -208,9 +208,9 @@ public class ClientEntityManagerTest extends TestCase {
     // Now, release it and expect to see the exception thrown, directly (since we are accessing the manager, directly).
     boolean didRelease = false;
     try {
-      this.manager.releaseEntity(entityDescriptor);
+      fetcher.close();
       didRelease = true;
-    } catch (EntityException e) {
+    } catch (RuntimeException e) {
       // Expected.
       didRelease = false;
     }
@@ -411,6 +411,10 @@ public class ClientEntityManagerTest extends TestCase {
         throw this.exception;
       }
       return this.result;
+    }
+    
+    public void close() {
+      result.close();
     }
   }
   

--- a/dso-l2/src/main/java/com/tc/l2/handler/L2StateChangeHandler.java
+++ b/dso-l2/src/main/java/com/tc/l2/handler/L2StateChangeHandler.java
@@ -23,8 +23,10 @@ import com.tc.async.api.ConfigurationContext;
 import com.tc.async.impl.StageController;
 import com.tc.l2.context.StateChangedEvent;
 import com.tc.l2.state.StateManager;
+import com.tc.net.ServerID;
 import com.tc.objectserver.core.api.ITopologyEventCollector;
 import com.tc.objectserver.core.api.ServerConfigurationContext;
+import com.tc.server.TCServerMain;
 import com.tc.util.State;
 
 
@@ -34,10 +36,12 @@ public class L2StateChangeHandler extends AbstractEventHandler<StateChangedEvent
   private final StageController stageManager;
   private ConfigurationContext context;
   private final ITopologyEventCollector eventCollector;
+  private final ServerID serverID;
 
-  public L2StateChangeHandler(StageController stageManager, ITopologyEventCollector eventCollector) {
+  public L2StateChangeHandler(ServerID myID, StageController stageManager, ITopologyEventCollector eventCollector) {
     this.stageManager = stageManager;
     this.eventCollector = eventCollector;
+    this.serverID = myID;
   }
 
   @Override
@@ -50,7 +54,7 @@ public class L2StateChangeHandler extends AbstractEventHandler<StateChangedEvent
     stateManager.fireStateChangedEvent(sce);
     // Now that we have processed the event, the last thing we want to do is notify the collector that the server's state
     // has changed.
-    eventCollector.serverDidEnterState(newState);
+    eventCollector.serverDidEnterState(this.serverID, newState, TCServerMain.getServer().getActivateTime());
   }
 
   @Override

--- a/dso-l2/src/main/java/com/tc/l2/handler/PlatformInfoRequestHandler.java
+++ b/dso-l2/src/main/java/com/tc/l2/handler/PlatformInfoRequestHandler.java
@@ -1,0 +1,109 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.l2.handler;
+
+import com.tc.async.api.AbstractEventHandler;
+import com.tc.async.api.EventHandler;
+import com.tc.async.api.EventHandlerException;
+import com.tc.config.schema.setup.ConfigurationSetupException;
+import com.tc.l2.msg.PlatformInfoRequest;
+import com.tc.net.NodeID;
+import com.tc.net.ServerID;
+import com.tc.net.TCSocketAddress;
+import com.tc.net.groups.AbstractGroupMessage;
+import com.tc.net.groups.GroupException;
+import com.tc.net.groups.GroupManager;
+import com.tc.net.groups.MessageID;
+import com.tc.object.config.schema.L2Config;
+import com.tc.objectserver.core.api.ITopologyEventCollector;
+import com.tc.server.TCServerMain;
+import com.tc.util.ProductInfo;
+import com.tc.util.State;
+
+
+public class PlatformInfoRequestHandler {
+  
+  private final GroupManager<AbstractGroupMessage> groupManager;
+  private final ITopologyEventCollector remoteEvents;
+
+  public PlatformInfoRequestHandler(GroupManager<AbstractGroupMessage> groupManager, ITopologyEventCollector remoteEvents) {
+    this.groupManager = groupManager;
+    this.remoteEvents = remoteEvents;
+  }
+  
+  public EventHandler<PlatformInfoRequest> getEventHandler() {
+    return new AbstractEventHandler<PlatformInfoRequest>() {
+      @Override
+      public void handleEvent(PlatformInfoRequest context) throws EventHandlerException {
+        try {
+          switch (context.getType()) {
+            case PlatformInfoRequest.REQUEST:
+              handleRequestEvent(context);
+              break;
+            case PlatformInfoRequest.SERVER_INFO:
+              handleServerInfo(context);
+              break;
+            case PlatformInfoRequest.SERVER_STATE:
+              handleServerState(context);
+              break;
+            default:
+              break;
+          }
+        } catch (GroupException g) {
+// Ignore
+        }
+      }
+    };
+  }
+  
+  private void handleRequestEvent(PlatformInfoRequest context) throws GroupException {
+    switch(context.getRequestType()) {
+      case SERVER_INFO:
+        collectAndSendServerInfo(context.messageFrom(), context.getMessageID());
+        break;
+      default:
+    }
+  }
+  
+  private void handleServerInfo(PlatformInfoRequest msg) throws GroupException {
+    try {
+      L2Config config = TCServerMain.getSetupManager().dsoL2ConfigFor(msg.getName());
+      String bindAddress = config.tsaPort().getBind();
+      if (bindAddress == null) {
+        // workaround for CDV-584
+        bindAddress = TCSocketAddress.WILDCARD_IP;
+      }
+      remoteEvents.serverDidJoinGroup((ServerID)msg.messageFrom(), msg.getName(), config.host(), bindAddress, 
+          config.tsaPort().getValue(), config.tsaGroupPort().getValue(), msg.getVersion(), msg.getBuild());
+    } catch (ConfigurationSetupException set) {
+
+    }
+  }  
+  
+  private void handleServerState(PlatformInfoRequest msg) throws GroupException {
+    remoteEvents.serverDidEnterState((ServerID)msg.messageFrom(), new State(msg.getState()), msg.getActivateTime());
+  }  
+  
+  private void collectAndSendServerInfo(NodeID dest, MessageID msg) throws GroupException {
+    String name = TCServerMain.getServer().getL2Identifier();
+    String version = ProductInfo.getInstance().version();
+    String build = ProductInfo.getInstance().buildID();
+    groupManager.sendTo(dest, new PlatformInfoRequest(name, version, build, TCServerMain.getServer().getStartTime(), msg));
+  }
+}

--- a/dso-l2/src/main/java/com/tc/objectserver/core/api/ITopologyEventCollector.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/core/api/ITopologyEventCollector.java
@@ -19,6 +19,8 @@
 package com.tc.objectserver.core.api;
 
 import com.tc.net.ClientID;
+import com.tc.net.NodeID;
+import com.tc.net.ServerID;
 import com.tc.net.protocol.tcm.MessageChannel;
 import com.tc.object.EntityID;
 import com.tc.util.State;
@@ -30,11 +32,28 @@ import com.tc.util.State;
  */
 public interface ITopologyEventCollector {
   /**
+   * Called when the server first joins the group
+   * 
+   * @param node  - The nodeid of the server
+   * @param serverName  - The name of the server in the config
+   * @param host - user supplied hostname
+   * @param bindAddress - The address to which this server listens for connections
+   * @param bindPort - The port that is bound to this connection 0 for active, remote port for passive
+   */
+  public void serverDidJoinGroup(ServerID node, String serverName, String host, String bindAddress, int bindPort, int groupPort, String version, String build);
+  /**
+   * Called when the server first joins the group
+   * 
+   * @param node  - The nodeid of server
+   */
+  public void serverDidLeaveGroup(ServerID node);
+  /**
    * Called when the server first enters the given state.
    * 
+   * @param node node id of the server changing state
    * @param state The new server state now set.
    */
-  public void serverDidEnterState(State state);
+  public void serverDidEnterState(NodeID node, State state, long activateTime);
 
   /**
    * Called when a client connects for the first time.  Note that this won't be called if the connection is deemed to be a

--- a/dso-l2/src/main/java/com/tc/objectserver/core/api/ServerConfigurationContext.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/core/api/ServerConfigurationContext.java
@@ -78,6 +78,9 @@ public interface ServerConfigurationContext extends ConfigurationContext {
   public static final String PASSIVE_REPLICATION_STAGE                            = "passive_replication_stage";
   public static final String PASSIVE_REPLICATION_ACK_STAGE                            = "passive_replication_ack_stage";
   
+  public static final String PLATFORM_INFORMATION_REQUEST                       = "platform_information_request";
+  public static final String PLATFORM_INFORMATION_RESPONSE                      = "platform_information_response";
+  
   // TODO::Move to enterprise
   public static final String AA_TRANSACTION_WATERMARK_BROADCAST_STAGE           = "aa_transaction_watermark_broadcast_stage";
   public static final String AA_TRANSACTION_WATERMARK_RECEIVE_STAGE             = "aa_transaction_watermark_receive_stage";

--- a/dso-l2/src/main/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollector.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollector.java
@@ -95,7 +95,7 @@ public class ManagementTopologyEventCollector implements ITopologyEventCollector
     this.servers.put(node, server);
     LOGGER.debug("adding NODE:" + Arrays.toString(makeServerPath(node)) + " NAME:" + PlatformMonitoringConstants.INSTANCE_NODE_NAME + " VALUE:" + server);
     if (null != this.serviceInterface) {
-      this.serviceInterface.addNode(PlatformMonitoringConstants.GROUP_PATH, node.toString(), null);
+      this.serviceInterface.addNode(PlatformMonitoringConstants.GROUP_PATH, node.toString(), server);
       this.serviceInterface.addNode(makeServerPath(node), PlatformMonitoringConstants.INSTANCE_NODE_NAME, server);
     }
   }
@@ -120,6 +120,7 @@ public class ManagementTopologyEventCollector implements ITopologyEventCollector
     LOGGER.debug("state NODE:" + node + " entering state " + stateValue);
     // Set this in the monitoring interface.
     if (null != this.serviceInterface) {
+      this.serviceInterface.addNode(PlatformMonitoringConstants.GROUP_PATH, node.toString(), null);
       this.serviceInterface.removeNode(makeServerPath(node), PlatformMonitoringConstants.STATE_NODE_NAME);
       this.serviceInterface.addNode(makeServerPath(node), PlatformMonitoringConstants.STATE_NODE_NAME, new ServerState(stateValue, activateTime));
     }

--- a/dso-l2/src/test/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollectorTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollectorTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import com.tc.l2.state.StateManager;
 import com.tc.net.ClientID;
+import com.tc.net.ServerID;
 import com.tc.net.protocol.tcm.MessageChannel;
 import com.tc.object.EntityID;
 
@@ -32,10 +33,12 @@ import static org.mockito.Mockito.mock;
 
 public class ManagementTopologyEventCollectorTest {
   private ManagementTopologyEventCollector collector;
+  private ServerID selfID;
 
   @Before
   public void setUp() throws Exception {
-    this.collector = new ManagementTopologyEventCollector(null);
+    this.selfID = mock(ServerID.class);
+    this.collector = new ManagementTopologyEventCollector(selfID, null);
   }
 
   @Test
@@ -102,7 +105,7 @@ public class ManagementTopologyEventCollectorTest {
     Assert.assertFalse(didSucceed);
     
     // Now, change state of the server to active.
-    this.collector.serverDidEnterState(StateManager.ACTIVE_COORDINATOR);
+    this.collector.serverDidEnterState(selfID, StateManager.ACTIVE_COORDINATOR, System.currentTimeMillis());
     isActive = true;
     
     // Promote the entity to active.
@@ -129,7 +132,7 @@ public class ManagementTopologyEventCollectorTest {
     ClientID client = mock(ClientID.class);
     
     // Put us into the active state.
-    this.collector.serverDidEnterState(StateManager.ACTIVE_COORDINATOR);
+    this.collector.serverDidEnterState(selfID, StateManager.ACTIVE_COORDINATOR, System.currentTimeMillis());
     boolean isActive = true;
     
     // Create the entity.

--- a/tc-messaging/src/main/java/com/tc/l2/msg/PlatformInfoRequest.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/PlatformInfoRequest.java
@@ -1,0 +1,142 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.l2.msg;
+
+import com.tc.io.TCByteBufferInput;
+import com.tc.io.TCByteBufferOutput;
+import com.tc.net.groups.AbstractGroupMessage;
+import com.tc.net.groups.MessageID;
+import java.io.IOException;
+
+/**
+ *
+ */
+public class PlatformInfoRequest extends AbstractGroupMessage {
+//  message types  
+  public static final int REQUEST               = 0; 
+  public static final int SERVER_INFO               = 1; 
+  public static final int SERVER_STATE               = 2; 
+  
+  private RequestType requestType;
+  
+  private String name;
+  private String version;
+  private String build;
+  
+  private String state;
+    
+  private long startTime;
+  private long activateTime;
+  
+  public enum RequestType {
+    SERVER_INFO;
+  }
+
+  public PlatformInfoRequest() {
+    this(REQUEST);
+  }
+  
+  public PlatformInfoRequest(int type) {
+    super(type);
+  }
+  
+  public PlatformInfoRequest(String state, long activate) {
+    this(SERVER_STATE);
+    this.state = state;
+    this.activateTime = activate;
+  }  
+  
+  public PlatformInfoRequest(String name, String version, String buildid, long startTime, MessageID requestID) {
+    this(SERVER_INFO, requestID);
+    this.name = name;
+    this.build = buildid;
+    this.version = version;
+    this.startTime = startTime;
+  }
+
+  private PlatformInfoRequest(int type, MessageID requestID) {
+    super(type, requestID);
+  }
+  
+  public void setRequestType(RequestType type) {
+    requestType = type;
+  }
+
+  public RequestType getRequestType() {
+    return requestType;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public String getBuild() {
+    return build;
+  }
+  
+  public String getName() {
+    return name;
+  }
+
+  public String getState() {
+    return state;
+  }
+
+  public long getStartTime() {
+    return startTime;
+  }
+
+  public long getActivateTime() {
+    return activateTime;
+  }
+
+  @Override
+  protected void basicDeserializeFrom(TCByteBufferInput in) throws IOException {
+    if (getType() == REQUEST) {
+      requestType = RequestType.values()[in.readInt()];
+    } else if (getType() == SERVER_INFO) {
+      this.name = in.readString();
+      this.version = in.readString();
+      this.build = in.readString();
+      this.startTime = in.readLong();
+    } else if (getType() == SERVER_STATE) {
+      this.state = in.readString();
+      this.activateTime = in.readLong();
+    }
+  }
+
+  @Override
+  protected void basicSerializeTo(TCByteBufferOutput out) {
+    if (getType() == REQUEST) {
+      if (requestType != null) {
+        out.writeInt(requestType.ordinal());
+      } else {
+        out.writeInt(-1);
+      }
+    } else if (getType() == SERVER_INFO) {
+      out.writeString(name);
+      out.writeString(version);
+      out.writeString(build);
+      out.writeLong(startTime);
+    } else if (getType() == SERVER_STATE) {
+      out.writeString(state);
+      out.writeLong(activateTime);
+    }
+  }
+}


### PR DESCRIPTION
Destroy during sync and handshake pose problems because they can leave a client or passive in an inconsistent state if the entity disappears during an operation.  Fix these cases by special handling and and checking for the destroy case.