### PR TITLE
Reverting this change while we investigate the problem

### DIFF
--- a/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
+++ b/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # 
 # The contents of this file are subject to the Terracotta Public License Version


### PR DESCRIPTION
-this is causing test hangs due to some subtlety of how invoking the bash-emulating sh as "bash" causes it to change some nuance of traps or kill