### PR TITLE
Correctly handle MessageCodecException in ManagedEntityImpl

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
@@ -28,6 +28,7 @@ import com.tc.object.EntityID;
 import com.tc.objectserver.handler.RetirementManager;
 
 import org.terracotta.entity.StateDumpable;
+import org.terracotta.exception.EntityUserException;
 
 
 /**
@@ -46,8 +47,9 @@ public interface ManagedEntity extends StateDumpable {
   * @param entityMessage The message instance, if it was generated internally (the extendedData is still expected)
   * @param extendedData payload of the invoke
   * @param defaultKey default concurrency key if no concurrency strategy is installed
+  * @throws EntityUserException A state-safe exception (MessageCodecException) was encountered while setting up the invoke.
   */ 
-  void addInvokeRequest(ServerEntityRequest request, EntityMessage entityMessage, byte[] extendedData, int defaultKey);
+  void addInvokeRequest(ServerEntityRequest request, EntityMessage entityMessage, byte[] extendedData, int defaultKey) throws EntityUserException;
   
   void addSyncRequest(ServerEntityRequest sync, byte[] payload, int concurrencyKey);
   

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -134,7 +134,7 @@ public class ManagedEntityImpl implements ManagedEntity {
   }
 
   @Override
-  public void addInvokeRequest(final ServerEntityRequest request, EntityMessage entityMessage, byte[] payload, int defaultKey) {
+  public void addInvokeRequest(final ServerEntityRequest request, EntityMessage entityMessage, byte[] payload, int defaultKey) throws EntityUserException {
     if (request.getAction() == ServerEntityAction.NOOP) {
       scheduleInOrder(getEntityDescriptorForSource(request.getSourceDescriptor()), request, payload, () -> {
         request.complete();
@@ -159,11 +159,8 @@ public class ManagedEntityImpl implements ManagedEntity {
     
       EntityMessage message = entityMessage;
       if (null == message) {
-        try {
-          message = runWithHelper(()->codec.decodeMessage(payload));
-        } catch (EntityUserException e) {
-          throw new RuntimeException(e);
-        }
+        // NOTE:  This can throw EntityUserException.
+        message = runWithHelper(()->codec.decodeMessage(payload));
       }
       // If we are still ok and managed to deserialize the message, continue.
       if (null != message) {

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
@@ -482,7 +482,7 @@ public class ManagedEntityImplTest {
     
   }
 
-  @Test (expected = RuntimeException.class)
+  @Test (expected = EntityUserException.class)
   public void testCodecException() throws Exception {
     managedEntity.addLifecycleRequest(mockCreateEntityRequest(), null);
     managedEntity.addLifecycleRequest(mockPromoteToActiveRequest(), null);
@@ -520,16 +520,13 @@ public class ManagedEntityImplTest {
 
       @Override
       public EntityMessage decode(int concurrencyKey, byte[] payload) throws MessageCodecException {
-        throw new UnsupportedOperationException("not supported!");
+        // We will fail here, simulating a decode exception.
+        throw new MessageCodecException("Simulated failure", new UnsupportedOperationException("not supported!"));
       }
     });
     ServerEntityRequest invokeRequest = mockInvokeRequest();
+    // We expect that this addInvokeRequest will throw EntityUserException.
     managedEntity.addInvokeRequest(invokeRequest, null, payload, ConcurrencyStrategy.MANAGEMENT_KEY);
-    
-    verify(activeServerEntity, never()).invoke(any(ClientDescriptor.class), any(EntityMessage.class));
-    verify(invokeRequest, never()).complete(any(byte[].class));
-    verify(invokeRequest).failure(any(EntityUserException.class));
-    verify(invokeRequest).retired();
   }
 
   @Test


### PR DESCRIPTION
-this kind of exception is state-safe, meaning that we can assume the problem would be mirrored on the passive, meaning that we can return it to the client, wrapped in EntityUserException
-this means that we no longer bring down the server when this exception is thrown