### PR TITLE
Fix #208: skip transaction caching for permanent entities

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/handler/EntityExistenceHelpers.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/EntityExistenceHelpers.java
@@ -43,9 +43,10 @@ public class EntityExistenceHelpers {
     Assert.assertNotNull(clientID);
     Assert.assertNotNull(transactionIDObject);
     Assert.assertNotNull(oldestTransactionOnClientObject);
-    long transactionID = transactionIDObject.toLong();
     
-    if (entityPersistor.wasEntityCreatedInJournal(clientID, transactionID)) {
+    long transactionID = transactionIDObject.toLong();
+    // if the clientID is null, then the create was server generated, don't log it or check it
+    if (!clientID.isNull() && entityPersistor.wasEntityCreatedInJournal(clientID, transactionID)) {
       // We either threw or did succeed in the journal, so just carry on as though we created it.
       resultWasCached = true;
     } else {
@@ -54,10 +55,16 @@ public class EntityExistenceHelpers {
       try {
         entityManager.createEntity(entityID, version, consumerID, canDelete);
         // Record the success.
-        entityPersistor.entityCreated(clientID, transactionID, oldestTransactionOnClient, entityID, version, consumerID, canDelete, configuration);
+    // if the clientID is null, then the create was server generated, don't log it or check it
+        if (!clientID.isNull()) {
+          entityPersistor.entityCreated(clientID, transactionID, oldestTransactionOnClient, entityID, version, consumerID, canDelete, configuration);
+        }
       } catch (EntityException e) {
         // Record the failure and re-throw.
-        entityPersistor.entityCreateFailed(clientID, transactionID, oldestTransactionOnClient, e);
+    // if the clientID is null, then the create was server generated, don't log it or check it
+        if (!clientID.isNull()) {
+          entityPersistor.entityCreateFailed(clientID, transactionID, oldestTransactionOnClient, e);
+        }
         throw e;
       }
     }
@@ -68,6 +75,7 @@ public class EntityExistenceHelpers {
     boolean resultWasCached = false;
     // We can't have a null client, transaction, or oldest transaction when an entity is destroyed - even synthetic clients shouldn't do this as they will disrupt clients.
     Assert.assertNotNull(clientID);
+    Assert.assertFalse(clientID.isNull());
     Assert.assertNotNull(transactionIDObject);
     Assert.assertNotNull(oldestTransactionOnClientObject);
     long transactionID = transactionIDObject.toLong();
@@ -98,6 +106,7 @@ public class EntityExistenceHelpers {
   public static boolean doesExist(EntityPersistor entityPersistor, ClientID clientID, TransactionID transactionIDObject, TransactionID oldestTransactionOnClientObject, EntityID entityID) {
     // We can't have a null client, transaction, or oldest transaction when an entity is checked - even synthetic clients shouldn't do this as they will disrupt clients.
     Assert.assertNotNull(clientID);
+    Assert.assertFalse(clientID.isNull());
     Assert.assertNotNull(transactionIDObject);
     Assert.assertNotNull(oldestTransactionOnClientObject);
     long transactionID = transactionIDObject.toLong();
@@ -110,6 +119,7 @@ public class EntityExistenceHelpers {
   public static byte[] reconfigureEntityReturnCachedResult(EntityPersistor entityPersistor, EntityManager entityManager, ClientID clientID, TransactionID transactionIDObject, TransactionID oldestTransactionOnClientObject, EntityID entityID, long version, byte[] configuration) throws EntityException {
     // We can't have a null client, transaction, or oldest transaction when an entity is created - even synthetic clients shouldn't do this as they will disrupt clients.
     Assert.assertNotNull(clientID);
+    Assert.assertFalse(clientID.isNull());
     Assert.assertNotNull(transactionIDObject);
     Assert.assertNotNull(oldestTransactionOnClientObject);
     long transactionID = transactionIDObject.toLong();

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/EntityExistenceHelpersTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/EntityExistenceHelpersTest.java
@@ -1,0 +1,87 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.objectserver.handler;
+
+import com.tc.net.ClientID;
+import com.tc.object.EntityID;
+import com.tc.object.tx.TransactionID;
+import com.tc.objectserver.api.EntityManager;
+import com.tc.objectserver.persistence.EntityPersistor;
+import com.tc.util.Assert;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Ignore;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ *
+ */
+public class EntityExistenceHelpersTest {
+  
+  public EntityExistenceHelpersTest() {
+  }
+  
+  @BeforeClass
+  public static void setUpClass() {
+  }
+  
+  @AfterClass
+  public static void tearDownClass() {
+  }
+  
+  @Before
+  public void setUp() {
+  }
+  
+  @After
+  public void tearDown() {
+  }
+
+  /**
+   * Test of createEntityReturnWasCached method, of class EntityExistenceHelpers.
+   */
+  @Test
+  public void testCreateEntityReturnWasCached() throws Exception {
+    EntityPersistor persistor = mock(EntityPersistor.class);
+    EntityManager manager = mock(EntityManager.class);
+    byte[] configuration = new byte[0];
+    ClientID cid = mock(ClientID.class);
+    TransactionID tid = mock(TransactionID.class);
+    EntityID eid = new EntityID("test", "test");
+    when(cid.isNull()).thenReturn(Boolean.FALSE);
+    boolean result = EntityExistenceHelpers.createEntityReturnWasCached(persistor, manager, cid, tid, TransactionID.NULL_ID, eid, 1, 1, configuration, true);
+// first run through should be false
+    Assert.assertFalse(result);
+    when(persistor.wasEntityCreatedInJournal(any(), anyLong())).thenReturn(Boolean.TRUE);
+    result = EntityExistenceHelpers.createEntityReturnWasCached(persistor, manager, cid, tid, TransactionID.NULL_ID, eid, 1, 1, configuration, true);
+// if the persistor thinks the entity was created, the entity return was cached
+    Assert.assertTrue(result);
+    when(cid.isNull()).thenReturn(Boolean.TRUE);
+    result = EntityExistenceHelpers.createEntityReturnWasCached(persistor, manager, cid, tid, TransactionID.NULL_ID, eid, 1, 1, configuration, true);
+// if the client id is null then the transaction was generated on the server and the return is never cached and the create never resent
+    Assert.assertFalse(result);
+  }
+}


### PR DESCRIPTION
When the client id is null, skip the transaction caching.  The action will never be resent.