### PR TITLE
Update to account for EndpointDelegate API change

### DIFF
--- a/dso-l1/src/main/java/com/tc/object/ClientEntityManagerImpl.java
+++ b/dso-l1/src/main/java/com/tc/object/ClientEntityManagerImpl.java
@@ -30,6 +30,7 @@ import org.terracotta.entity.InvokeFuture;
 import org.terracotta.entity.MessageCodec;
 import org.terracotta.entity.EntityMessage;
 import org.terracotta.entity.EntityResponse;
+import org.terracotta.entity.MessageCodecException;
 import org.terracotta.exception.EntityException;
 
 import com.tc.entity.NetworkVoltronEntityMessage;
@@ -145,7 +146,13 @@ public class ClientEntityManagerImpl implements ClientEntityManager {
     EntityClientEndpoint endpoint = this.objectStoreMap.get(entityDescriptor);
     if (endpoint != null) {
       EntityClientEndpointImpl endpointImpl = (EntityClientEndpointImpl) endpoint;
-      endpointImpl.handleMessage(message);
+      try {
+        endpointImpl.handleMessage(message);
+      } catch (MessageCodecException e) {
+        // For now (at least), we will fail on this codec exception since it indicates a serious bug in the entity
+        // implementation.
+        Assert.fail(e.getLocalizedMessage());
+      }
     } else {
       logger.info("Entity " + entityDescriptor + " not found. Ignoring message.");
     }

--- a/dso-l1/src/main/java/com/tc/object/EntityClientEndpointImpl.java
+++ b/dso-l1/src/main/java/com/tc/object/EntityClientEndpointImpl.java
@@ -79,11 +79,12 @@ public class EntityClientEndpointImpl<M extends EntityMessage, R extends EntityR
     this.delegate = delegate;
   }
   
-  public void handleMessage(byte[] message) {
+  public void handleMessage(byte[] message) throws MessageCodecException {
     // We technically allow messages to come back from the server, after we are closed, simple because it means that the
     // server hasn't yet handled the close.
     if (null != this.delegate) {
-      this.delegate.handleMessage(message);
+      R messageFromServer = this.codec.decodeResponse(message);
+      this.delegate.handleMessage(messageFromServer);
     }
   }
 

--- a/dso-l1/src/main/java/com/tc/object/EntityClientEndpointImpl.java
+++ b/dso-l1/src/main/java/com/tc/object/EntityClientEndpointImpl.java
@@ -88,7 +88,7 @@ public class EntityClientEndpointImpl<M extends EntityMessage, R extends EntityR
   }
 
   @Override
-  public InvocationBuilder beginInvoke() {
+  public InvocationBuilder<M, R> beginInvoke() {
     // We can't create new invocations when the endpoint is closed.
     checkEndpointOpen();
     return new InvocationBuilderImpl();
@@ -110,25 +110,25 @@ public class EntityClientEndpointImpl<M extends EntityMessage, R extends EntityR
     }
 
     @Override
-    public InvocationBuilder ackSent() {
+    public InvocationBuilder<M, R> ackSent() {
       acks.add(VoltronEntityMessage.Acks.SENT);
       return this;
     }
 
     @Override
-    public InvocationBuilder ackReceived() {
+    public InvocationBuilder<M, R> ackReceived() {
       acks.add(VoltronEntityMessage.Acks.RECEIVED);
       return this;
     }
 
     @Override
-    public InvocationBuilder ackCompleted() {
+    public InvocationBuilder<M, R> ackCompleted() {
       acks.add(VoltronEntityMessage.Acks.APPLIED);
       return this;
     }
 
     @Override
-    public InvocationBuilder replicate(boolean requiresReplication) {
+    public InvocationBuilder<M, R> replicate(boolean requiresReplication) {
       this.requiresReplication = requiresReplication;
       return this;
     }


### PR DESCRIPTION
-EndpointDelegate.handleMessage() now takes EntityResponse instead of byte[]

**Note:**  This depends on Terracotta-OSS/terracotta-apis#78