### PR TITLE
Fix #42: Created IEntityMessenger implementation and basic support

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -195,6 +195,7 @@ import com.tc.server.ServerConnectionValidator;
 import com.tc.server.TCServer;
 import com.tc.services.CommunicatorResponseHandler;
 import com.tc.services.CommunicatorService;
+import com.tc.services.EntityMessengerProvider;
 import com.tc.services.TerracottaServiceProviderRegistry;
 import com.tc.services.TerracottaServiceProviderRegistryImpl;
 import com.tc.stats.counter.CounterManager;
@@ -627,6 +628,10 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
     EntityManagerImpl entityManager = new EntityManagerImpl(this.serviceRegistry, clientEntityStateManager, eventCollector, processor, this::sendNoop);
     channelManager.addEventListener(clientEntityStateManager);
     processTransactionHandler.setLateBoundComponents(channelManager, entityManager);
+    
+    // We need to connect the IInterEntityMessengerProvider to the voltronMessageSink.
+    final EntityMessengerProvider messengerProvider = new EntityMessengerProvider(voltronMessageSink);
+    this.serviceRegistry.registerBuiltin(messengerProvider);
     
     // If we are running in a restartable mode, instantiate any entities in storage.
     if (restartable) {

--- a/dso-l2/src/main/java/com/tc/services/EntityMessengerProvider.java
+++ b/dso-l2/src/main/java/com/tc/services/EntityMessengerProvider.java
@@ -1,0 +1,58 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.services;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.terracotta.entity.IEntityMessenger;
+import org.terracotta.entity.ServiceConfiguration;
+import org.terracotta.entity.ServiceProviderCleanupException;
+
+import com.tc.async.api.Sink;
+import com.tc.entity.VoltronEntityMessage;
+import com.tc.objectserver.api.ManagedEntity;
+
+
+/**
+ * The built-in provider of IEntityMessenger services.
+ * These messages are fed into the general VoltronEntityMessage sink, provided by the server implementation.
+ */
+public class EntityMessengerProvider implements BuiltInServiceProvider {
+  private final Sink<VoltronEntityMessage> messageSink;
+
+  public EntityMessengerProvider(Sink<VoltronEntityMessage> messageSink) {
+    this.messageSink = messageSink;
+  }
+
+  @Override
+  public <T> T getService(long consumerID, ManagedEntity owningEntity, ServiceConfiguration<T> configuration) {
+    return configuration.getServiceType().cast(new EntityMessengerService(this.messageSink, owningEntity));
+  }
+
+  @Override
+  public Collection<Class<?>> getProvidedServiceTypes() {
+    return Collections.singleton(IEntityMessenger.class);
+  }
+
+  @Override
+  public void clear() throws ServiceProviderCleanupException {
+    // Do nothing.
+  }
+}

--- a/dso-l2/src/main/java/com/tc/services/EntityMessengerService.java
+++ b/dso-l2/src/main/java/com/tc/services/EntityMessengerService.java
@@ -1,0 +1,105 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.services;
+
+import org.terracotta.entity.EntityMessage;
+import org.terracotta.entity.IEntityMessenger;
+import org.terracotta.entity.MessageCodec;
+import org.terracotta.entity.MessageCodecException;
+
+import com.tc.async.api.Sink;
+import com.tc.entity.VoltronEntityMessage;
+import com.tc.net.ClientID;
+import com.tc.object.ClientInstanceID;
+import com.tc.object.EntityDescriptor;
+import com.tc.object.tx.TransactionID;
+import com.tc.objectserver.api.ManagedEntity;
+
+
+/**
+ * Implements the IEntityMessenger interface by maintaining a "fake" EntityDescriptor (as there is no actual reference from
+ * a client) and using that to send "fake" VoltronEntityMessage instances into the server's message sink.
+ */
+public class EntityMessengerService implements IEntityMessenger {
+  private final Sink<VoltronEntityMessage> messageSink;
+  private final MessageCodec<EntityMessage, ?> codec;
+  private final EntityDescriptor fakeDescriptor;
+
+  @SuppressWarnings("unchecked")
+  public EntityMessengerService(Sink<VoltronEntityMessage> messageSink, ManagedEntity owningEntity) {
+    this.messageSink = messageSink;
+    // Note that the codec will actually expect to work on a sub-type of EntityMessage but this service isn't explicitly
+    // given the actual type.  This means that incorrect usage will result in a runtime failure.
+    this.codec = (MessageCodec<EntityMessage, ?>) owningEntity.getCodec();
+    
+    ClientInstanceID clientInstanceID = null;
+    this.fakeDescriptor = new EntityDescriptor(owningEntity.getID(), clientInstanceID, owningEntity.getVersion());
+  }
+
+  @Override
+  public void messageSelf(EntityMessage message) throws MessageCodecException {
+    // We first serialize the message (note that this is partially so we can use the common message processor, which expects
+    // to deserialize, but also because we may have to replicate the message to the passive).
+    byte[] serializedMessage = this.codec.encodeMessage(message);
+    FakeEntityMessage interEntityMessage = new FakeEntityMessage(this.fakeDescriptor, serializedMessage);
+    this.messageSink.addSingleThreaded(interEntityMessage);
+  }
+
+
+  /**
+   * We fake up a Voltron entity message to enqueue for the entity to process in the future.
+   */
+  private static class FakeEntityMessage implements VoltronEntityMessage {
+    private final EntityDescriptor descriptor;
+    private final byte[] message;
+
+    public FakeEntityMessage(EntityDescriptor descriptor, byte[] message) {
+      this.descriptor = descriptor;
+      this.message = message;
+    }
+    @Override
+    public ClientID getSource() {
+      return null;
+    }
+    @Override
+    public TransactionID getTransactionID() {
+      return null;
+    }
+    @Override
+    public EntityDescriptor getEntityDescriptor() {
+      return this.descriptor;
+    }
+    @Override
+    public boolean doesRequireReplication() {
+      return true;
+    }
+    @Override
+    public Type getVoltronType() {
+      return Type.INVOKE_ACTION;
+    }
+    @Override
+    public byte[] getExtendedData() {
+      return this.message;
+    }
+    @Override
+    public TransactionID getOldestTransactionOnClient() {
+      return null;
+    }
+  }
+}

--- a/dso-l2/src/test/java/com/tc/services/EntityMessengerProviderTest.java
+++ b/dso-l2/src/test/java/com/tc/services/EntityMessengerProviderTest.java
@@ -1,0 +1,84 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.services;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.terracotta.entity.EntityMessage;
+import org.terracotta.entity.EntityResponse;
+import org.terracotta.entity.IEntityMessenger;
+import org.terracotta.entity.MessageCodec;
+import org.terracotta.entity.ServiceConfiguration;
+
+import com.tc.async.api.Sink;
+import com.tc.entity.VoltronEntityMessage;
+import com.tc.objectserver.api.ManagedEntity;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+public class EntityMessengerProviderTest {
+  private Sink<VoltronEntityMessage> messageSink;
+  private long consumerID;
+  private MessageCodec<EntityMessage, EntityResponse> messageCodec;
+  private ManagedEntity owningEntity;
+  private ServiceConfiguration<IEntityMessenger> configuration;
+
+  private EntityMessengerProvider entityMessengerProvider;
+
+
+  // Suppress warnings about mock assignments not having the right generics.
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  @Before
+  public void setUp() throws Exception {
+    // Build the underlying components needed by the provider or common to tests.
+    this.messageSink = mock(Sink.class);
+    this.consumerID = 1;
+    this.messageCodec = mock(MessageCodec.class);
+    this.owningEntity = mock(ManagedEntity.class);
+    when(this.owningEntity.getCodec()).thenReturn((MessageCodec)this.messageCodec);
+    this.configuration = mock(ServiceConfiguration.class);
+    when(this.configuration.getServiceType()).thenReturn(IEntityMessenger.class);
+    
+    // Build the test subject.
+    this.entityMessengerProvider = new EntityMessengerProvider(this.messageSink);
+  }
+
+  @Test
+  public void testBuildServiceOnly() throws Exception {
+    IEntityMessenger service = this.entityMessengerProvider.getService(this.consumerID, this.owningEntity, this.configuration);
+    Assert.assertNotNull(service);
+  }
+
+  @Test
+  public void testSendSimpleMessage() throws Exception {
+    IEntityMessenger service = this.entityMessengerProvider.getService(this.consumerID, this.owningEntity, this.configuration);
+    EntityMessage message = mock(EntityMessage.class);
+    
+    service.messageSelf(message);
+    
+    // Verify the calls we observed.
+    verify(this.messageCodec).encodeMessage(message);
+    verify(this.messageSink).addSingleThreaded(any(VoltronEntityMessage.class));
+  }
+}


### PR DESCRIPTION
-provided via the built-in provider: EntityMessengerProvider
-DistributedObjectServer initializes this with the same message sink used by incoming network entity messages
-note that the "fake" messages enqueued by this service can be identified via their null source node.  ProcessTransactionHandler uses this to ensure that it doesn't persist the order of these messages (since they can't be re-sent as they originate internally)
-also added a simple unit test starting-point