### PR TITLE
Fix #168: Use NULL_ID singletons instead of null for synthetic message fields

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
@@ -28,6 +28,7 @@ import com.tc.logging.TCLogging;
 import com.tc.net.ClientID;
 import com.tc.net.NodeID;
 import com.tc.net.protocol.tcm.MessageChannel;
+import com.tc.object.ClientInstanceID;
 import com.tc.object.EntityDescriptor;
 import com.tc.object.EntityID;
 import com.tc.object.net.DSOChannelManager;
@@ -175,8 +176,9 @@ public class ProcessTransactionHandler {
     // In the general case, however, we need to pass this as a real ServerEntityRequest, into the entityProcessor.
     ServerEntityRequest serverEntityRequest = new ServerEntityRequestImpl(descriptor, action, transactionID, oldestTransactionOnClient, sourceNodeID, doesRequireReplication, safeGetChannel(sourceNodeID));
     // Before we pass this on to the entity or complete it, directly, we can send the received() ACK, since we now know the message order.
-    // (Note that synthetic messages have a null sourceNodeID)
-    if (null != sourceNodeID) {
+    // Note that we only want to persist the messages with a true sourceNodeID.  Synthetic invocations and sync messages
+    // don't have one (although sync messages shouldn't come down this path).
+    if (!ClientInstanceID.NULL_ID.equals(sourceNodeID)) {
       if (null != oldestTransactionOnClient) {
         // This client still needs transaction order persistence.
         this.transactionOrderPersistor.updateWithNewMessage(sourceNodeID, transactionID, oldestTransactionOnClient);

--- a/dso-l2/src/main/java/com/tc/services/EntityMessengerService.java
+++ b/dso-l2/src/main/java/com/tc/services/EntityMessengerService.java
@@ -48,8 +48,7 @@ public class EntityMessengerService implements IEntityMessenger {
     // given the actual type.  This means that incorrect usage will result in a runtime failure.
     this.codec = (MessageCodec<EntityMessage, ?>) owningEntity.getCodec();
     
-    ClientInstanceID clientInstanceID = null;
-    this.fakeDescriptor = new EntityDescriptor(owningEntity.getID(), clientInstanceID, owningEntity.getVersion());
+    this.fakeDescriptor = new EntityDescriptor(owningEntity.getID(), ClientInstanceID.NULL_ID, owningEntity.getVersion());
   }
 
   @Override
@@ -75,11 +74,11 @@ public class EntityMessengerService implements IEntityMessenger {
     }
     @Override
     public ClientID getSource() {
-      return null;
+      return ClientID.NULL_ID;
     }
     @Override
     public TransactionID getTransactionID() {
-      return null;
+      return TransactionID.NULL_ID;
     }
     @Override
     public EntityDescriptor getEntityDescriptor() {
@@ -99,7 +98,7 @@ public class EntityMessengerService implements IEntityMessenger {
     }
     @Override
     public TransactionID getOldestTransactionOnClient() {
-      return null;
+      return TransactionID.NULL_ID;
     }
   }
 }


### PR DESCRIPTION
-using nulls, directly, causes issues for serialization/deserialization
-these NULL_ID singletons can still be used for logical decisions around how to apply the synthetic messages
-also added the check to ReplicatedTransactionHandler to not persist the synthetic messages