### PR TITLE
Removed DirectExecutor, TryLockRunnable, and the Future interactions

### DIFF
--- a/connection-impl/src/main/java/com/terracotta/connection/entity/MaintenanceModeService.java
+++ b/connection-impl/src/main/java/com/terracotta/connection/entity/MaintenanceModeService.java
@@ -16,7 +16,6 @@
  *  Terracotta, Inc., a Software AG company
  *
  */
-
 package com.terracotta.connection.entity;
 
 import com.tc.logging.TCLogger;
@@ -27,121 +26,39 @@ import com.tc.object.locks.ClientLockManager;
 import com.tc.object.locks.EntityLockID;
 import com.tc.object.locks.LockID;
 import com.tc.object.locks.LockLevel;
-import java.util.List;
-import java.util.concurrent.AbstractExecutorService;
-import com.tc.util.Assert;
 
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
-/**
- * @author twu
- */
 public class MaintenanceModeService {
   private static TCLogger LOGGER = TCLogging.getLogger(MaintenanceModeService.class);
-  private final ExecutorService executorService = new DirectExecutor();
   private final ClientLockManager clientLockManager;
- 
-  private class DirectExecutor extends AbstractExecutorService {
-    
-    @Override
-    public void shutdown() {
-      throw new UnsupportedOperationException();
-    }
 
-    @Override
-    public List<Runnable> shutdownNow() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean isShutdown() {
-      return false;
-    }
-
-    @Override
-    public boolean isTerminated() {
-      return false;
-    }
-
-    @Override
-    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void execute(Runnable command) {
-      command.run();
-    }
-    
-  }
   public MaintenanceModeService(ClientLockManager clientLockManager) {
     this.clientLockManager = clientLockManager;
   }
 
-  private static void await(Future<?> future) {
-    boolean interrupted = false;
-    while (true) {
-      try {
-        future.get();
-        break;
-      } catch (InterruptedException e) {
-        interrupted = true;
-      } catch (ExecutionException e) {
-        throw new RuntimeException(e);
-      }
-    }
-    if (interrupted) {
-      Thread.currentThread().interrupt();
-    }
-  }
-
   public <T extends Entity> void readLockEntity(final Class<T> c, final String name) {
-    await(executorService.submit(new Runnable() {
-      @Override
-      public void run() {
-        LockID lockID = new EntityLockID(c.getName(), name);
-        lock(lockID, LockLevel.READ);
-      }
-    }));
+    LockID lockID = new EntityLockID(c.getName(), name);
+    lock(lockID, LockLevel.READ);
   }
 
   public <T extends Entity> void readUnlockEntity(final Class<T> c, final String name) {
-    await(executorService.submit(new Runnable() {
-      @Override
-      public void run() {
-        LockID lockID = new EntityLockID(c.getName(), name);
-        unlock(lockID, LockLevel.READ);
-      }
-    }));
+    LockID lockID = new EntityLockID(c.getName(), name);
+    unlock(lockID, LockLevel.READ);
   }
 
   public <T extends Entity> void enterMaintenanceMode(final Class<T> c, final String name) {
-    await(executorService.submit(new Runnable() {
-      @Override
-      public void run() {
-        LockID lockID = new EntityLockID(c.getName(), name);
-        lock(lockID, LockLevel.WRITE);
-      }
-    }));
+    LockID lockID = new EntityLockID(c.getName(), name);
+    lock(lockID, LockLevel.WRITE);
   }
 
   public <T extends Entity> boolean tryEnterMaintenanceMode(final Class<T> c, final String name) {
-    TryLockRunnable runnable = new TryLockRunnable(c, name);
-    await(executorService.submit(runnable));
-    return runnable.didLock();
+    LockID lockID = new EntityLockID(c.getName(), name);
+    return tryLock(lockID, LockLevel.WRITE);
   }
 
   public <T extends Entity> void exitMaintenanceMode(final Class<T> c, final String name) {
-    await(executorService.submit(new Runnable() {
-      @Override
-      public void run() {
-        LockID lockID = new EntityLockID(c.getName(), name);
-        unlock(lockID, LockLevel.WRITE);
-      }
-    }));
+    LockID lockID = new EntityLockID(c.getName(), name);
+    unlock(lockID, LockLevel.WRITE);
   }
 
   private void lock(LockID id, LockLevel level) {
@@ -169,37 +86,5 @@ public class MaintenanceModeService {
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug("time to unlock:" + id + " " + level + " " + (System.nanoTime() - time) + " nanos");
       }
-  }
-
-
-  /**
-   * We create this explicit runnable for tryLock since we want to know whether the lock did happen.
-   */
-  private class TryLockRunnable implements Runnable {
-    private final Class<?> clazz;
-    private final String name;
-    private boolean didRun = false;
-    private boolean didLock = false;
-    
-    public TryLockRunnable(Class<?> clazz, String name) {
-      this.clazz = clazz;
-      this.name = name;
-    }
-
-    /**
-     * Checks if the lock was successful and also asserts that the attempt was at least made.
-     * @return True if the lock was successful
-     */
-    public boolean didLock() {
-      Assert.assertTrue(this.didRun);
-      return this.didLock;
-    }
-    
-    @Override
-    public void run() {
-      LockID lockID = new EntityLockID(clazz.getName(), name);
-      this.didLock = tryLock(lockID, LockLevel.WRITE);
-      this.didRun = true;
-    }
   }
 }


### PR DESCRIPTION
-these were remnants of a previous design approach which seemed to be over-designed in light of the very simple, in-order, approach we now have
-removing these components make the simplicity of the current design more obvious