### PR TITLE
Clean client entity mgr

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -169,11 +169,11 @@ public class ManagedEntityImpl implements ManagedEntity {
   private void scheduleInOrder(EntityDescriptor desc, ServerEntityRequest request, byte[] payload, Runnable r, int ckey) {
 // this all makes sense because this is only called by the PTH single thread
 // deferCleared is cleared by one of the request queues
-    Assert.assertTrue(
-        Thread.currentThread().getName().contains(ServerConfigurationContext.PASSIVE_REPLICATION_STAGE)
-        || Thread.currentThread().getName().contains(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE)
-        || Thread.currentThread().getName().contains(ServerConfigurationContext.CLIENT_HANDSHAKE_STAGE)
-    );
+    if (isInActiveState) {
+      Assert.assertTrue(Thread.currentThread().getName().contains(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE));
+    } else {
+      Assert.assertTrue(Thread.currentThread().getName().contains(ServerConfigurationContext.PASSIVE_REPLICATION_STAGE));
+    }
     
     SchedulingRunnable next = new SchedulingRunnable(desc, request, payload, r, ckey);
     

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
@@ -18,8 +18,6 @@
  */
 package com.tc.objectserver.entity;
 
-import com.tc.async.api.Sink;
-import com.tc.entity.VoltronEntityMessage;
 import com.tc.net.ClientID;
 import org.junit.Before;
 import org.junit.Test;
@@ -121,7 +119,7 @@ public class ManagedEntityImplTest {
         return null;
       }
     }).when(requestMulti).scheduleRequest(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt());
-    Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
+    Thread.currentThread().setName(ServerConfigurationContext.PASSIVE_REPLICATION_STAGE);
   }
   
   @SuppressWarnings("unchecked")
