### PR TITLE
Active-passive parallel invoke support

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ActivePassiveAckWaiter.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ActivePassiveAckWaiter.java
@@ -1,0 +1,79 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.objectserver.entity;
+
+import com.tc.net.NodeID;
+import com.tc.util.Assert;
+
+import java.util.HashSet;
+import java.util.Set;
+
+
+/**
+ * This type is used by ActiveToPassiveReplication in order to wait on all the passives either sending a RECEIVED or
+ * COMPLETED acknowledgement for a specific message.
+ */
+public class ActivePassiveAckWaiter {
+  private final Set<NodeID> receivedPending;
+  private final Set<NodeID> completedPending;
+
+  public ActivePassiveAckWaiter(Set<NodeID> allPassiveNodes) {
+    this.receivedPending =  new HashSet<NodeID>(allPassiveNodes);
+    this.completedPending =  new HashSet<NodeID>(allPassiveNodes);
+  }
+
+  public synchronized void waitForReceived() throws InterruptedException {
+    while (!this.receivedPending.isEmpty()) {
+      wait();
+    }
+  }
+
+  public synchronized void waitForCompleted() throws InterruptedException {
+    while (!this.completedPending.isEmpty()) {
+      wait();
+    }
+  }
+
+  public synchronized boolean isCompleted() {
+    return this.completedPending.isEmpty();
+  }
+
+  public synchronized void didReceiveOnPassive(NodeID onePassive) {
+    boolean didContain = this.receivedPending.remove(onePassive);
+    // We must have contained this passive in order to receive.
+    Assert.assertTrue(didContain);
+    // Wake everyone up if this changed something.
+    if (this.receivedPending.isEmpty()) {
+      notifyAll();
+    }
+  }
+
+  public synchronized void didCompleteOnPassive(NodeID onePassive) {
+    // Note that we will try to remove from the received set, but usually it will already have been removed.
+    boolean didContainInReceived = this.receivedPending.remove(onePassive);
+    // We know that it must still be in the completed set, though.
+    boolean didContainInCompleted = this.completedPending.remove(onePassive);
+    // We must have contained this passive in order to complete.
+    Assert.assertTrue(didContainInCompleted);
+    // Wake everyone up if this changed something.
+    if ((didContainInReceived && this.receivedPending.isEmpty()) || this.completedPending.isEmpty()) {
+      notifyAll();
+    }
+  }
+}

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ActiveToPassiveReplication.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ActiveToPassiveReplication.java
@@ -94,7 +94,7 @@ public class ActiveToPassiveReplication implements PassiveReplicationBroker, Gro
   private boolean prime(NodeID node) {
     if (!passiveNodes.contains(node)) {
       logger.info("Starting message sequence on " + node);
-      ReplicationMessage resetOrderedSink = new ReplicationMessage(ReplicationMessage.START);
+      ReplicationMessage resetOrderedSink = ReplicationMessage.createStartMessage();
       Semaphore block = new Semaphore(0);
       replicate.addSingleThreaded(resetOrderedSink.target(node,()->block.release()));
       waitOnSemaphore(block);

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ActiveToPassiveReplication.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ActiveToPassiveReplication.java
@@ -94,7 +94,7 @@ public class ActiveToPassiveReplication implements PassiveReplicationBroker, Gro
   private boolean prime(NodeID node) {
     if (!passiveNodes.contains(node)) {
       logger.info("Starting message sequence on " + node);
-      ReplicationMessage resetOrderedSink = new ReplicationMessage();
+      ReplicationMessage resetOrderedSink = new ReplicationMessage(ReplicationMessage.START);
       Semaphore block = new Semaphore(0);
       replicate.addSingleThreaded(resetOrderedSink.target(node,()->block.release()));
       waitOnSemaphore(block);

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ActiveToPassiveReplication.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ActiveToPassiveReplication.java
@@ -38,13 +38,10 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+
 
 /**
  *  This class acts to connect {@link ProcessTransactionHandler} to the {@link ReplicationSender}
@@ -60,7 +57,7 @@ public class ActiveToPassiveReplication implements PassiveReplicationBroker, Gro
   private boolean activated = false;
   private final Set<NodeID> passiveNodes = new CopyOnWriteArraySet<>();
   private final Set<NodeID> standByNodes = new HashSet<>();
-  private final ConcurrentHashMap<MessageID, Set<NodeID>> waiters = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<MessageID, ActivePassiveAckWaiter> waiters = new ConcurrentHashMap<>();
   private final Sink<ReplicationEnvelope> replicate;
   private final Executor passiveSyncPool = Executors.newCachedThreadPool();
 
@@ -126,7 +123,7 @@ public class ActiveToPassiveReplication implements PassiveReplicationBroker, Gro
         // start passive sync message
         logger.debug("starting sync for " + newNode);
         try {
-          replicateMessage(PassiveSyncMessage.createStartSyncMessage(), Collections.singleton(newNode)).get();
+          replicateMessage(PassiveSyncMessage.createStartSyncMessage(), Collections.singleton(newNode)).waitForCompleted();
           for (ManagedEntity entity : entities) {
             logger.debug("starting sync for entity " + newNode + "/" + entity.getID());
             entity.sync(newNode);
@@ -134,33 +131,35 @@ public class ActiveToPassiveReplication implements PassiveReplicationBroker, Gro
           }
       //  passive sync done message.  causes passive to go into passive standby mode
           logger.debug("ending sync " + newNode);
-          replicateMessage(PassiveSyncMessage.createEndSyncMessage(), Collections.singleton(newNode)).get();
-        } catch (InterruptedException | ExecutionException e) {
+          replicateMessage(PassiveSyncMessage.createEndSyncMessage(), Collections.singleton(newNode)).waitForCompleted();
+        } catch (InterruptedException e) {
           throw new AssertionError("error during passive sync", e);
         }
       }
     });
   }
 
-  private void acknowledge(MessageID mid, NodeID releaser) {
-    Set<NodeID> plist = waiters.get(mid);
-    if (plist != null) {
-      synchronized(plist) {
-        if (plist.remove(releaser)) {
-          if (plist.isEmpty()) {
-            if (!waiters.remove(mid, plist)) {
-              throwAssertionError();
-            }
-            plist.notifyAll();
-          }
-        }
-      }
+  public void ackReceived(GroupMessage msg) {
+    ActivePassiveAckWaiter waiter = waiters.get(msg.inResponseTo());
+    if (null != waiter) {
+      waiter.didReceiveOnPassive(msg.messageFrom());
     }
-  }    
+  }
 
-  public void acknowledge(GroupMessage msg) {
-    acknowledge(msg.inResponseTo(), msg.messageFrom());
-  }    
+  public void ackCompleted(GroupMessage msg) {
+    internalAckCompleted(msg.inResponseTo(), msg.messageFrom());
+  }
+
+  /**
+   * This internal handling for completed is split out since it happens for both completed acks but also situations which
+   * implies no ack is forthcoming (the passive disappearing, for example).
+   */
+  private void internalAckCompleted(MessageID mid, NodeID passive) {
+    ActivePassiveAckWaiter waiter = waiters.get(mid);
+    if (null != waiter) {
+      waiter.didCompleteOnPassive(passive);
+    }
+  }
 
   @Override
   public Set<NodeID> passives() {
@@ -168,52 +167,18 @@ public class ActiveToPassiveReplication implements PassiveReplicationBroker, Gro
   }
 
   @Override
-  public Future<Void> replicateMessage(ReplicationMessage msg, Set<NodeID> all) {
+  public ActivePassiveAckWaiter replicateMessage(ReplicationMessage msg, Set<NodeID> all) {
     Set<NodeID> copy = new HashSet<>(all); 
 // don't replicate to a passive that is no longer there
     copy.retainAll(passives());
+    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(copy);
     if (!copy.isEmpty()) {
-      waiters.put(msg.getMessageID(), copy);
+      waiters.put(msg.getMessageID(), waiter);
       for (NodeID node : copy) {
-        replicate.addSingleThreaded(msg.target(node, ()->acknowledge(msg.getMessageID(), node)));
+        replicate.addSingleThreaded(msg.target(node, ()->internalAckCompleted(msg.getMessageID(), node)));
       }
     }
-    
-    return new Future<Void>() {
-
-      @Override
-      public boolean cancel(boolean mayInterruptIfRunning) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-      }
-
-      @Override
-      public boolean isCancelled() {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-      }
-
-      @Override
-      public boolean isDone() {
-        synchronized(copy) {
-          return copy.isEmpty();
-        }
-      }
-
-      @Override
-      public Void get() throws InterruptedException, ExecutionException {
-        synchronized (copy) {
-          copy.retainAll(passiveNodes);
-          while (!copy.isEmpty()) {
-            copy.wait();
-          }
-        }
-        return null;
-      }
-
-      @Override
-      public Void get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        throw new UnsupportedOperationException("not implemented");
-      }
-    };
+    return waiter;
   }
 
   public void removePassive(NodeID nodeID) {
@@ -223,7 +188,7 @@ public class ActiveToPassiveReplication implements PassiveReplicationBroker, Gro
 //  acknowledge all the messages for this node because it is gone, this may result in 
 //  a double ack locally but that is ok.  acknowledge is loose and can tolerate it. 
     if (activated) {
-      waiters.forEach((key, value)->acknowledge(key, nodeID));
+      waiters.forEach((key, value)->internalAckCompleted(key, nodeID));
 //  this is a flush message (null).  Tell the sink there will be no more 
 //  messages targeted at this nodeid
       Semaphore block = new Semaphore(0);
@@ -238,11 +203,6 @@ public class ActiveToPassiveReplication implements PassiveReplicationBroker, Gro
     } catch (InterruptedException e) {
       throw new AssertionError(e);
     }
-  }
-  
-  private void throwAssertionError() {
-    throw new AssertionError("an error in the implementation has occurred standby nodes:" 
-        + standByNodes + " passivesNodes:" + passiveNodes);
   }
 
   @Override

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/NoReplicationBroker.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/NoReplicationBroker.java
@@ -23,10 +23,8 @@ import com.tc.net.NodeID;
 import com.tc.util.Assert;
 import java.util.Collections;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+
+
 /**
  * Stubbed implementation which provides no replication.
  */
@@ -34,32 +32,7 @@ public class NoReplicationBroker implements PassiveReplicationBroker {
   
   private boolean isActive = false;
   
-  public static final Future<Void> NOOP_FUTURE = new Future<Void>() {
-      @Override
-      public boolean cancel(boolean mayInterruptIfRunning) {
-        return false;
-      }
-
-      @Override
-      public boolean isCancelled() {
-        return false;
-      }
-
-      @Override
-      public boolean isDone() {
-        return true;
-      }
-
-      @Override
-      public Void get() throws InterruptedException, ExecutionException {
-        return null;
-      }
-
-      @Override
-      public Void get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        return null;
-      }
-  };
+  public static final ActivePassiveAckWaiter NOOP_WAITER = new ActivePassiveAckWaiter(Collections.emptySet());
 
   @Override
   public void enterActiveState() {
@@ -74,7 +47,7 @@ public class NoReplicationBroker implements PassiveReplicationBroker {
   }
 
   @Override
-  public Future<Void> replicateMessage(ReplicationMessage msg, Set<NodeID> passives) {
-    return NOOP_FUTURE;
+  public ActivePassiveAckWaiter replicateMessage(ReplicationMessage msg, Set<NodeID> passives) {
+    return NOOP_WAITER;
   }
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/PassiveReplicationBroker.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/PassiveReplicationBroker.java
@@ -21,10 +21,10 @@ package com.tc.objectserver.entity;
 import com.tc.l2.msg.ReplicationMessage;
 import com.tc.net.NodeID;
 import java.util.Set;
-import java.util.concurrent.Future;
+
 
 public interface PassiveReplicationBroker {
-  Future<Void> replicateMessage(ReplicationMessage msg, Set<NodeID> passives);
+  ActivePassiveAckWaiter replicateMessage(ReplicationMessage msg, Set<NodeID> passives);
   Set<NodeID> passives();
   void enterActiveState();
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
@@ -213,12 +213,13 @@ public class RequestProcessor implements StateChangeListener {
     
     void invoke()  {
       try {
-//  if this lockstep of waiting for passives before executing on actives is changed, make sure exclusive mode
-//  in ManagedEntityImpl is accounted for.  For exclusive mode, ManagedEntityImpl
-//  in passive mode relies on this control flow in the active so that no new messages are 
-//  received on the passive entity before exclusive mode is completed
-        this.replicationWaiter.waitForCompleted();
+        // NOTE:  We want to wait to hear that the passive has received the replicated invoke.
+        this.replicationWaiter.waitForReceived();
+        // We can now run the invoke.
         invoke.run();
+        // Now that we are done, wait for the passive to finish.
+        this.replicationWaiter.waitForCompleted();
+        // We are now completely finished.
         finish();
       } catch (InterruptedException interrupted) {
 //  shutdown logic?  uniterruptable?

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
@@ -156,7 +156,7 @@ public class RequestProcessor implements StateChangeListener {
     }
 //  TODO: Evaluate what to replicate...right now, everything is replicated.  Evaluate whether
 //  NOOP should be replicated.  For now, NOOPs hold ordering
-    return new ReplicationMessage(id, src, tid, oldest, actionCode, payload, concurrency);
+    return ReplicationMessage.createReplicatedMessage(id, src, tid, oldest, actionCode, payload, concurrency);
   }
   
   private static class EntityRequest implements MultiThreadedEventContext, Runnable {

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -224,7 +224,7 @@ public class ReplicatedTransactionHandler {
     moveToPassiveUnitialized(node);
     try {
       LOGGER.info("Requesting Passive Sync from " + node);
-      groupManager.sendTo(node, new ReplicationMessageAck(ReplicationMessage.START));
+      groupManager.sendTo(node, ReplicationMessageAck.createSyncRequestMessage());
     } catch (GroupException ge) {
       LOGGER.warn("can't request passive sync", ge);
     }
@@ -364,7 +364,7 @@ public class ReplicatedTransactionHandler {
         LOGGER.debug("acking " + rep);
       }
       if (!rep.messageFrom().equals(ServerID.NULL_ID)) {
-        groupManager.sendTo(rep.messageFrom(), new ReplicationMessageAck(rep.getMessageID()));
+        groupManager.sendTo(rep.messageFrom(), ReplicationMessageAck.createCompletedAck(rep.getMessageID()));
       }
     } catch (GroupException ge) {
 //  Passive must have died.  Swallow the exception

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -150,6 +150,9 @@ public class ReplicatedTransactionHandler {
     TransactionID transactionID = rep.getTransactionID();
     TransactionID oldestTransactionOnClient = rep.getOldestTransactionOnClient();
 
+    // Send the RECEIVED ack before we run this.
+    ackReceived(rep);
+    
     // Note that we only want to persist the messages with a true sourceNodeID.  Synthetic invocations and sync messages
     // don't have one (although sync messages shouldn't come down this path).
     if (!ClientInstanceID.NULL_ID.equals(sourceNodeID)) {
@@ -355,19 +358,33 @@ public class ReplicatedTransactionHandler {
           rep.getTransactionID(), rep.getOldestTransactionOnClient(), rep.getSource(), false, ()->acknowledge(rep));
     }
   }
-  
+
+  private void ackReceived(ReplicationMessage rep) {
+    try {
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("acking(received) " + rep);
+      }
+      if (!rep.messageFrom().equals(ServerID.NULL_ID)) {
+        groupManager.sendTo(rep.messageFrom(), ReplicationMessageAck.createReceivedAck(rep.getMessageID()));
+      }
+    } catch (GroupException ge) {
+      // Active must have died.  Swallow the exception after logging.
+      LOGGER.warn("active died on received ack", ge);
+    }
+  }
+
   private void acknowledge(ReplicationMessage rep) {
 //  when is the right time to send the ack?
     try {
       if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug("acking " + rep);
+        LOGGER.debug("acking(completed) " + rep);
       }
       if (!rep.messageFrom().equals(ServerID.NULL_ID)) {
         groupManager.sendTo(rep.messageFrom(), ReplicationMessageAck.createCompletedAck(rep.getMessageID()));
       }
     } catch (GroupException ge) {
-//  Passive must have died.  Swallow the exception
-      LOGGER.info("active died on ack", ge);
+      // Active must have died.  Swallow the exception after logging.
+      LOGGER.warn("active died on ack", ge);
     }
   }
 

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -138,7 +138,6 @@ public class ReplicatedTransactionHandler {
         }
         break;
       case ReplicationMessage.START:
-      case ReplicationMessage.RESPONSE:
         throw new AssertionError("unexpected message type " + rep);
       default:
         // This is an unexpected replicated message type.

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicationSender.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicationSender.java
@@ -159,8 +159,7 @@ public class ReplicationSender extends AbstractEventHandler<ReplicationEnvelope>
   }
   
   private boolean shouldReplicate(ReplicationMessage msg) {
-    if (msg.getType() == ReplicationMessage.START ||
-        msg.getType() == ReplicationMessage.RESPONSE) {
+    if (msg.getType() == ReplicationMessage.START) {
 //  these types of messages are incoming types or internal server use, not outgoing
       throw new AssertionError("unexpected message type " + msg);
     }

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -727,6 +727,9 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
           @Override
           public void handleEvent(ReplicationMessageAck context) throws EventHandlerException {
             switch (context.getType()) {
+              case ReplicationMessageAck.RECEIVED:
+                // TODO:  Implement support for received act in ActiveToPassiveReplication.
+                break;
               case ReplicationMessageAck.COMPLETED:
             passives.acknowledge(context);
                 break;

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -727,10 +727,10 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
           @Override
           public void handleEvent(ReplicationMessageAck context) throws EventHandlerException {
             switch (context.getType()) {
-              case ReplicationMessage.RESPONSE:
+              case ReplicationMessageAck.COMPLETED:
             passives.acknowledge(context);
                 break;
-              case ReplicationMessage.START:
+              case ReplicationMessageAck.START_SYNC:
                 passives.startPassiveSync(context.messageFrom());
                 break;
               default:

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -159,7 +159,6 @@ import com.tc.object.net.DSOChannelManagerImpl;
 import com.tc.object.net.DSOChannelManagerMBean;
 import com.tc.object.session.NullSessionManager;
 import com.tc.object.session.SessionManager;
-import com.tc.object.tx.TransactionID;
 import com.tc.objectserver.context.NodeStateEventContext;
 import com.tc.objectserver.core.api.GlobalServerStatsImpl;
 import com.tc.objectserver.core.api.ITopologyEventCollector;
@@ -728,10 +727,10 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
           public void handleEvent(ReplicationMessageAck context) throws EventHandlerException {
             switch (context.getType()) {
               case ReplicationMessageAck.RECEIVED:
-                // TODO:  Implement support for received act in ActiveToPassiveReplication.
+                passives.ackReceived(context);
                 break;
               case ReplicationMessageAck.COMPLETED:
-            passives.acknowledge(context);
+                passives.ackCompleted(context);
                 break;
               case ReplicationMessageAck.START_SYNC:
                 passives.startPassiveSync(context.messageFrom());

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -863,7 +863,7 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
       try {
         this.seda.getStageManager()
             .getStage(ServerConfigurationContext.PASSIVE_REPLICATION_STAGE, ReplicationMessage.class)
-            .getSink().addSingleThreaded(new ReplicationMessage(new EntityDescriptor(eid, ClientInstanceID.NULL_ID, version), ClientID.NULL_ID, TransactionID.NULL_ID, TransactionID.NULL_ID, ReplicationMessage.ReplicationType.NOOP, new byte[0], 0));
+            .getSink().addSingleThreaded(ReplicationMessage.createNoOpMessage(eid, version));
         return;
       } catch (IllegalStateException state) {
 //  ignore, could have transitioned to active before message got added

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ActivePassiveAckWaiterTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ActivePassiveAckWaiterTest.java
@@ -1,0 +1,212 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.objectserver.entity;
+
+import com.tc.net.NodeID;
+import com.tc.util.Assert;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+
+public class ActivePassiveAckWaiterTest {
+  /**
+   * Test that we can handle the degenerate case of an empty waiter.
+   */
+  @Test
+  public void testEmptyWait() throws Exception {
+    Set<NodeID> passives = Collections.emptySet();
+    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives);
+    // This can run in a single thread.
+    Assert.assertTrue(waiter.isCompleted());
+    waiter.waitForReceived();
+    waiter.waitForCompleted();
+    Assert.assertTrue(waiter.isCompleted());
+  }
+
+  @Test
+  public void testSingleWait() throws Exception {
+    Set<NodeID> passives = new HashSet<NodeID>();
+    NodeID onePassive = mock(NodeID.class);
+    passives.add(onePassive);
+    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives);
+    Interlock interlock = new Interlock(1);
+    LockStep lockStep = new LockStep(waiter, interlock);
+    lockStep.start();
+    interlock.waitOnStarts();
+    waiter.didReceiveOnPassive(onePassive);
+    interlock.waitOnReceivesOnly();
+    waiter.didCompleteOnPassive(onePassive);
+    interlock.waitOnCompletes();
+    lockStep.join();
+  }
+
+  @Test
+  public void testMultiWait() throws Exception {
+    Set<NodeID> passives = new HashSet<NodeID>();
+    NodeID onePassive = mock(NodeID.class);
+    passives.add(onePassive);
+    NodeID twoPassive = mock(NodeID.class);
+    passives.add(twoPassive);
+    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives);
+    Interlock interlock = new Interlock(1);
+    LockStep lockStep = new LockStep(waiter, interlock);
+    lockStep.start();
+    interlock.waitOnStarts();
+    waiter.didReceiveOnPassive(onePassive);
+    waiter.didReceiveOnPassive(twoPassive);
+    interlock.waitOnReceivesOnly();
+    waiter.didCompleteOnPassive(twoPassive);
+    waiter.didCompleteOnPassive(onePassive);
+    interlock.waitOnCompletes();
+    lockStep.join();
+  }
+
+  @Test
+  public void testMultiWaitWithMoreThreads() throws Exception {
+    Set<NodeID> passives = new HashSet<NodeID>();
+    NodeID onePassive = mock(NodeID.class);
+    passives.add(onePassive);
+    NodeID twoPassive = mock(NodeID.class);
+    passives.add(twoPassive);
+    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives);
+    Interlock interlock = new Interlock(2);
+    LockStep lockStep1 = new LockStep(waiter, interlock);
+    LockStep lockStep2 = new LockStep(waiter, interlock);
+    lockStep1.start();
+    lockStep2.start();
+    interlock.waitOnStarts();
+    waiter.didReceiveOnPassive(onePassive);
+    waiter.didReceiveOnPassive(twoPassive);
+    interlock.waitOnReceivesOnly();
+    waiter.didCompleteOnPassive(twoPassive);
+    waiter.didCompleteOnPassive(onePassive);
+    interlock.waitOnCompletes();
+    lockStep1.join();
+    lockStep2.join();
+  }
+
+  @Test
+  public void testImplicitReceive() throws Exception {
+    Set<NodeID> passives = new HashSet<NodeID>();
+    NodeID onePassive = mock(NodeID.class);
+    passives.add(onePassive);
+    NodeID twoPassive = mock(NodeID.class);
+    passives.add(twoPassive);
+    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives);
+    Interlock interlock = new Interlock(1);
+    LockStep lockStep = new LockStep(waiter, interlock);
+    lockStep.start();
+    interlock.waitOnStarts();
+    waiter.didCompleteOnPassive(twoPassive);
+    waiter.didCompleteOnPassive(onePassive);
+    interlock.waitOnCompletes();
+    lockStep.join();
+  }
+
+
+  private static class LockStep extends Thread {
+    private final ActivePassiveAckWaiter waiter;
+    private final Interlock interlock;
+    
+    public LockStep(ActivePassiveAckWaiter waiter, Interlock interlock) {
+      this.waiter = waiter;
+      this.interlock = interlock;
+    }
+    @Override
+    public void run() {
+      Assert.assertFalse(this.waiter.isCompleted());
+      try {
+        this.interlock.decrementStarts();
+        this.waiter.waitForReceived();
+        this.interlock.decrementReceives();
+        this.waiter.waitForCompleted();
+      } catch (InterruptedException e) {
+        Assert.fail();
+      }
+      this.interlock.decrementCompletes();
+      Assert.assertTrue(this.waiter.isCompleted());
+    }
+  }
+
+
+  private static class Interlock {
+    private final int observerThreadCount;
+    private int pendingStarts;
+    private int pendingReceives;
+    private int pendingCompletes;
+    
+    public Interlock(int observerThreadCount) {
+      this.observerThreadCount = observerThreadCount;
+      this.pendingStarts = observerThreadCount;
+      this.pendingReceives = observerThreadCount;
+      this.pendingCompletes = observerThreadCount;
+    }
+    
+    public synchronized void decrementStarts() {
+      this.pendingStarts -= 1;
+      if (0 == this.pendingStarts) {
+        notifyAll();
+      }
+    }
+    
+    public synchronized void decrementReceives() {
+      this.pendingReceives -= 1;
+      Assert.assertTrue(this.pendingReceives >= 0);
+      if (0 == this.pendingReceives) {
+        notifyAll();
+      }
+    }
+    
+    public synchronized void decrementCompletes() {
+      this.pendingCompletes -= 1;
+      Assert.assertTrue(this.pendingCompletes >= 0);
+      if (0 == this.pendingCompletes) {
+        notifyAll();
+      }
+    }
+    
+    public synchronized void waitOnStarts() throws InterruptedException {
+      while (this.pendingStarts > 0) {
+        wait();
+      }
+    }
+    
+    public synchronized void waitOnReceivesOnly() throws InterruptedException {
+      while (this.pendingReceives > 0) {
+        Assert.assertTrue(this.observerThreadCount == this.pendingCompletes);
+        wait();
+      }
+      Assert.assertTrue(this.observerThreadCount == this.pendingCompletes);
+    }
+    
+    public synchronized void waitOnCompletes() throws InterruptedException {
+      while (this.pendingCompletes > 0) {
+        Assert.assertTrue(this.pendingCompletes >= this.pendingReceives);
+        wait();
+      }
+      Assert.assertTrue(0 == this.pendingReceives);
+    }
+  }
+}

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/RequestProcessorTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/RequestProcessorTest.java
@@ -179,7 +179,7 @@ public class RequestProcessorTest {
 
     PassiveReplicationBroker broker = mock(PassiveReplicationBroker.class);
     when(broker.passives()).thenReturn(Collections.singleton(mock(NodeID.class)));
-    when(broker.replicateMessage(Matchers.any(), Matchers.any())).thenReturn(NoReplicationBroker.NOOP_FUTURE);
+    when(broker.replicateMessage(Matchers.any(), Matchers.any())).thenReturn(NoReplicationBroker.NOOP_WAITER);
     RequestProcessor instance = new RequestProcessor(dump);
     instance.setReplication(broker);
     

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
@@ -287,7 +287,7 @@ public class ReplicatedTransactionHandlerTest {
   }
   
   private ReplicationMessage createMockReplicationMessage(EntityID eid, long VERSION, byte[] payload, int concurrency) {
-    return new ReplicationMessage(new EntityDescriptor(eid, ClientInstanceID.NULL_ID, VERSION), 
+    return ReplicationMessage.createReplicatedMessage(new EntityDescriptor(eid, ClientInstanceID.NULL_ID, VERSION), 
         source, TransactionID.NULL_ID, TransactionID.NULL_ID, ReplicationMessage.ReplicationType.INVOKE_ACTION, payload, concurrency);
   }
 

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
@@ -139,7 +139,8 @@ public class ReplicatedTransactionHandlerTest {
     this.loopbackSink.addSingleThreaded(PassiveSyncMessage.createEndSyncMessage());
 
     verify(entity).addInvokeRequest(Matchers.any(), Matchers.any(), Matchers.eq(rand));
-    verify(groupManager).sendTo(Matchers.eq(sid), Matchers.any());
+    // Note that we want to verify 2 ACK messages:  RECEIVED and COMPLETED.
+    verify(groupManager, times(2)).sendTo(Matchers.eq(sid), Matchers.any());
   }  
   
   @Test
@@ -166,7 +167,8 @@ public class ReplicatedTransactionHandlerTest {
     this.loopbackSink.addSingleThreaded(PassiveSyncMessage.createEndSyncMessage());
     this.loopbackSink.addSingleThreaded(msg);
     verify(entity).addInvokeRequest(Matchers.any(), Matchers.any(), Matchers.eq(rand));
-    verify(groupManager).sendTo(Matchers.eq(sid), Matchers.any());
+    // Note that we want to verify 2 ACK messages:  RECEIVED and COMPLETED.
+    verify(groupManager, times(2)).sendTo(Matchers.eq(sid), Matchers.any());
   }
   
   @Test

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicationSenderTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicationSenderTest.java
@@ -87,10 +87,6 @@ public class ReplicationSenderTest {
     });
   }
   
-  private ReplicationMessage makeMessage(int type) {
-    return new ReplicationMessage(type);
-  }
-    
   private ReplicationMessage makeMessage(ReplicationType type) {
     switch (type) {
       case CREATE_ENTITY:
@@ -100,7 +96,7 @@ public class ReplicationSenderTest {
       case NOOP:
       case RECONFIGURE_ENTITY:
       case RELEASE_ENTITY:
-        return new ReplicationMessage(new EntityDescriptor(entity, ClientInstanceID.NULL_ID, 1), ClientID.NULL_ID, TransactionID.NULL_ID, TransactionID.NULL_ID, type, new byte[0], 0);
+        return ReplicationMessage.createReplicatedMessage(new EntityDescriptor(entity, ClientInstanceID.NULL_ID, 1), ClientID.NULL_ID, TransactionID.NULL_ID, TransactionID.NULL_ID, type, new byte[0], 0);
       case SYNC_BEGIN:
         return PassiveSyncMessage.createStartSyncMessage();
       case SYNC_END:
@@ -130,7 +126,7 @@ public class ReplicationSenderTest {
     entity = new EntityID("TEST", "test");
     List<ReplicationMessage> origin = new LinkedList<>();
     List<ReplicationMessage> validation = new LinkedList<>();
-    buildTest(origin, validation, makeMessage(ReplicationMessage.START), true);
+    buildTest(origin, validation, ReplicationMessage.createStartMessage(), true);
     buildTest(origin, validation, makeMessage(ReplicationType.NOOP), true);
     buildTest(origin, validation, makeMessage(ReplicationType.NOOP), true);
     buildTest(origin, validation, makeMessage(ReplicationType.SYNC_BEGIN), false);
@@ -167,7 +163,7 @@ public class ReplicationSenderTest {
     entity = new EntityID("TEST", "test");
     List<ReplicationMessage> origin = new LinkedList<>();
     List<ReplicationMessage> validation = new LinkedList<>();
-    buildTest(origin, validation, makeMessage(ReplicationMessage.START), true);
+    buildTest(origin, validation, ReplicationMessage.createStartMessage(), true);
     buildTest(origin, validation, makeMessage(ReplicationType.NOOP), true);
     buildTest(origin, validation, makeMessage(ReplicationType.NOOP), true);
     buildTest(origin, validation, makeMessage(ReplicationType.SYNC_BEGIN), false);
@@ -204,7 +200,7 @@ public class ReplicationSenderTest {
     entity = new EntityID("TEST", "test");
     List<ReplicationMessage> origin = new LinkedList<>();
     List<ReplicationMessage> validation = new LinkedList<>();
-    buildTest(origin, validation, makeMessage(ReplicationMessage.START), true);
+    buildTest(origin, validation, ReplicationMessage.createStartMessage(), true);
     buildTest(origin, validation, makeMessage(ReplicationType.NOOP), true);
     buildTest(origin, validation, makeMessage(ReplicationType.NOOP), true);
     buildTest(origin, validation, makeMessage(ReplicationType.CREATE_ENTITY), false);

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
@@ -61,6 +61,21 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
     SYNC_ENTITY_CONCURRENCY_END;
   }
   
+  // Factory methods.
+  public static ReplicationMessage createStartMessage() {
+    return new ReplicationMessage(START);
+  }
+
+  public static ReplicationMessage createNoOpMessage(EntityID eid, long version) {
+    return new ReplicationMessage(new EntityDescriptor(eid, ClientInstanceID.NULL_ID, version), ClientID.NULL_ID, TransactionID.NULL_ID, TransactionID.NULL_ID, ReplicationMessage.ReplicationType.NOOP, new byte[0], 0);
+  }
+
+  public static ReplicationMessage createReplicatedMessage(EntityDescriptor descriptor, ClientID src, 
+      TransactionID tid, TransactionID oldest, 
+      ReplicationType action, byte[] payload, int concurrency) {
+    return new ReplicationMessage(descriptor, src, tid, oldest, action, payload, concurrency);
+  }
+
   EntityDescriptor descriptor;
     
   ClientID src;
@@ -79,15 +94,15 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
     
   }
   
-  public ReplicationMessage(int type) {
+  protected ReplicationMessage(int type) {
     super(type);
   }
   
-  public ReplicationMessage(MessageID mid) {
+  protected ReplicationMessage(MessageID mid) {
     super(RESPONSE, mid);
   }  
 //  a true replicated message
-  public ReplicationMessage(EntityDescriptor descriptor, ClientID src, 
+  private ReplicationMessage(EntityDescriptor descriptor, ClientID src, 
       TransactionID tid, TransactionID oldest, 
       ReplicationType action, byte[] payload, int concurrency) {
     super(action.ordinal() >= ReplicationType.SYNC_BEGIN.ordinal() ? SYNC : REPLICATE);

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
@@ -24,7 +24,6 @@ import com.tc.io.TCByteBufferOutput;
 import com.tc.net.ClientID;
 import com.tc.net.NodeID;
 import com.tc.net.groups.AbstractGroupMessage;
-import com.tc.net.groups.MessageID;
 import com.tc.object.ClientInstanceID;
 import com.tc.object.EntityDescriptor;
 import com.tc.object.EntityID;
@@ -40,8 +39,7 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
   public static final int INVALID               = 0; // Sent to replicate a request on the passive
   public static final int REPLICATE               = 1; // Sent to replicate a request on the passive
   public static final int SYNC               = 2; // Sent to replicate a request on the passive
-  public static final int RESPONSE                = 3; // response that the replicated action completed
-  public static final int START                = 4; // response that the replicated action completed
+  public static final int START                = 3; // response that the replicated action completed
 
   public enum ReplicationType {
     NOOP,
@@ -98,9 +96,6 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
     super(type);
   }
   
-  protected ReplicationMessage(MessageID mid) {
-    super(RESPONSE, mid);
-  }  
 //  a true replicated message
   private ReplicationMessage(EntityDescriptor descriptor, ClientID src, 
       TransactionID tid, TransactionID oldest, 
@@ -206,9 +201,6 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
         in.readFully(this.payload);
         this.concurrency = in.readInt();
         break;
-      case RESPONSE:
-        this.rid = in.readLong();
-        break;
     }
   }
 
@@ -239,10 +231,6 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
           out.writeInt(0);
         }
         out.writeInt(concurrency);
-        break;
-      case RESPONSE:
-//      do nothing, just need the messageid
-        out.writeLong(rid);
         break;
     }
   }

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessageAck.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessageAck.java
@@ -30,16 +30,21 @@ import java.io.IOException;
 public class ReplicationMessageAck extends AbstractGroupMessage {
   //message types  
   public static final int INVALID               = 0; // Sent to replicate a request on the passive
-  public static final int COMPLETED                = 1; // response that the replicated action completed
-  public static final int START_SYNC                = 2; // Sent from the passive when it wants the active to start passive sync.
+  public static final int RECEIVED                = 2; // Means that the replicated action has been received by the passive
+  public static final int COMPLETED                = 3; // response that the replicated action completed
+  public static final int START_SYNC                = 4; // Sent from the passive when it wants the active to start passive sync.
 
   // Factory methods.
   public static ReplicationMessageAck createSyncRequestMessage() {
     return new ReplicationMessageAck(START_SYNC);
   }
 
+  public static ReplicationMessageAck createReceivedAck(MessageID requestToAck) {
+    return new ReplicationMessageAck(RECEIVED, requestToAck);
+  }
+
   public static ReplicationMessageAck createCompletedAck(MessageID requestToAck) {
-    return new ReplicationMessageAck(requestToAck);
+    return new ReplicationMessageAck(COMPLETED, requestToAck);
   }
 
 
@@ -52,8 +57,8 @@ public class ReplicationMessageAck extends AbstractGroupMessage {
     super(type);
   }
   
-  private ReplicationMessageAck(MessageID requestID) {
-    super(COMPLETED, requestID);
+  private ReplicationMessageAck(int type, MessageID requestID) {
+    super(type, requestID);
   }
 
   @Override

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessageAck.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessageAck.java
@@ -20,16 +20,22 @@ package com.tc.l2.msg;
 
 import com.tc.io.TCByteBufferInput;
 import com.tc.io.TCByteBufferOutput;
+import com.tc.net.groups.AbstractGroupMessage;
 import com.tc.net.groups.MessageID;
 import java.io.IOException;
 
 /**
  *
  */
-public class ReplicationMessageAck extends ReplicationMessage {
+public class ReplicationMessageAck extends AbstractGroupMessage {
+  //message types  
+  public static final int INVALID               = 0; // Sent to replicate a request on the passive
+  public static final int COMPLETED                = 1; // response that the replicated action completed
+  public static final int START_SYNC                = 2; // Sent from the passive when it wants the active to start passive sync.
+
   // Factory methods.
   public static ReplicationMessageAck createSyncRequestMessage() {
-    return new ReplicationMessageAck(START);
+    return new ReplicationMessageAck(START_SYNC);
   }
 
   public static ReplicationMessageAck createCompletedAck(MessageID requestToAck) {
@@ -38,23 +44,25 @@ public class ReplicationMessageAck extends ReplicationMessage {
 
 
   public ReplicationMessageAck() {
+    super(INVALID);
   }
+
 //  this type requests passive sync from the active  
   private ReplicationMessageAck(int type) {
     super(type);
   }
   
   private ReplicationMessageAck(MessageID requestID) {
-    super(requestID);
+    super(COMPLETED, requestID);
   }
 
   @Override
   protected void basicDeserializeFrom(TCByteBufferInput in) throws IOException {
-
+    // Do nothing - no instance variables.
   }
 
   @Override
   protected void basicSerializeTo(TCByteBufferOutput out) {
-
+    // Do nothing - no instance variables.
   }
 }

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessageAck.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessageAck.java
@@ -27,15 +27,24 @@ import java.io.IOException;
  *
  */
 public class ReplicationMessageAck extends ReplicationMessage {
+  // Factory methods.
+  public static ReplicationMessageAck createSyncRequestMessage() {
+    return new ReplicationMessageAck(START);
+  }
+
+  public static ReplicationMessageAck createCompletedAck(MessageID requestToAck) {
+    return new ReplicationMessageAck(requestToAck);
+  }
+
 
   public ReplicationMessageAck() {
   }
 //  this type requests passive sync from the active  
-  public ReplicationMessageAck(int type) {
+  private ReplicationMessageAck(int type) {
     super(type);
   }
   
-  public ReplicationMessageAck(MessageID requestID) {
+  private ReplicationMessageAck(MessageID requestID) {
     super(requestID);
   }
 


### PR DESCRIPTION
* this uses a new RECEIVED ack added in the active-passive dialect (note that this is NOT exposed to the client)
* the OLD logic on the active was:  block until passive completes, now run invoke, then return
* the new logic on the active is:  block until passive receives, now run invoke, then block until passive completes, then return
* there are some concerns that exclusive mode might have been relying on some nature of the old ACK ordering but we believe that has changed and none of the tests had a problem
* by injecting a 20ms sleep between the "block for receives" and "invoke", I was able to observe MessageFloodTest running in both orders over the course of a run