### PR TITLE
Expose Client PID info on Server side

### DIFF
--- a/common/src/main/java/com/tc/net/protocol/tcm/ClientMessageChannelImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/ClientMessageChannelImpl.java
@@ -45,6 +45,7 @@ import com.tc.util.Assert;
 import com.tc.util.TCTimeoutException;
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.net.UnknownHostException;
 
 
@@ -214,11 +215,21 @@ public class ClientMessageChannelImpl extends AbstractMessageChannel implements 
     final ClientHandshakeMessage rv = (ClientHandshakeMessage) createMessage(TCMessageType.CLIENT_HANDSHAKE_MESSAGE);
     rv.setClientVersion(clientVersion);
     rv.setEnterpriseClient(isEnterpriseClient);
+    rv.setClientPID(getPID());
     return rv;
   }
 
   @Override
   public ClientHandshakeMessageFactory getClientHandshakeMessageFactory() {
     return this;
+  }
+
+  private int getPID() {
+    String vmName = ManagementFactory.getRuntimeMXBean().getName();
+    int index = vmName.indexOf('@');
+
+    if (index < 0) { throw new RuntimeException("unexpected format: " + vmName); }
+
+    return Integer.parseInt(vmName.substring(0, index));
   }
 }

--- a/common/src/main/java/com/tc/object/msg/TestClientHandshakeMessage.java
+++ b/common/src/main/java/com/tc/object/msg/TestClientHandshakeMessage.java
@@ -56,6 +56,7 @@ public class TestClientHandshakeMessage extends TestTCMessage implements ClientH
   public List<TransactionID>                   transactionIDs                 = new ArrayList<TransactionID>();
   private TestMessageChannel    channel;
   private String                clientVersion;
+  private int                   pid;
   private final Set<ClientEntityReferenceContext> reconnectReferenceSet = new HashSet<ClientEntityReferenceContext>();
   private final Set<ResendVoltronEntityMessage> resendMessageSet = new HashSet<ResendVoltronEntityMessage>();
 
@@ -110,6 +111,16 @@ public class TestClientHandshakeMessage extends TestTCMessage implements ClientH
   @Override
   public String getClientVersion() {
     return this.clientVersion;
+  }
+
+  @Override
+  public void setClientPID(int pid) {
+    this.pid = pid;
+  }
+
+  @Override
+  public int getClientPID() {
+    return pid;
   }
 
   @Override

--- a/dso-l2/src/main/java/com/tc/objectserver/core/api/ITopologyEventCollector.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/core/api/ITopologyEventCollector.java
@@ -23,6 +23,7 @@ import com.tc.net.ServerID;
 import com.tc.net.protocol.tcm.MessageChannel;
 import com.tc.object.EntityID;
 import com.tc.util.State;
+import org.terracotta.entity.ClientDescriptor;
 
 
 /**
@@ -102,8 +103,9 @@ public interface ITopologyEventCollector {
    * 
    * @param client The client.
    * @param id The unique identifier for this entity.
+   * @param clientDescriptor corresponding ClientDescriptor for client
    */
