### PR TITLE
Fix #137 - cleanup tc properties

### DIFF
--- a/common/src/main/java/com/tc/net/core/SocketParams.java
+++ b/common/src/main/java/com/tc/net/core/SocketParams.java
@@ -22,6 +22,7 @@ import com.tc.logging.TCLogger;
 import com.tc.logging.TCLogging;
 import com.tc.properties.TCProperties;
 import com.tc.properties.TCPropertiesImpl;
+import com.tc.properties.TCPropertiesConsts;
 
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -33,7 +34,6 @@ import java.net.SocketException;
 class SocketParams {
   private static final TCLogger logger       = TCLogging.getLogger(SocketParams.class);
 
-  private static final String   PREFIX       = "net.core";
   private static final String   RECV_BUFFER  = "recv.buffer";
   private static final String   SEND_BUFFER  = "send.buffer";
   private static final String   TCP_NO_DELAY = "tcpnodelay";
@@ -45,7 +45,7 @@ class SocketParams {
   private final boolean         keepAlive;
 
   SocketParams() {
-    TCProperties props = TCPropertiesImpl.getProperties().getPropertiesFor(PREFIX);
+    TCProperties props = TCPropertiesImpl.getProperties().getPropertiesFor(TCPropertiesConsts.NETCORE_CATEGORY);
 
     this.recvBuffer = props.getInt(RECV_BUFFER, -1);
     this.sendBuffer = props.getInt(SEND_BUFFER, -1);

--- a/common/src/main/java/com/tc/properties/TCPropertiesConsts.java
+++ b/common/src/main/java/com/tc/properties/TCPropertiesConsts.java
@@ -47,6 +47,8 @@ public interface TCPropertiesConsts {
    ********************************************************************************************************************/
   public static final String ENTITY_PROCESSOR_THREADS                                    = "server.entity.processor.threads";
   public static final String L2_SEDA_STAGE_SINK_CAPACITY                                    = "l2.seda.stage.sink.capacity";
+  String L2_TCCOM_WORKERTHREADS                                                          = "l2.tccom.workerthreads";
+  String L2_SEDA_STAGE_WORKERTHREADS                                                     = "l2.seda.stage.workerthreads";
 
   /*********************************************************************************************************************
    * <code>
@@ -391,5 +393,20 @@ public interface TCPropertiesConsts {
    * </code>
    ********************************************************************************************************************/
   public static final String VERSION_COMPATIBILITY_CHECK                                    = "version.compatibility.check";
+
+  /*********************************************************************************************************************
+   * <code>
+   * Section :  Some useful subcategories
+   * </code>
+   ********************************************************************************************************************/
+
+  public static final String  L1_CATEGORY                                                   = "L1";
+  public static final String  L2_CATEGORY                                                   = "L2";
+  public static final String  L1_L2_HEALTH_CHECK_CATEGORY                                   = "l1.healthcheck.l2";
+  public static final String  L2_L1_HEALTH_CHECK_CATEGORY                                   = "l2.healthcheck.l1";
+  public static final String  L2_L2_HEALTH_CHECK_CATEGORY                                   = "l2.healthcheck.l2";
+  public static final String  L1_LOCK_MANAGER_CATEGORY                                      = "l1.lockmanager";
+  public static final String  LOGGING_CATEGORY                                              = "logging";
+  public static final String  NETCORE_CATEGORY                                              = "net.core";
 
 }

--- a/common/src/test/java/com/tc/net/core/NoReconnectThreadTest.java
+++ b/common/src/test/java/com/tc/net/core/NoReconnectThreadTest.java
@@ -52,6 +52,7 @@ import com.tc.test.TCTestCase;
 import com.tc.util.PortChooser;
 import com.tc.util.concurrent.ThreadUtil;
 import com.tc.util.runtime.ThreadDumpUtil;
+import com.tc.properties.TCPropertiesConsts;
 
 import java.net.InetAddress;
 import java.util.Collections;
@@ -113,7 +114,7 @@ public class NoReconnectThreadTest extends TCTestCase implements ChannelEventLis
                                                                          new NullConnectionPolicy(), 3,
                                                                          new HealthCheckerConfigImpl(TCPropertiesImpl
                                                                              .getProperties()
-                                                                             .getPropertiesFor("l2.healthcheck.l2"),
+                                                                             .getPropertiesFor(TCPropertiesConsts.L2_L2_HEALTH_CHECK_CATEGORY),
                                                                                                      "Test Server"),
                                                                          new ServerID(),
                                                                          new TransportHandshakeErrorNullHandler(),
@@ -175,7 +176,7 @@ public class NoReconnectThreadTest extends TCTestCase implements ChannelEventLis
                                                                          new NullConnectionPolicy(), 3,
                                                                          new HealthCheckerConfigImpl(TCPropertiesImpl
                                                                              .getProperties()
-                                                                             .getPropertiesFor("l2.healthcheck.l2"),
+                                                                             .getPropertiesFor(TCPropertiesConsts.L2_L2_HEALTH_CHECK_CATEGORY),
                                                                                                      "Test Server"),
                                                                          new ServerID(),
                                                                          new TransportHandshakeErrorNullHandler(),

--- a/common/src/test/java/com/tc/net/core/OOOReconnectTimeoutTest.java
+++ b/common/src/test/java/com/tc/net/core/OOOReconnectTimeoutTest.java
@@ -49,6 +49,7 @@ import com.tc.util.Assert;
 import com.tc.util.PortChooser;
 import com.tc.util.concurrent.ThreadUtil;
 import com.tc.util.runtime.ThreadDumpUtil;
+import com.tc.properties.TCPropertiesConsts;
 
 import java.net.InetAddress;
 import java.util.Collections;
@@ -106,7 +107,7 @@ public class OOOReconnectTimeoutTest extends TCTestCase {
                                                                    new NullConnectionPolicy(), 3,
                                                                    new HealthCheckerConfigImpl(TCPropertiesImpl
                                                                        .getProperties()
-                                                                       .getPropertiesFor("l2.healthcheck.l1"),
+                                                                       .getPropertiesFor(TCPropertiesConsts.L2_L1_HEALTH_CHECK_CATEGORY),
                                                                                                "Test Server"),
                                                                    new ServerID(),
                                                                    new TransportHandshakeErrorNullHandler(),

--- a/common/src/test/java/com/tc/net/core/TCWorkerCommManagerTest.java
+++ b/common/src/test/java/com/tc/net/core/TCWorkerCommManagerTest.java
@@ -60,6 +60,7 @@ import com.tc.util.Assert;
 import com.tc.util.CallableWaiter;
 import com.tc.util.PortChooser;
 import com.tc.util.concurrent.ThreadUtil;
+import com.tc.properties.TCPropertiesConsts;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -308,7 +309,7 @@ public class TCWorkerCommManagerTest extends TCTestCase {
                                                                    new NullConnectionPolicy(), 3,
                                                                    new HealthCheckerConfigImpl(TCPropertiesImpl
                                                                        .getProperties()
-                                                                       .getPropertiesFor("l2.healthcheck.l1"),
+                                                                       .getPropertiesFor(TCPropertiesConsts.L2_L1_HEALTH_CHECK_CATEGORY),
                                                                                                "Test Server"),
                                                                    new ServerID(),
                                                                    new TransportHandshakeErrorNullHandler(),

--- a/common/src/test/java/com/tc/net/protocol/transport/HealthCheckerMonitorThreadEngineTest.java
+++ b/common/src/test/java/com/tc/net/protocol/transport/HealthCheckerMonitorThreadEngineTest.java
@@ -25,6 +25,7 @@ import com.tc.logging.TCLogger;
 import com.tc.logging.TCLogging;
 import com.tc.properties.TCProperties;
 import com.tc.properties.TCPropertiesImpl;
+import com.tc.properties.TCPropertiesConsts;
 
 import static com.tc.net.protocol.transport.ConnectionHealthCheckerImpl.HealthCheckerMonitorThreadEngine;
 import static org.junit.Assert.assertFalse;
@@ -39,7 +40,7 @@ public class HealthCheckerMonitorThreadEngineTest {
 
   @Test
   public void testAllowCheckTimeIfEnabledInConfig() {
-    final TCProperties props = TCPropertiesImpl.getProperties().getPropertiesFor("l2.healthcheck.l2");
+    final TCProperties props = TCPropertiesImpl.getProperties().getPropertiesFor(TCPropertiesConsts.L2_L2_HEALTH_CHECK_CATEGORY);
     // enable time checking
     props.setProperty("checkTime.enabled", "true");
     // ignore interval
@@ -52,7 +53,7 @@ public class HealthCheckerMonitorThreadEngineTest {
 
   @Test
   public void testDisallowCheckTimeIfDisabledInConfig() {
-    final TCProperties props = TCPropertiesImpl.getProperties().getPropertiesFor("l2.healthcheck.l2");
+    final TCProperties props = TCPropertiesImpl.getProperties().getPropertiesFor(TCPropertiesConsts.L2_L2_HEALTH_CHECK_CATEGORY);
     // disable time checking
     props.setProperty("checkTime.enabled", "false");
     HealthCheckerConfigImpl config = new HealthCheckerConfigImpl(props, "test-config");
@@ -63,7 +64,7 @@ public class HealthCheckerMonitorThreadEngineTest {
 
   @Test
   public void testDisallowCheckTimeIfIntervalNotExceeded() {
-    final TCProperties props = TCPropertiesImpl.getProperties().getPropertiesFor("l2.healthcheck.l2");
+    final TCProperties props = TCPropertiesImpl.getProperties().getPropertiesFor(TCPropertiesConsts.L2_L2_HEALTH_CHECK_CATEGORY);
     // set short interval
     props.setProperty("checkTime.interval", "900000");
     HealthCheckerConfigImpl config = new HealthCheckerConfigImpl(props, "test-config");

--- a/common/src/test/java/com/tc/util/TCPropertiesConstsTest.java
+++ b/common/src/test/java/com/tc/util/TCPropertiesConstsTest.java
@@ -55,9 +55,21 @@ public class TCPropertiesConstsTest extends TCTestCase {
     exemptedProperties.add(TCPropertiesConsts.L1_SERVER_EVENT_DELIVERY_QUEUE_SIZE);
     
     exemptedProperties.add(TCPropertiesConsts.ENTITY_PROCESSOR_THREADS);
+    exemptedProperties.add(TCPropertiesConsts.L2_SEDA_STAGE_WORKERTHREADS);
+    exemptedProperties.add(TCPropertiesConsts.L2_TCCOM_WORKERTHREADS);
   
     exemptedProperties.add(TCPropertiesConsts.CLIENT_MAX_PENDING_REQUESTS);
     exemptedProperties.add(TCPropertiesConsts.CLIENT_MAX_SENT_REQUESTS);
+
+    // exempt all subcategories
+    exemptedProperties.add(TCPropertiesConsts.L1_CATEGORY);
+    exemptedProperties.add(TCPropertiesConsts.L2_CATEGORY);
+    exemptedProperties.add(TCPropertiesConsts.L1_L2_HEALTH_CHECK_CATEGORY);
+    exemptedProperties.add(TCPropertiesConsts.L2_L1_HEALTH_CHECK_CATEGORY);
+    exemptedProperties.add(TCPropertiesConsts.L2_L2_HEALTH_CHECK_CATEGORY);
+    exemptedProperties.add(TCPropertiesConsts.L1_LOCK_MANAGER_CATEGORY);
+    exemptedProperties.add(TCPropertiesConsts.LOGGING_CATEGORY);
+    exemptedProperties.add(TCPropertiesConsts.NETCORE_CATEGORY);
   }
 
   private void loadDefaults(String propFile) {

--- a/dso-l1/src/main/java/com/tc/object/DistributedObjectClient.java
+++ b/dso-l1/src/main/java/com/tc/object/DistributedObjectClient.java
@@ -314,7 +314,7 @@ public class DistributedObjectClient implements TCClient {
 
     final TCProperties tcProperties = TCPropertiesImpl.getProperties();
     final boolean checkClientServerVersions = tcProperties.getBoolean(TCPropertiesConsts.VERSION_COMPATIBILITY_CHECK);
-    this.l1Properties = tcProperties.getPropertiesFor("l1");
+    this.l1Properties = tcProperties.getPropertiesFor(TCPropertiesConsts.L1_CATEGORY);
     final int maxSize = tcProperties.getInt(TCPropertiesConsts.L1_SEDA_STAGE_SINK_CAPACITY);
 
     final SessionManager sessionManager = new SessionManagerImpl(new SessionManagerImpl.SequenceFactory() {
@@ -348,8 +348,8 @@ public class DistributedObjectClient implements TCClient {
                                      networkStackHarnessFactory,
                                      new NullConnectionPolicy(),
                                      this.connectionComponents.createConnectionInfoConfigItemByGroup().length,
-                                     new HealthCheckerConfigClientImpl(this.l1Properties
-                                         .getPropertiesFor("healthcheck.l2"), "DSO Client"),
+                                     new HealthCheckerConfigClientImpl(tcProperties
+                                         .getPropertiesFor(TCPropertiesConsts.L1_L2_HEALTH_CHECK_CATEGORY), "DSO Client"),
                                      getMessageTypeClassMapping(),
             ReconnectionRejectedHandlerL1.SINGLETON, securityManager, productId);
 
@@ -408,7 +408,7 @@ public class DistributedObjectClient implements TCClient {
                            new ClientIDLogger(this.channel, TCLogging
                                .getLogger(ClientLockManager.class)), sessionManager, this.channel
                                .getLockRequestMessageFactory(), this.threadIDManager,
-            new ClientLockManagerConfigImpl(this.l1Properties.getPropertiesFor("lockmanager")),
+            new ClientLockManagerConfigImpl(tcProperties.getPropertiesFor(TCPropertiesConsts.L1_LOCK_MANAGER_CATEGORY)),
             this.taskRunner);
     final CallbackDumpAdapter lockDumpAdapter = new CallbackDumpAdapter(this.lockManager);
     this.threadGroup.addCallbackOnExitDefaultHandler(lockDumpAdapter);

--- a/dso-l2/src/main/java/com/tc/l2/logging/TCLoggingLog4J.java
+++ b/dso-l2/src/main/java/com/tc/l2/logging/TCLoggingLog4J.java
@@ -36,6 +36,7 @@ import com.tc.properties.TCProperties;
 import com.tc.properties.TCPropertiesImpl;
 import com.tc.util.Assert;
 import com.tc.util.ProductInfo;
+import com.tc.properties.TCPropertiesConsts;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -69,7 +70,6 @@ public class TCLoggingLog4J implements TCLoggingService {
   
   private static final int          MAX_BUFFERED_LOG_MESSAGES          = 10 * 1000;
 
-  private static final String       LOGGING_PROPERTIES_SECTION         = "logging";
   private static final String       MAX_LOG_FILE_SIZE_PROPERTY         = "maxLogFileSize";
   private static final int          DEFAULT_MAX_LOG_FILE_SIZE          = 512;
   private static final String       MAX_BACKUPS_PROPERTY               = "maxBackups";
@@ -416,7 +416,7 @@ public class TCLoggingLog4J implements TCLoggingService {
 
     synchronized (TCLoggingLog4J.class) {
       try {
-        TCProperties props = TCPropertiesImpl.getProperties().getPropertiesFor(LOGGING_PROPERTIES_SECTION);
+        TCProperties props = TCPropertiesImpl.getProperties().getPropertiesFor(TCPropertiesConsts.LOGGING_CATEGORY);
         newFileAppender = new TCRollingFileAppender(new PatternLayout(FILE_AND_JMX_PATTERN), logFilePath, true);
         newFileAppender.setName("file appender");
         int maxLogFileSize = props.getInt(MAX_LOG_FILE_SIZE_PROPERTY, DEFAULT_MAX_LOG_FILE_SIZE);

--- a/dso-l2/src/main/java/com/tc/net/groups/TCGroupManagerImpl.java
+++ b/dso-l2/src/main/java/com/tc/net/groups/TCGroupManagerImpl.java
@@ -230,7 +230,8 @@ public class TCGroupManagerImpl implements GroupManager<AbstractGroupMessage>, C
 
   private void init(TCSocketAddress socketAddress) {
 
-    l2Properties = TCPropertiesImpl.getProperties().getPropertiesFor("l2");
+    TCProperties tcProperties = TCPropertiesImpl.getProperties();
+    l2Properties = tcProperties.getPropertiesFor(TCPropertiesConsts.L2_CATEGORY);
 
     createTCGroupManagerStages();
     final NetworkStackHarnessFactory networkStackHarnessFactory = getNetworkStackHarnessFactory();
@@ -245,8 +246,8 @@ public class TCGroupManagerImpl implements GroupManager<AbstractGroupMessage>, C
                                                           new NullMessageMonitor(), messageRouter,
                                                           networkStackHarnessFactory, this.connectionPolicy,
                                                           L2Utils.getOptimalCommWorkerThreads(),
-                                                          new HealthCheckerConfigImpl(l2Properties
-                                                              .getPropertiesFor("healthcheck.l2"), "TCGroupManager"),
+                                                          new HealthCheckerConfigImpl(tcProperties
+                                                              .getPropertiesFor(TCPropertiesConsts.L2_L2_HEALTH_CHECK_CATEGORY), "TCGroupManager"),
                                                           thisNodeID, new TransportHandshakeErrorHandlerForGroupComm(),
                                                           messageTypeClassMapping, Collections.emptyMap(),
         securityManager);

--- a/dso-l2/src/main/java/com/tc/net/utils/L2Utils.java
+++ b/dso-l2/src/main/java/com/tc/net/utils/L2Utils.java
@@ -36,13 +36,13 @@ public class L2Utils {
   public static int getOptimalCommWorkerThreads() {
 //  TODO:  reduced number of default threads.  re-evaluate closer to release MKS 6.8.2015
     int def = Math.min(Runtime.getRuntime().availableProcessors()/2, MAX_DEFAULT_COMM_THREADS);
-    return TCPropertiesImpl.getProperties().getInt("l2.tccom.workerthreads", def);
+    return TCPropertiesImpl.getProperties().getInt(TCPropertiesConsts.L2_TCCOM_WORKERTHREADS, def);
   }
 
   public static int getOptimalStageWorkerThreads() {
 //  TODO:  reduced number of default threads.  re-evaluate closer to release MKS 6.8.2015
     int def = Math.min(Runtime.getRuntime().availableProcessors()/2, MAX_DEFAULT_STAGE_THREADS);
-    return TCPropertiesImpl.getProperties().getInt("l2.seda.stage.workerthreads", def);
+    return TCPropertiesImpl.getProperties().getInt(TCPropertiesConsts.L2_SEDA_STAGE_WORKERTHREADS, def);
   }
 
   /**

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -504,7 +504,7 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
                                                                messageRouter, networkStackHarnessFactory,
                                                                this.connectionPolicy, commWorkerThreadCount,
                                                                new HealthCheckerConfigImpl(tcProperties
-                                                                   .getPropertiesFor("l2.healthcheck.l1"), "TSA Server"),
+                                                                   .getPropertiesFor(TCPropertiesConsts.L2_L1_HEALTH_CHECK_CATEGORY), "TSA Server"),
                                                                this.thisServerNodeID,
                                                                new TransportHandshakeErrorNullHandler(),
                                                                getMessageTypeClassMappings(), Collections.emptyMap(),

--- a/dso-l2/src/test/java/com/tc/config/TcPropertiesWithSpacesOverWriteTest.java
+++ b/dso-l2/src/test/java/com/tc/config/TcPropertiesWithSpacesOverWriteTest.java
@@ -23,6 +23,7 @@ import com.tc.properties.TCProperties;
 import com.tc.properties.TCPropertiesImpl;
 import com.tc.test.TCTestCase;
 import com.tc.util.Assert;
+import com.tc.properties.TCPropertiesConsts;
 import org.apache.commons.io.IOUtils;
 
 import java.io.File;
@@ -36,10 +37,8 @@ public class TcPropertiesWithSpacesOverWriteTest extends TCTestCase {
     String config = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>"
         + "\n<tc-config xmlns=\"http://www.terracotta.org/config\">"
         + "<tc-properties>"
-        + "<property name=\" l1.cachemanager.enabled \" value=\"    false    \" />"
-        + "<property name=\"   logging.maxLogFileSize  \" value=\"   1234\" />"
-        + "<property name=\"l1.transactionmanager.maxPendingBatches   \" value=\"2345   \" />"
-        + "<property name=\"    l1.cachemanager.leastCount    \" value=\"  9000   \" />"
+        + "<property name=\"  " + TCPropertiesConsts.L2_HEALTHCHECK_L2_SOCKECT_CONNECT + "  \" value=\"    false    \" />"
+        + "<property name=\"  " +   TCPropertiesConsts.LOGGING_MAX_LOGFILE_SIZE  + "  \" value=\"   1234\" />"
         + "</tc-properties>"
         + "\n<servers>"
         + "\n      <server name=\"server1\">"
@@ -53,10 +52,8 @@ public class TcPropertiesWithSpacesOverWriteTest extends TCTestCase {
     factory.createL2TVSConfigurationSetupManager("server1", getClass().getClassLoader());
 
     TCProperties tcProps = TCPropertiesImpl.getProperties();
-    Assert.assertEquals(false, tcProps.getBoolean("l1.cachemanager.enabled"));
-    Assert.assertEquals(1234, tcProps.getInt("logging.maxLogFileSize"));
-    Assert.assertEquals(2345, tcProps.getInt("l1.transactionmanager.maxPendingBatches"));
-    Assert.assertEquals(9000, tcProps.getInt("l1.cachemanager.leastCount"));
+    Assert.assertEquals(false, tcProps.getBoolean(TCPropertiesConsts.L2_HEALTHCHECK_L2_SOCKECT_CONNECT));
+    Assert.assertEquals(1234, tcProps.getInt(TCPropertiesConsts.LOGGING_MAX_LOGFILE_SIZE));
   }
 
   private synchronized void writeConfigFile(String fileContents) {

--- a/dso-l2/src/test/java/com/tc/net/groups/TCGroupManagerImplTest.java
+++ b/dso-l2/src/test/java/com/tc/net/groups/TCGroupManagerImplTest.java
@@ -44,6 +44,7 @@ import com.tc.net.protocol.tcm.MessageChannel;
 import com.tc.net.protocol.tcm.TCMessageType;
 import com.tc.net.protocol.transport.NullConnectionPolicy;
 import com.tc.net.proxy.TCPProxy;
+import com.tc.properties.TCPropertiesConsts;
 import com.tc.properties.TCPropertiesImpl;
 import com.tc.test.TCTestCase;
 import com.tc.util.PortChooser;
@@ -213,11 +214,11 @@ public class TCGroupManagerImplTest extends TCTestCase {
 
     proxy.setDelay(Integer.MAX_VALUE);
 
-    long minTimeToSayDead = TCPropertiesImpl.getProperties().getLong("l2.healthcheck.l1.ping.idletime")
-                            + (TCPropertiesImpl.getProperties().getLong("l2.healthcheck.l1.ping.interval") * TCPropertiesImpl
-                                .getProperties().getLong("l2.healthcheck.l1.ping.probes"));
+    long minTimeToSayDead = TCPropertiesImpl.getProperties().getLong(TCPropertiesConsts.L2_HEALTHCHECK_L1_PING_IDLETIME)
+                            + (TCPropertiesImpl.getProperties().getLong(TCPropertiesConsts.L2_HEALTHCHECK_L1_PING_INTERVAL) * TCPropertiesImpl
+                                .getProperties().getLong(TCPropertiesConsts.L2_HEALTHCHECK_L1_PING_PROBES));
     // giving more buffer time, to catch problem if any
-    minTimeToSayDead += (3 * TCPropertiesImpl.getProperties().getLong("l2.healthcheck.l1.ping.interval"));
+    minTimeToSayDead += (3 * TCPropertiesImpl.getProperties().getLong(TCPropertiesConsts.L2_HEALTHCHECK_L1_PING_IDLETIME));
 
     // HC will not say the other end is DEAD as the callback port from the client TCGroupMgr is available
     System.out.println("Sleeping for min time " + minTimeToSayDead);
@@ -228,8 +229,8 @@ public class TCGroupManagerImplTest extends TCTestCase {
     // eventually after full probe, the node has to goto DEAD state
     while (groups[1].size() != 0) {
       System.out.println(".");
-      ThreadUtil.reallySleep(TCPropertiesImpl.getProperties().getLong("l2.healthcheck.l1.ping.interval")
-                             * TCPropertiesImpl.getProperties().getLong("l2.healthcheck.l1.ping.probes"));
+      ThreadUtil.reallySleep(TCPropertiesImpl.getProperties().getLong(TCPropertiesConsts.L2_HEALTHCHECK_L1_PING_INTERVAL)
+                             * TCPropertiesImpl.getProperties().getLong(TCPropertiesConsts.L2_HEALTHCHECK_L1_PING_PROBES));
     }
     tearGroups();
   }


### PR DESCRIPTION
   * replace tc properites string literals usage with named constants
   * remove unnecessary public static final usage in TCPropertiesConsts interface
   * create subcategories for use with TCProperties.getPropertiesFor(...)