### PR TITLE
RetirementManager is now per-entity instance, instead of global

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
@@ -25,6 +25,8 @@ import org.terracotta.entity.MessageCodec;
 import com.tc.net.ClientID;
 import com.tc.net.NodeID;
 import com.tc.object.EntityID;
+import com.tc.objectserver.handler.RetirementManager;
+
 import org.terracotta.entity.StateDumpable;
 
 
@@ -78,4 +80,12 @@ public interface ManagedEntity extends StateDumpable {
    * @return The codec which can translate to/from this entity's message dialect.
    */
   MessageCodec<?, ?> getCodec();
+
+  /**
+   * Of specific interest to the EntityMessengerService since it may need to install dependencies between messages to this
+   * entity.
+   * 
+   * @return The entity's local RetirementManager instance.
+   */
+  public RetirementManager getRetirementManager();
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/EntityManagerImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/EntityManagerImpl.java
@@ -20,7 +20,6 @@ package com.tc.objectserver.entity;
 
 import org.terracotta.entity.EntityMessage;
 import org.terracotta.entity.ServerEntityService;
-import org.terracotta.entity.StateDumpable;
 import org.terracotta.entity.StateDumper;
 import org.terracotta.exception.EntityAlreadyExistsException;
 import org.terracotta.exception.EntityException;
@@ -31,7 +30,6 @@ import com.tc.object.EntityID;
 import com.tc.objectserver.api.EntityManager;
 import com.tc.objectserver.api.ManagedEntity;
 import com.tc.objectserver.core.api.ITopologyEventCollector;
-import com.tc.objectserver.handler.RetirementManager;
 import com.tc.services.TerracottaServiceProviderRegistry;
 import com.tc.util.Assert;
 import java.util.ArrayList;
@@ -56,17 +54,15 @@ public class EntityManagerImpl implements EntityManager {
   private final BiConsumer<EntityID, Long> noopLoopback;
   
   private final RequestProcessor processorPipeline;
-  private final RetirementManager retirementManager;
   private boolean shouldCreateActiveEntities;
 
   public EntityManagerImpl(TerracottaServiceProviderRegistry serviceRegistry, 
       ClientEntityStateManager clientEntityStateManager, ITopologyEventCollector eventCollector, 
-      RequestProcessor processor, RetirementManager retirementManager, BiConsumer<EntityID, Long> noopLoopback) {
+      RequestProcessor processor, BiConsumer<EntityID, Long> noopLoopback) {
     this.serviceRegistry = serviceRegistry;
     this.clientEntityStateManager = clientEntityStateManager;
     this.eventCollector = eventCollector;
     this.processorPipeline = processor;
-    this.retirementManager = retirementManager;
     // By default, the server starts up in a passive mode so we will create passive entities.
     this.shouldCreateActiveEntities = false;
     this.creationLoader = Thread.currentThread().getContextClassLoader();
@@ -99,7 +95,7 @@ public class EntityManagerImpl implements EntityManager {
     // Valid entity versions start at 1.
     Assert.assertTrue(version > 0);
     ManagedEntity temp = new ManagedEntityImpl(id, version, noopLoopback, serviceRegistry.subRegistry(consumerID),
-        clientEntityStateManager, this.eventCollector, processorPipeline, this.retirementManager, getVersionCheckedService(id, version), this.shouldCreateActiveEntities);
+        clientEntityStateManager, this.eventCollector, processorPipeline, getVersionCheckedService(id, version), this.shouldCreateActiveEntities);
     if (entities.putIfAbsent(id, temp) != null) {
       throw new EntityAlreadyExistsException(id.getClassName(), id.getEntityName());
     }
@@ -109,7 +105,7 @@ public class EntityManagerImpl implements EntityManager {
   public void loadExisting(EntityID entityID, long recordedVersion, long consumerID, byte[] configuration) throws EntityException {
     // Valid entity versions start at 1.
     Assert.assertTrue(recordedVersion > 0);
-    ManagedEntity temp = new ManagedEntityImpl(entityID, recordedVersion, noopLoopback, serviceRegistry.subRegistry(consumerID), clientEntityStateManager, this.eventCollector, processorPipeline, this.retirementManager, getVersionCheckedService(entityID, recordedVersion), this.shouldCreateActiveEntities);
+    ManagedEntity temp = new ManagedEntityImpl(entityID, recordedVersion, noopLoopback, serviceRegistry.subRegistry(consumerID), clientEntityStateManager, this.eventCollector, processorPipeline, getVersionCheckedService(entityID, recordedVersion), this.shouldCreateActiveEntities);
     if (entities.putIfAbsent(entityID, temp) != null) {
       throw new IllegalStateException("Double create for entity " + entityID);
     }    

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -635,6 +635,11 @@ public class ManagedEntityImpl implements ManagedEntity {
   }
 
   @Override
+  public RetirementManager getRetirementManager() {
+    return this.retirementManager;
+  }
+
+  @Override
   public void loadEntity(byte[] configuration) {
     this.loadExisting(configuration);
   }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -105,7 +105,7 @@ public class ManagedEntityImpl implements ManagedEntity {
   private byte[] constructorInfo;
 
   ManagedEntityImpl(EntityID id, long version, BiConsumer<EntityID, Long> loopback, InternalServiceRegistry registry, ClientEntityStateManager clientEntityStateManager, ITopologyEventCollector eventCollector,
-                    RequestProcessor process, RetirementManager retirementManager, ServerEntityService<EntityMessage, EntityResponse> factory,
+                    RequestProcessor process, ServerEntityService<EntityMessage, EntityResponse> factory,
                     boolean isInActiveState) {
     this.id = id;
     this.version = version;

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -115,7 +115,8 @@ public class ManagedEntityImpl implements ManagedEntity {
     this.eventCollector = eventCollector;
     this.factory = factory;
     this.executor = process;
-    this.retirementManager = retirementManager;
+    // Create the RetirementManager here, since it is currently scoped per-entity.
+    this.retirementManager = new RetirementManager();
     this.isInActiveState = isInActiveState;
     registry.setOwningEntity(this);
     this.codec = factory.getMessageCodec();

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/PlatformEntity.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/PlatformEntity.java
@@ -25,6 +25,7 @@ import com.tc.object.EntityDescriptor;
 import com.tc.object.EntityID;
 import com.tc.objectserver.api.ManagedEntity;
 import com.tc.objectserver.api.ServerEntityRequest;
+import com.tc.objectserver.handler.RetirementManager;
 import com.tc.util.Assert;
 
 import org.terracotta.entity.ClientDescriptor;
@@ -121,5 +122,12 @@ public class PlatformEntity implements ManagedEntity {
   @Override
   public void dumpStateTo(StateDumper stateDumper) {
 
+  }
+
+  @Override
+  public RetirementManager getRetirementManager() {
+    // The platform entity doesn't expose this since it isn't expecting message interdependencies, internally.
+    Assert.fail();
+    return null;
   }
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -175,7 +175,6 @@ import com.tc.objectserver.handler.ClientHandshakeHandler;
 import com.tc.objectserver.handler.ProcessTransactionHandler;
 import com.tc.objectserver.handler.RequestLockUnLockHandler;
 import com.tc.objectserver.handler.RespondToRequestLockHandler;
-import com.tc.objectserver.handler.RetirementManager;
 import com.tc.objectserver.handshakemanager.ServerClientHandshakeManager;
 import com.tc.objectserver.locks.LockManagerImpl;
 import com.tc.objectserver.locks.LockResponseContext;
@@ -645,14 +644,12 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
         pInfo.buildVersion(), pInfo.buildID());
 
     RequestProcessor processor = new RequestProcessor(requestProcessorSink);
-    // This will be removed in a later change - just minimizing an API change for clarity.
-    RetirementManager retirementManager = null;
-    entityManager = new EntityManagerImpl(this.serviceRegistry, clientEntityStateManager, eventCollector, processor, retirementManager, this::sendNoop);
+    entityManager = new EntityManagerImpl(this.serviceRegistry, clientEntityStateManager, eventCollector, processor, this::sendNoop);
     channelManager.addEventListener(clientEntityStateManager);
     processTransactionHandler.setLateBoundComponents(channelManager, entityManager);
     
     // We need to connect the IInterEntityMessengerProvider to the voltronMessageSink.
-    final EntityMessengerProvider messengerProvider = new EntityMessengerProvider(voltronMessageSink, retirementManager);
+    final EntityMessengerProvider messengerProvider = new EntityMessengerProvider(voltronMessageSink);
     this.serviceRegistry.registerBuiltin(messengerProvider);
     
     // If we are running in a restartable mode, instantiate any entities in storage.

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -645,7 +645,8 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
         pInfo.buildVersion(), pInfo.buildID());
 
     RequestProcessor processor = new RequestProcessor(requestProcessorSink);
-    RetirementManager retirementManager = new RetirementManager();
+    // This will be removed in a later change - just minimizing an API change for clarity.
+    RetirementManager retirementManager = null;
     entityManager = new EntityManagerImpl(this.serviceRegistry, clientEntityStateManager, eventCollector, processor, retirementManager, this::sendNoop);
     channelManager.addEventListener(clientEntityStateManager);
     processTransactionHandler.setLateBoundComponents(channelManager, entityManager);

--- a/dso-l2/src/main/java/com/tc/services/EntityMessengerProvider.java
+++ b/dso-l2/src/main/java/com/tc/services/EntityMessengerProvider.java
@@ -28,7 +28,6 @@ import org.terracotta.entity.ServiceProviderCleanupException;
 import com.tc.async.api.Sink;
 import com.tc.entity.VoltronEntityMessage;
 import com.tc.objectserver.api.ManagedEntity;
-import com.tc.objectserver.handler.RetirementManager;
 
 
 /**
@@ -37,16 +36,14 @@ import com.tc.objectserver.handler.RetirementManager;
  */
 public class EntityMessengerProvider implements BuiltInServiceProvider {
   private final Sink<VoltronEntityMessage> messageSink;
-  private final RetirementManager retirementManager;
 
-  public EntityMessengerProvider(Sink<VoltronEntityMessage> messageSink, RetirementManager retirementManager) {
+  public EntityMessengerProvider(Sink<VoltronEntityMessage> messageSink) {
     this.messageSink = messageSink;
-    this.retirementManager = retirementManager;
   }
 
   @Override
   public <T> T getService(long consumerID, ManagedEntity owningEntity, ServiceConfiguration<T> configuration) {
-    return configuration.getServiceType().cast(new EntityMessengerService(this.messageSink, this.retirementManager, owningEntity));
+    return configuration.getServiceType().cast(new EntityMessengerService(this.messageSink, owningEntity));
   }
 
   @Override

--- a/dso-l2/src/main/java/com/tc/services/EntityMessengerService.java
+++ b/dso-l2/src/main/java/com/tc/services/EntityMessengerService.java
@@ -45,14 +45,12 @@ public class EntityMessengerService implements IEntityMessenger {
   private final EntityDescriptor fakeDescriptor;
 
   @SuppressWarnings("unchecked")
-  public EntityMessengerService(Sink<VoltronEntityMessage> messageSink, RetirementManager retirementManager, ManagedEntity owningEntity) {
+  public EntityMessengerService(Sink<VoltronEntityMessage> messageSink, ManagedEntity owningEntity) {
     this.messageSink = messageSink;
     // We need access to the retirement manager in order to build dependencies between messages on this entity.
     this.retirementManager = owningEntity.getRetirementManager();
     // If this service is being created, we expect that the entity has a retirement mananger.
     Assert.assertTrue(null != this.retirementManager);
-    // The passed-in retirementManager is expected to be null (just a remnant of an old API to keep this change minimal).
-    Assert.assertTrue(null == retirementManager);
     // Note that the codec will actually expect to work on a sub-type of EntityMessage but this service isn't explicitly
     // given the actual type.  This means that incorrect usage will result in a runtime failure.
     this.codec = (MessageCodec<EntityMessage, ?>) owningEntity.getCodec();

--- a/dso-l2/src/main/java/com/tc/services/EntityMessengerService.java
+++ b/dso-l2/src/main/java/com/tc/services/EntityMessengerService.java
@@ -49,9 +49,10 @@ public class EntityMessengerService implements IEntityMessenger {
     this.messageSink = messageSink;
     // We need access to the retirement manager in order to build dependencies between messages on this entity.
     this.retirementManager = owningEntity.getRetirementManager();
-    // NOTE:  The retirement manager is still passed in, to reduce the scope of this change, so just verify that it is the
-    // same instance we got from the owningEntity.
-    Assert.assertTrue(retirementManager == this.retirementManager);
+    // If this service is being created, we expect that the entity has a retirement mananger.
+    Assert.assertTrue(null != this.retirementManager);
+    // The passed-in retirementManager is expected to be null (just a remnant of an old API to keep this change minimal).
+    Assert.assertTrue(null == retirementManager);
     // Note that the codec will actually expect to work on a sub-type of EntityMessage but this service isn't explicitly
     // given the actual type.  This means that incorrect usage will result in a runtime failure.
     this.codec = (MessageCodec<EntityMessage, ?>) owningEntity.getCodec();

--- a/dso-l2/src/main/java/com/tc/services/EntityMessengerService.java
+++ b/dso-l2/src/main/java/com/tc/services/EntityMessengerService.java
@@ -31,6 +31,7 @@ import com.tc.object.EntityDescriptor;
 import com.tc.object.tx.TransactionID;
 import com.tc.objectserver.api.ManagedEntity;
 import com.tc.objectserver.handler.RetirementManager;
+import com.tc.util.Assert;
 
 
 /**
@@ -46,7 +47,11 @@ public class EntityMessengerService implements IEntityMessenger {
   @SuppressWarnings("unchecked")
   public EntityMessengerService(Sink<VoltronEntityMessage> messageSink, RetirementManager retirementManager, ManagedEntity owningEntity) {
     this.messageSink = messageSink;
-    this.retirementManager = retirementManager;
+    // We need access to the retirement manager in order to build dependencies between messages on this entity.
+    this.retirementManager = owningEntity.getRetirementManager();
+    // NOTE:  The retirement manager is still passed in, to reduce the scope of this change, so just verify that it is the
+    // same instance we got from the owningEntity.
+    Assert.assertTrue(retirementManager == this.retirementManager);
     // Note that the codec will actually expect to work on a sub-type of EntityMessage but this service isn't explicitly
     // given the actual type.  This means that incorrect usage will result in a runtime failure.
     this.codec = (MessageCodec<EntityMessage, ?>) owningEntity.getCodec();

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/EntityManagerImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/EntityManagerImplTest.java
@@ -16,7 +16,6 @@
  *  Terracotta, Inc., a Software AG company
  *
  */
-
 package com.tc.objectserver.entity;
 
 import org.junit.Before;
@@ -28,7 +27,6 @@ import org.terracotta.TestEntity;
 import com.tc.object.EntityID;
 import com.tc.objectserver.api.EntityManager;
 import com.tc.objectserver.core.api.ITopologyEventCollector;
-import com.tc.objectserver.handler.RetirementManager;
 import com.tc.services.InternalServiceRegistry;
 import com.tc.services.TerracottaServiceProviderRegistry;
 
@@ -40,8 +38,8 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+
 public class EntityManagerImplTest {
-  
   private EntityManager entityManager;
   private EntityID id;
   private long version;
@@ -57,7 +55,6 @@ public class EntityManagerImplTest {
         mock(ClientEntityStateManager.class),
         mock(ITopologyEventCollector.class),
         mock(RequestProcessor.class),
-        mock(RetirementManager.class),
         mock(BiConsumer.class)
     );
     id = new EntityID(TestEntity.class.getName(), "foo");

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
@@ -42,7 +42,6 @@ import com.tc.objectserver.api.ServerEntityAction;
 import com.tc.objectserver.api.ServerEntityRequest;
 import com.tc.objectserver.core.api.ITopologyEventCollector;
 import com.tc.objectserver.core.api.ServerConfigurationContext;
-import com.tc.objectserver.handler.RetirementManager;
 import com.tc.services.InternalServiceRegistry;
 import com.tc.util.Assert;
 
@@ -84,7 +83,6 @@ public class ManagedEntityImplTest {
   private ActiveServerEntity<EntityMessage, EntityResponse> activeServerEntity;
   private PassiveServerEntity<EntityMessage, EntityResponse> passiveServerEntity;
   private RequestProcessor requestMulti;
-  private RetirementManager retirementManager;
   private ClientEntityStateManager clientEntityStateManager;
   private ITopologyEventCollector eventCollector;
   private NodeID nodeID;
@@ -104,7 +102,6 @@ public class ManagedEntityImplTest {
     loopback = mock(BiConsumer.class);
 
     requestMulti = mock(RequestProcessor.class);
-    retirementManager = new RetirementManager();
     activeServerEntity = mock(ActiveServerEntity.class);
     passiveServerEntity = mock(PassiveServerEntity.class);
     serverEntityService = getServerEntityService(this.activeServerEntity, this.passiveServerEntity);
@@ -113,7 +110,7 @@ public class ManagedEntityImplTest {
 
     // We will start this in a passive state, as the general test case.
     boolean isInActiveState = false;
-    managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, retirementManager, serverEntityService, isInActiveState);
+    managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, isInActiveState);
     clientDescriptor = new ClientDescriptorImpl(nodeID, entityDescriptor);
     Mockito.doAnswer(new Answer<Object>() {
       @Override
@@ -180,7 +177,7 @@ public class ManagedEntityImplTest {
   @Test
   public void testDoubleCreateActive() throws Exception {
     // create a ManagedEntity which is in active state
-    ManagedEntityImpl activeEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, retirementManager, serverEntityService, true);
+    ManagedEntityImpl activeEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, true);
     // We want to pretend that we are the expected thread.
     Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
     
@@ -195,7 +192,7 @@ public class ManagedEntityImplTest {
   @Test
   public void testGetEntityMissing() throws Exception {
     // create a ManagedEntity which is in active state
-    ManagedEntityImpl managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, retirementManager, serverEntityService, true);
+    ManagedEntityImpl managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, true);
     Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
     
     com.tc.net.ClientID requester = new com.tc.net.ClientID(0);
@@ -235,7 +232,7 @@ public class ManagedEntityImplTest {
   public void testPerformActionMissingEntityActive() throws Exception {
     // We will need to create an active managed entity (the default one in the test is passive).
     boolean isInActiveState = true;
-    ManagedEntityImpl activeEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, retirementManager, serverEntityService, isInActiveState);
+    ManagedEntityImpl activeEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, isInActiveState);
     
     ServerEntityRequest request = mockInvokeRequest();
     activeEntity.addInvokeRequest(request, null, new byte[0], ConcurrencyStrategy.MANAGEMENT_KEY);
@@ -279,7 +276,7 @@ public class ManagedEntityImplTest {
         throw new UnsupportedOperationException("not supported!");
       }
     });
-    managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, retirementManager, serverEntityService, false);
+    managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, false);
     managedEntity.addLifecycleRequest(mockCreateEntityRequest(), null);
     managedEntity.addLifecycleRequest(mockPromoteToActiveRequest(), null);
     Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
@@ -329,7 +326,7 @@ public class ManagedEntityImplTest {
         throw new UnsupportedOperationException("not supported!");
       }
     });
-    managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, retirementManager, serverEntityService, false);
+    managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, false);
     managedEntity.addLifecycleRequest(mockCreateEntityRequest(), null);
     managedEntity.addLifecycleRequest(mockPromoteToActiveRequest(), null);
     
@@ -426,7 +423,7 @@ public class ManagedEntityImplTest {
     };
     when(this.serverEntityService.getConcurrencyStrategy(any(byte[].class))).thenReturn(basic);
     when(this.serverEntityService.getMessageCodec()).thenReturn(codec);
-    managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, retirementManager, serverEntityService, false);
+    managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, false);
     managedEntity.addLifecycleRequest(mockCreateEntityRequest(), new byte[0]);
     managedEntity.addLifecycleRequest(mockPromoteToActiveRequest(), new byte[0]);
     Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ProcessTransactionHandlerTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ProcessTransactionHandlerTest.java
@@ -103,11 +103,10 @@ public class ProcessTransactionHandlerTest {
     this.clientEntityStateManager = new ClientEntityStateManagerImpl(loopbackSink);
     this.eventCollector = mock(ITopologyEventCollector.class);
     RequestProcessor processor = new RequestProcessor(this.requestProcessorSink);
-    RetirementManager retirementManager = new RetirementManager();
     PassiveReplicationBroker broker = mock(PassiveReplicationBroker.class);
     when(broker.passives()).thenReturn(Collections.emptySet());
     processor.setReplication(broker);
-    EntityManagerImpl entityManager = new EntityManagerImpl(this.terracottaServiceProviderRegistry, clientEntityStateManager, eventCollector, processor, retirementManager, this::sendNoop);
+    EntityManagerImpl entityManager = new EntityManagerImpl(this.terracottaServiceProviderRegistry, clientEntityStateManager, eventCollector, processor, this::sendNoop);
     entityManager.enterActiveState();
     channelManager.addEventListener(clientEntityStateManager);
     processTransactionHandler.setLateBoundComponents(channelManager, entityManager);

--- a/dso-l2/src/test/java/com/tc/services/EntityMessengerProviderTest.java
+++ b/dso-l2/src/test/java/com/tc/services/EntityMessengerProviderTest.java
@@ -40,7 +40,6 @@ import static org.mockito.Mockito.when;
 
 public class EntityMessengerProviderTest {
   private Sink<VoltronEntityMessage> messageSink;
-  private RetirementManager retirementManager;
   private long consumerID;
   private MessageCodec<EntityMessage, EntityResponse> messageCodec;
   private ManagedEntity owningEntity;
@@ -55,7 +54,6 @@ public class EntityMessengerProviderTest {
   public void setUp() throws Exception {
     // Build the underlying components needed by the provider or common to tests.
     this.messageSink = mock(Sink.class);
-    this.retirementManager = null;
     this.consumerID = 1;
     this.messageCodec = mock(MessageCodec.class);
     this.owningEntity = mock(ManagedEntity.class);
@@ -65,7 +63,7 @@ public class EntityMessengerProviderTest {
     when(this.configuration.getServiceType()).thenReturn(IEntityMessenger.class);
     
     // Build the test subject.
-    this.entityMessengerProvider = new EntityMessengerProvider(this.messageSink, this.retirementManager);
+    this.entityMessengerProvider = new EntityMessengerProvider(this.messageSink);
   }
 
   @Test

--- a/dso-l2/src/test/java/com/tc/services/EntityMessengerProviderTest.java
+++ b/dso-l2/src/test/java/com/tc/services/EntityMessengerProviderTest.java
@@ -55,12 +55,12 @@ public class EntityMessengerProviderTest {
   public void setUp() throws Exception {
     // Build the underlying components needed by the provider or common to tests.
     this.messageSink = mock(Sink.class);
-    this.retirementManager = mock(RetirementManager.class);
+    this.retirementManager = null;
     this.consumerID = 1;
     this.messageCodec = mock(MessageCodec.class);
     this.owningEntity = mock(ManagedEntity.class);
     when(this.owningEntity.getCodec()).thenReturn((MessageCodec)this.messageCodec);
-    when(this.owningEntity.getRetirementManager()).thenReturn(this.retirementManager);
+    when(this.owningEntity.getRetirementManager()).thenReturn(mock(RetirementManager.class));
     this.configuration = mock(ServiceConfiguration.class);
     when(this.configuration.getServiceType()).thenReturn(IEntityMessenger.class);
     

--- a/dso-l2/src/test/java/com/tc/services/EntityMessengerProviderTest.java
+++ b/dso-l2/src/test/java/com/tc/services/EntityMessengerProviderTest.java
@@ -60,6 +60,7 @@ public class EntityMessengerProviderTest {
     this.messageCodec = mock(MessageCodec.class);
     this.owningEntity = mock(ManagedEntity.class);
     when(this.owningEntity.getCodec()).thenReturn((MessageCodec)this.messageCodec);
+    when(this.owningEntity.getRetirementManager()).thenReturn(this.retirementManager);
     this.configuration = mock(ServiceConfiguration.class);
     when(this.configuration.getServiceType()).thenReturn(IEntityMessenger.class);
     


### PR DESCRIPTION
The work is split up since much of the change is plumbing.