@@ -167,6 +165,7 @@ public class ManagedEntityImplTest {
   public void testGetEntityMissing() throws Exception {
     // create a ManagedEntity which is in active state
     ManagedEntityImpl managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, true);
+    Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
     
     com.tc.net.ClientID requester = new com.tc.net.ClientID(0);
     ServerEntityRequest request = mockGetRequest(requester);
@@ -181,7 +180,8 @@ public class ManagedEntityImplTest {
     byte[] config = mockCreatePayload("foo");
     managedEntity.addLifecycleRequest(mockCreateEntityRequest(),  config);
     managedEntity.addLifecycleRequest(mockPromoteToActiveRequest(), null);
-    
+    Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
+
     com.tc.net.ClientID requester = new com.tc.net.ClientID(0);
     ServerEntityRequest request = mockGetRequest(requester);
     managedEntity.addLifecycleRequest(request, null);
@@ -237,6 +237,7 @@ public class ManagedEntityImplTest {
     managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, false);
     managedEntity.addLifecycleRequest(mockCreateEntityRequest(), null);
     managedEntity.addLifecycleRequest(mockPromoteToActiveRequest(), null);
+    Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
 
     when(activeServerEntity.invoke(eq(clientDescriptor), any(EntityMessage.class))).thenReturn(new EntityResponse() {});
     ServerEntityRequest invokeRequest = mockInvokeRequest();
@@ -313,6 +314,9 @@ public class ManagedEntityImplTest {
       barrier.await();
       return new EntityResponse() {};
     });
+    
+    Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
+    
     managedEntity.addInvokeRequest(mgmtInvoke, payload, ConcurrencyStrategy.MANAGEMENT_KEY);
     
     verify(loopback, times(3)).accept(Matchers.any(), Matchers.anyLong());
@@ -379,6 +383,7 @@ public class ManagedEntityImplTest {
     managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, false);
     managedEntity.addLifecycleRequest(mockCreateEntityRequest(), new byte[0]);
     managedEntity.addLifecycleRequest(mockPromoteToActiveRequest(), new byte[0]);
+    Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
 
     Deque<Integer> queued = new LinkedList<>();
     Deque<Runnable> blockers = new LinkedList<>();
@@ -494,6 +499,7 @@ public class ManagedEntityImplTest {
 
     // Get and release are only relevant on the active.
     managedEntity.addLifecycleRequest(mockPromoteToActiveRequest(), null);
+    Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
     
     // Run the GET and verify that connected() call was received by the entity.
     com.tc.net.ClientID requester = new com.tc.net.ClientID(0);
@@ -523,8 +529,10 @@ public class ManagedEntityImplTest {
     
     // Now, switch modes to active.
     managedEntity.addLifecycleRequest(mockPromoteToActiveRequest(), null);
+    Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
     verify(activeServerEntity).loadExisting();
     
+    Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
     // Verify that we fail to create it again.
     ServerEntityRequest failedCreateRequest = mockCreateEntityRequest();
     managedEntity.addLifecycleRequest(failedCreateRequest, null);
@@ -549,7 +557,7 @@ public class ManagedEntityImplTest {
   public void testDestroy() throws Exception {
     managedEntity.addLifecycleRequest(mockCreateEntityRequest(), null);
     managedEntity.addLifecycleRequest(mockPromoteToActiveRequest(), null);
-    
+    Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
     managedEntity.addLifecycleRequest(mockRequestForAction(ServerEntityAction.DESTROY_ENTITY), null);
 
     verify(activeServerEntity).destroy();

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicationSenderTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicationSenderTest.java
@@ -1,0 +1,254 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.objectserver.handler;
+
+import com.tc.async.api.EventHandlerException;
+import com.tc.l2.msg.PassiveSyncMessage;
+import com.tc.l2.msg.ReplicationEnvelope;
+import com.tc.l2.msg.ReplicationMessage;
+import com.tc.l2.msg.ReplicationMessage.ReplicationType;
+import com.tc.net.ClientID;
+import com.tc.net.NodeID;
+import com.tc.net.groups.GroupManager;
+import com.tc.object.ClientInstanceID;
+import com.tc.object.EntityDescriptor;
+import com.tc.object.EntityID;
+import com.tc.object.tx.TransactionID;
+import com.tc.util.Assert;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Matchers;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+/**
+ *
+ */
+public class ReplicationSenderTest {
+  
+  NodeID node = mock(NodeID.class);
+  GroupManager groupMgr = mock(GroupManager.class);
+  List<ReplicationEnvelope> collector = new LinkedList<>();
+  ReplicationSender testSender = new ReplicationSender(groupMgr);
+  EntityID entity = EntityID.NULL_ID;
+  int concurrency = 1;
+  
+  public ReplicationSenderTest() {
+  }
+  
+  @BeforeClass
+  public static void setUpClass() {
+  }
+  
+  @AfterClass
+  public static void tearDownClass() {
+  }
+  
+  @Before
+  public void setUp() throws Exception {
+    doAnswer((invoke)-> {
+      Object[] args = invoke.getArguments();
+      collector.add(((ReplicationMessage)args[1]).target((NodeID)args[0]));
+      return null;
+    }).when(groupMgr).sendTo(Matchers.any(NodeID.class), Matchers.any(ReplicationMessage.class));
+  }
+  
+  private void makeAndSendSequence(Collection<ReplicationType> list) throws Exception {
+    list.stream().forEach(msg->{
+      ReplicationMessage rep = makeMessage(msg);
+      try {
+        testSender.handleEvent(rep.target(node));
+      } catch (EventHandlerException exp) {
+        throw new RuntimeException(exp);
+      }
+    });
+  }
+  
+  private ReplicationMessage makeMessage(int type) {
+    return new ReplicationMessage(type);
+  }
+    
+  private ReplicationMessage makeMessage(ReplicationType type) {
+    switch (type) {
+      case CREATE_ENTITY:
+      case DESTROY_ENTITY:
+      case DOES_EXIST:
+      case INVOKE_ACTION:
+      case NOOP:
+      case RECONFIGURE_ENTITY:
+      case RELEASE_ENTITY:
+        return new ReplicationMessage(new EntityDescriptor(entity, ClientInstanceID.NULL_ID, 1), ClientID.NULL_ID, TransactionID.NULL_ID, TransactionID.NULL_ID, type, new byte[0], 0);
+      case SYNC_BEGIN:
+        return PassiveSyncMessage.createStartSyncMessage();
+      case SYNC_END:
+        return PassiveSyncMessage.createEndSyncMessage();
+      case SYNC_ENTITY_BEGIN:
+        return PassiveSyncMessage.createStartEntityMessage(entity, 1, new byte[0]);
+      case SYNC_ENTITY_CONCURRENCY_BEGIN:
+        return PassiveSyncMessage.createStartEntityKeyMessage(entity, 1, concurrency);
+      case SYNC_ENTITY_CONCURRENCY_END:
+        return PassiveSyncMessage.createEndEntityKeyMessage(entity, 1, concurrency++);
+      case SYNC_ENTITY_CONCURRENCY_PAYLOAD:
+        return PassiveSyncMessage.createPayloadMessage(entity, 1, concurrency, new byte[0]);
+      case SYNC_ENTITY_END:
+        return PassiveSyncMessage.createEndEntityMessage(entity, 1);
+      default:
+        throw new AssertionError("bad message type");
+    }
+  }
+  
+  @After
+  public void tearDown() {
+    
+  }
+  
+  @Test
+  public void filterSCDC() throws Exception {  // Sync-Create-Delete-Create
+    entity = new EntityID("TEST", "test");
+    List<ReplicationMessage> origin = new LinkedList<>();
+    List<ReplicationMessage> validation = new LinkedList<>();
+    buildTest(origin, validation, makeMessage(ReplicationMessage.START), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.NOOP), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.NOOP), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_BEGIN), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.INVOKE_ACTION), true);  
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_ENTITY_BEGIN), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.CREATE_ENTITY), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_ENTITY_CONCURRENCY_BEGIN), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.INVOKE_ACTION), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.NOOP), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_ENTITY_CONCURRENCY_PAYLOAD), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.INVOKE_ACTION), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.NOOP), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_ENTITY_CONCURRENCY_END), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.DESTROY_ENTITY), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.CREATE_ENTITY), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.INVOKE_ACTION), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_ENTITY_END), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_END), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.INVOKE_ACTION), false);
+
+    origin.stream().forEach(msg-> {
+      try {
+        testSender.handleEvent(msg.target(node));
+      } catch (EventHandlerException h) {
+        throw new RuntimeException(h);
+      }
+    });
+    
+    validateCollector(validation);
+  }  
+  
+  @Test
+  public void filterCDC() throws Exception {  // Create-Delete-Create
+    entity = new EntityID("TEST", "test");
+    List<ReplicationMessage> origin = new LinkedList<>();
+    List<ReplicationMessage> validation = new LinkedList<>();
+    buildTest(origin, validation, makeMessage(ReplicationMessage.START), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.NOOP), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.NOOP), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_BEGIN), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.CREATE_ENTITY), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.INVOKE_ACTION), false);  // invoke actions are valid since the stream is working off the create
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_ENTITY_BEGIN), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_ENTITY_CONCURRENCY_BEGIN), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.INVOKE_ACTION), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.NOOP), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_ENTITY_CONCURRENCY_PAYLOAD), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.INVOKE_ACTION), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.NOOP), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_ENTITY_CONCURRENCY_END), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.DESTROY_ENTITY), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.CREATE_ENTITY), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.INVOKE_ACTION), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_ENTITY_END), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_END), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.INVOKE_ACTION), false);
+
+    origin.stream().forEach(msg-> {
+      try {
+        testSender.handleEvent(msg.target(node));
+      } catch (EventHandlerException h) {
+        throw new RuntimeException(h);
+      }
+    });
+    
+    validateCollector(validation);
+  }  
+
+  @Test
+  public void filterValidation() throws Exception {
+    entity = new EntityID("TEST", "test");
+    List<ReplicationMessage> origin = new LinkedList<>();
+    List<ReplicationMessage> validation = new LinkedList<>();
+    buildTest(origin, validation, makeMessage(ReplicationMessage.START), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.NOOP), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.NOOP), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.CREATE_ENTITY), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_BEGIN), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.INVOKE_ACTION), true);   // invoke actions are valid since the stream is working off the create
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_ENTITY_BEGIN), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_ENTITY_CONCURRENCY_BEGIN), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.INVOKE_ACTION), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.NOOP), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_ENTITY_CONCURRENCY_PAYLOAD), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.INVOKE_ACTION), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.NOOP), true);
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_ENTITY_CONCURRENCY_END), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_ENTITY_END), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.SYNC_END), false);
+    buildTest(origin, validation, makeMessage(ReplicationType.INVOKE_ACTION), false);
+
+    origin.stream().forEach(msg-> {
+      try {
+        testSender.handleEvent(msg.target(node));
+      } catch (EventHandlerException h) {
+        throw new RuntimeException(h);
+      }
+    });
+    
+    validateCollector(validation);
+  }
+  
+  private void validateCollector(Collection<ReplicationMessage> valid) {
+    Iterator<ReplicationMessage> next = valid.iterator();
+    collector.stream().forEach(cmsg->{
+      ReplicationMessage vmsg = next.next();
+      if (vmsg.getReplicationType() != ReplicationType.SYNC_BEGIN &&
+          vmsg.getReplicationType() != ReplicationType.SYNC_END) {
+        Assert.assertEquals(vmsg + "!=" + cmsg.getMessage(), vmsg.getEntityID(), cmsg.getMessage().getEntityID());
+      }
+      Assert.assertEquals(vmsg + "!=" + cmsg.getMessage(), vmsg.getReplicationType(), cmsg.getMessage().getReplicationType());
+      Assert.assertEquals(vmsg + "!=" + cmsg.getMessage(), vmsg.getConcurrency(), cmsg.getMessage().getConcurrency());
+      System.err.println(vmsg.getReplicationType() + " on " + vmsg.getEntityID());
+    });
+  }
+  
+  private void buildTest(List<ReplicationMessage> origin, List<ReplicationMessage> validation, ReplicationMessage msg, boolean filtered) {
+    origin.add(msg);
+    if (!filtered) validation.add(msg);
+  }
+}

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationEnvelope.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationEnvelope.java
@@ -46,8 +46,6 @@ public class ReplicationEnvelope {
   public void release() {
     if (waitRelease != null) {
       waitRelease.run();
-    } else {
-      throw new AssertionError("not waiting");
     }
   }
 }


### PR DESCRIPTION
Fix the reconnect timeout assertion by executing resends from the proper stage.

Fix destroy during sync hang and create during sync miss with new unit test and refactoring of ReplicationSender and ReplicatedTransactionHandler

Close hooks for release of entities do not operate as documented.  fix by making sure the close hook is not called on exception.