### PR TITLE
Fix #213 - terracotta-kit: Move plugins dir to server dir

### DIFF
--- a/terracotta-kit/src/assemble/distribution.xml
+++ b/terracotta-kit/src/assemble/distribution.xml
@@ -56,7 +56,7 @@ The Initial Developer of the Covered Software is
     </fileSet>
     <fileSet>
       <directory>${basedir}/src/assemble/plugins</directory>
-      <outputDirectory>/plugins</outputDirectory>
+      <outputDirectory>/server/plugins</outputDirectory>
     </fileSet>
     <fileSet>
       <directory>${basedir}/src/assemble/legal</directory>

--- a/terracotta-kit/src/assemble/server/bin/start-tc-server.bat
+++ b/terracotta-kit/src/assemble/server/bin/start-tc-server.bat
@@ -35,8 +35,8 @@ setlocal enabledelayedexpansion enableextensions
 
 set TC_INSTALL_DIR=%~d0%~p0..\..
 set TC_INSTALL_DIR="%TC_INSTALL_DIR:"=%"
-set PLUGIN_LIB_DIR=%TC_INSTALL_DIR%\plugins\lib
-set PLUGIN_API_DIR=%TC_INSTALL_DIR%\plugins\api
+set PLUGIN_LIB_DIR=%TC_INSTALL_DIR%\server\plugins\lib
+set PLUGIN_API_DIR=%TC_INSTALL_DIR%\server\plugins\api
 
 if exist %TC_INSTALL_DIR%\server\bin\setenv.bat (
   call %TC_INSTALL_DIR%\server\bin\setenv.bat

--- a/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
+++ b/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
@@ -45,8 +45,8 @@ trap cleanup_INT SIGINT
 
 THIS_DIR=`dirname $0`
 TC_INSTALL_DIR=`cd $THIS_DIR;pwd`/../..
-PLUGIN_LIB_DIR="$TC_INSTALL_DIR/plugins/lib"
-PLUGIN_API_DIR="$TC_INSTALL_DIR/plugins/api"
+PLUGIN_LIB_DIR="$TC_INSTALL_DIR/server/plugins/lib"
+PLUGIN_API_DIR="$TC_INSTALL_DIR/server/plugins/api"
 
 if test \! -d "${JAVA_HOME}"; then
   echo "$0: the JAVA_HOME environment variable is not defined correctly"


### PR DESCRIPTION
This PR creates terracotta-kit structure mentioned in #213 , basically moving plugins directory under server directory

new structure 
```
14:26:04 ~/Projects/work/kits $ tree -d terracotta-5.0.0-SNAPSHOT/
terracotta-5.0.0-SNAPSHOT/
├── client
├── legal
└── server
    ├── bin
    ├── lib
    └── plugins
        ├── api
        └── lib

8 directories
14:26:08 ~/Projects/work/kits $ 
```