### PR TITLE
Using bash instead of sh

### DIFF
--- a/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
+++ b/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # 
 # The contents of this file are subject to the Terracotta Public License Version


### PR DESCRIPTION
start-tc-server.sh uses bash syntax (eg function) but uses sh as the interpreter.   /bin/sh != /bin/bash on many unix flavors (eg Ubuntu, where /bin/sh = dash).   

In other words, this script cannot work without bash, hence it should say so.