-  public void clientDidFetchEntity(ClientID client, EntityID id);
+  public void clientDidFetchEntity(ClientID client, EntityID id, ClientDescriptor clientDescriptor);
 
   /**
    * Called when a given client successfully releases a specific entity.  Note that the same client can fetch a given entity

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -258,7 +258,7 @@ public class ManagedEntityImpl implements ManagedEntity {
       write.unlock();
     }
     // Fire the event that the client fetched the entity.
-    this.eventCollector.clientDidFetchEntity(clientID, this.getID());
+    this.eventCollector.clientDidFetchEntity(clientID, this.getID(), clientDescriptor);
   }
   
   private void invokeLifecycleOperation(ServerEntityRequest request, byte[] payload) {
@@ -579,7 +579,7 @@ public class ManagedEntityImpl implements ManagedEntity {
         this.activeServerEntity.connected(sourceDescriptor);
         getEntityRequest.complete(this.constructorInfo);
         // Fire the event that the client fetched the entity.
-        this.eventCollector.clientDidFetchEntity(clientID, this.getID());
+        this.eventCollector.clientDidFetchEntity(clientID, this.getID(), sourceDescriptor);
       } else {
         getEntityRequest.complete();
       }

--- a/dso-l2/src/main/java/com/tc/objectserver/handshakemanager/ServerClientHandshakeManager.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handshakemanager/ServerClientHandshakeManager.java
@@ -19,6 +19,7 @@
 package com.tc.objectserver.handshakemanager;
 
 import com.tc.async.api.Stage;
+import com.tc.objectserver.core.impl.ManagementTopologyEventCollector;
 import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.exception.EntityException;
 
@@ -115,6 +116,7 @@ public class ServerClientHandshakeManager {
             throw new ClientHandshakeException("Client " + clientID + " connected after startup should have no existing wait contexts.");
           }
         }
+        handshake.getChannel().addAttachment(ManagementTopologyEventCollector.CLIENT_PID_CONST_NAME, handshake.getClientPID(), false);
         sendAckMessageFor(clientID);
       } else if (this.state == State.STARTING) {
         // This is a client reconnecting after a restart.

--- a/tc-messaging/src/main/java/com/tc/object/msg/ClientHandshakeMessage.java
+++ b/tc-messaging/src/main/java/com/tc/object/msg/ClientHandshakeMessage.java
@@ -34,6 +34,10 @@ public interface ClientHandshakeMessage extends TCMessage {
 
   String getClientVersion();
 
+  void setClientPID(int pid);
+
+  int getClientPID();
+
   void setEnterpriseClient(boolean isEnterpirseClient);
 
   boolean enterpriseClient();

--- a/tc-messaging/src/main/java/com/tc/object/msg/ClientHandshakeMessageImpl.java
+++ b/tc-messaging/src/main/java/com/tc/object/msg/ClientHandshakeMessageImpl.java
@@ -44,11 +44,13 @@ public class ClientHandshakeMessageImpl extends DSOMessageBase implements Client
   private static final byte   LOCAL_TIME_MILLS         = 4;
   private static final byte   RECONNECT_REFERENCES     = 5;
   private static final byte   RESEND_MESSAGES          = 6;
+  private static final byte   CLIENT_PID               = 7;
 
   private final Set<ClientServerExchangeLockContext> lockContexts             = new HashSet<ClientServerExchangeLockContext>();
   private long                currentLocalTimeMills    = System.currentTimeMillis();
   private boolean             enterpriseClient         = false;
-  private String              clientVersion            = "UNKNOW";
+  private String              clientVersion            = "UNKNOWN";
+  private int                 pid                      = -1;
   private final Set<ClientEntityReferenceContext> reconnectReferences = new HashSet<ClientEntityReferenceContext>();
   private final Set<ResendVoltronEntityMessage> resendMessages = new TreeSet<ResendVoltronEntityMessage>(new Comparator<ResendVoltronEntityMessage>() {
     @Override
@@ -75,6 +77,16 @@ public class ClientHandshakeMessageImpl extends DSOMessageBase implements Client
   @Override
   public String getClientVersion() {
     return this.clientVersion;
+  }
+
+  @Override
+  public void setClientPID(int pid) {
+    this.pid = pid;
+  }
+
+  @Override
+  public int getClientPID() {
+    return pid;
   }
 
   @Override
@@ -109,6 +121,7 @@ public class ClientHandshakeMessageImpl extends DSOMessageBase implements Client
     }
     putNVPair(ENTERPRISE_CLIENT, this.enterpriseClient);
     putNVPair(CLIENT_VERSION, this.clientVersion);
+    putNVPair(CLIENT_PID, this.pid);
     putNVPair(LOCAL_TIME_MILLS, this.currentLocalTimeMills);
     for (final ClientEntityReferenceContext referenceContext : this.reconnectReferences) {
       putNVPair(RECONNECT_REFERENCES, referenceContext);
@@ -138,6 +151,9 @@ public class ClientHandshakeMessageImpl extends DSOMessageBase implements Client
         return true;
       case RESEND_MESSAGES:
         this.resendMessages.add(getObject(new ResendVoltronEntityMessage()));
+        return true;
+      case CLIENT_PID:
+        this.pid = getIntValue();
         return true;
       default:
         return false;


### PR DESCRIPTION
1. Follow API changes in Terracotta-OSS/terracotta-apis#47
2. Add Client PID to ClientHandshakeMessage and send it during handshake 
3. API change for ITopologyEventCollector.clientDidFetchEntity to include ClientDescriptor 
4. Add corresponding unit tests 