### PR TITLE
Fix to ActivePassiveAckWaiters handling

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ActivePassiveAckWaiter.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ActivePassiveAckWaiter.java
@@ -64,16 +64,21 @@ public class ActivePassiveAckWaiter {
     }
   }
 
-  public synchronized void didCompleteOnPassive(NodeID onePassive) {
+  /** 
+   * @return True if this was the last outstanding completion required and the waiter is now done.
+   */
+  public synchronized boolean didCompleteOnPassive(NodeID onePassive) {
     // Note that we will try to remove from the received set, but usually it will already have been removed.
     boolean didContainInReceived = this.receivedPending.remove(onePassive);
     // We know that it must still be in the completed set, though.
     boolean didContainInCompleted = this.completedPending.remove(onePassive);
     // We must have contained this passive in order to complete.
     Assert.assertTrue(didContainInCompleted);
+    boolean isDoneWaiting = this.completedPending.isEmpty();
     // Wake everyone up if this changed something.
-    if ((didContainInReceived && this.receivedPending.isEmpty()) || this.completedPending.isEmpty()) {
+    if ((didContainInReceived && this.receivedPending.isEmpty()) || isDoneWaiting) {
       notifyAll();
     }
+    return isDoneWaiting;
   }
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ActivePassiveAckWaiter.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ActivePassiveAckWaiter.java
@@ -64,16 +64,24 @@ public class ActivePassiveAckWaiter {
     }
   }
 
-  /** 
+  /**
+   * Notifies the waiter that it is complete for the given node.
+   * 
+   * @param onePassive The passive which has completed the replicated message
+   * @param isNormalComplete True if this was a normal complete ack, false if we are completing because the node disappeared
    * @return True if this was the last outstanding completion required and the waiter is now done.
    */
-  public synchronized boolean didCompleteOnPassive(NodeID onePassive) {
+  public synchronized boolean didCompleteOnPassive(NodeID onePassive, boolean isNormalComplete) {
     // Note that we will try to remove from the received set, but usually it will already have been removed.
     boolean didContainInReceived = this.receivedPending.remove(onePassive);
     // We know that it must still be in the completed set, though.
     boolean didContainInCompleted = this.completedPending.remove(onePassive);
     // We must have contained this passive in order to complete.
-    Assert.assertTrue(didContainInCompleted);
+    if (isNormalComplete) {
+      // In the unexpected case, we are just making sure this node is removed from all waiters, even though it might have
+      // already completed on some of them.
+      Assert.assertTrue(didContainInCompleted);
+    }
     boolean isDoneWaiting = this.completedPending.isEmpty();
     // Wake everyone up if this changed something.
     if ((didContainInReceived && this.receivedPending.isEmpty()) || isDoneWaiting) {

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ActiveToPassiveReplication.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ActiveToPassiveReplication.java
@@ -157,7 +157,10 @@ public class ActiveToPassiveReplication implements PassiveReplicationBroker, Gro
   private void internalAckCompleted(MessageID mid, NodeID passive) {
     ActivePassiveAckWaiter waiter = waiters.get(mid);
     if (null != waiter) {
-      waiter.didCompleteOnPassive(passive);
+      boolean shouldDiscardWaiter = waiter.didCompleteOnPassive(passive);
+      if (shouldDiscardWaiter) {
+        waiters.remove(mid);
+      }
     }
   }
 

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ActivePassiveAckWaiterTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ActivePassiveAckWaiterTest.java
@@ -57,7 +57,8 @@ public class ActivePassiveAckWaiterTest {
     interlock.waitOnStarts();
     waiter.didReceiveOnPassive(onePassive);
     interlock.waitOnReceivesOnly();
-    waiter.didCompleteOnPassive(onePassive);
+    boolean waiterIsDone = waiter.didCompleteOnPassive(onePassive);
+    Assert.assertTrue(waiterIsDone);
     interlock.waitOnCompletes();
     lockStep.join();
   }
@@ -77,8 +78,10 @@ public class ActivePassiveAckWaiterTest {
     waiter.didReceiveOnPassive(onePassive);
     waiter.didReceiveOnPassive(twoPassive);
     interlock.waitOnReceivesOnly();
-    waiter.didCompleteOnPassive(twoPassive);
-    waiter.didCompleteOnPassive(onePassive);
+    boolean waiterIsDone = waiter.didCompleteOnPassive(twoPassive);
+    Assert.assertFalse(waiterIsDone);
+    waiterIsDone = waiter.didCompleteOnPassive(onePassive);
+    Assert.assertTrue(waiterIsDone);
     interlock.waitOnCompletes();
     lockStep.join();
   }
@@ -100,8 +103,10 @@ public class ActivePassiveAckWaiterTest {
     waiter.didReceiveOnPassive(onePassive);
     waiter.didReceiveOnPassive(twoPassive);
     interlock.waitOnReceivesOnly();
-    waiter.didCompleteOnPassive(twoPassive);
-    waiter.didCompleteOnPassive(onePassive);
+    boolean waiterIsDone = waiter.didCompleteOnPassive(twoPassive);
+    Assert.assertFalse(waiterIsDone);
+    waiterIsDone = waiter.didCompleteOnPassive(onePassive);
+    Assert.assertTrue(waiterIsDone);
     interlock.waitOnCompletes();
     lockStep1.join();
     lockStep2.join();
@@ -119,8 +124,10 @@ public class ActivePassiveAckWaiterTest {
     LockStep lockStep = new LockStep(waiter, interlock);
     lockStep.start();
     interlock.waitOnStarts();
-    waiter.didCompleteOnPassive(twoPassive);
-    waiter.didCompleteOnPassive(onePassive);
+    boolean waiterIsDone = waiter.didCompleteOnPassive(twoPassive);
+    Assert.assertFalse(waiterIsDone);
+    waiterIsDone = waiter.didCompleteOnPassive(onePassive);
+    Assert.assertTrue(waiterIsDone);
     interlock.waitOnCompletes();
     lockStep.join();
   }

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ActivePassiveAckWaiterTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ActivePassiveAckWaiterTest.java
@@ -57,7 +57,7 @@ public class ActivePassiveAckWaiterTest {
     interlock.waitOnStarts();
     waiter.didReceiveOnPassive(onePassive);
     interlock.waitOnReceivesOnly();
-    boolean waiterIsDone = waiter.didCompleteOnPassive(onePassive);
+    boolean waiterIsDone = waiter.didCompleteOnPassive(onePassive, true);
     Assert.assertTrue(waiterIsDone);
     interlock.waitOnCompletes();
     lockStep.join();
@@ -78,9 +78,9 @@ public class ActivePassiveAckWaiterTest {
     waiter.didReceiveOnPassive(onePassive);
     waiter.didReceiveOnPassive(twoPassive);
     interlock.waitOnReceivesOnly();
-    boolean waiterIsDone = waiter.didCompleteOnPassive(twoPassive);
+    boolean waiterIsDone = waiter.didCompleteOnPassive(twoPassive, true);
     Assert.assertFalse(waiterIsDone);
-    waiterIsDone = waiter.didCompleteOnPassive(onePassive);
+    waiterIsDone = waiter.didCompleteOnPassive(onePassive, true);
     Assert.assertTrue(waiterIsDone);
     interlock.waitOnCompletes();
     lockStep.join();
@@ -103,9 +103,9 @@ public class ActivePassiveAckWaiterTest {
     waiter.didReceiveOnPassive(onePassive);
     waiter.didReceiveOnPassive(twoPassive);
     interlock.waitOnReceivesOnly();
-    boolean waiterIsDone = waiter.didCompleteOnPassive(twoPassive);
+    boolean waiterIsDone = waiter.didCompleteOnPassive(twoPassive, true);
     Assert.assertFalse(waiterIsDone);
-    waiterIsDone = waiter.didCompleteOnPassive(onePassive);
+    waiterIsDone = waiter.didCompleteOnPassive(onePassive, true);
     Assert.assertTrue(waiterIsDone);
     interlock.waitOnCompletes();
     lockStep1.join();
@@ -124,9 +124,56 @@ public class ActivePassiveAckWaiterTest {
     LockStep lockStep = new LockStep(waiter, interlock);
     lockStep.start();
     interlock.waitOnStarts();
-    boolean waiterIsDone = waiter.didCompleteOnPassive(twoPassive);
+    boolean waiterIsDone = waiter.didCompleteOnPassive(twoPassive, true);
     Assert.assertFalse(waiterIsDone);
-    waiterIsDone = waiter.didCompleteOnPassive(onePassive);
+    waiterIsDone = waiter.didCompleteOnPassive(onePassive, true);
+    Assert.assertTrue(waiterIsDone);
+    interlock.waitOnCompletes();
+    lockStep.join();
+  }
+
+  @Test
+  public void testFailedDoubleComplete() throws Exception {
+    Set<NodeID> passives = new HashSet<NodeID>();
+    NodeID onePassive = mock(NodeID.class);
+    passives.add(onePassive);
+    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives);
+    Interlock interlock = new Interlock(1);
+    LockStep lockStep = new LockStep(waiter, interlock);
+    lockStep.start();
+    interlock.waitOnStarts();
+    waiter.didReceiveOnPassive(onePassive);
+    interlock.waitOnReceivesOnly();
+    boolean waiterIsDone = waiter.didCompleteOnPassive(onePassive, true);
+    Assert.assertTrue(waiterIsDone);
+    boolean didFail = false;
+    try {
+      waiter.didCompleteOnPassive(onePassive, true);
+    } catch (AssertionError e) {
+      // We expect this to fail on double-complete.
+      didFail = true;
+    }
+    Assert.assertTrue(didFail);
+    interlock.waitOnCompletes();
+    lockStep.join();
+  }
+
+  @Test
+  public void testDisconnectAfterComplete() throws Exception {
+    Set<NodeID> passives = new HashSet<NodeID>();
+    NodeID onePassive = mock(NodeID.class);
+    passives.add(onePassive);
+    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives);
+    Interlock interlock = new Interlock(1);
+    LockStep lockStep = new LockStep(waiter, interlock);
+    lockStep.start();
+    interlock.waitOnStarts();
+    waiter.didReceiveOnPassive(onePassive);
+    interlock.waitOnReceivesOnly();
+    boolean waiterIsDone = waiter.didCompleteOnPassive(onePassive, true);
+    Assert.assertTrue(waiterIsDone);
+    // We will try to complete, again, but this won't assert, since we are stating that it is not a normal complete.
+    waiterIsDone = waiter.didCompleteOnPassive(onePassive, false);
     Assert.assertTrue(waiterIsDone);
     interlock.waitOnCompletes();
     lockStep.join();


### PR DESCRIPTION
* Fix a leak where we never removed these waiters
* Don't assert that the waiter was waiting for the completed node in the case where the node unexpectedly disappeared