### PR TITLE
Fix #212: create() assumes tryLock failure implies entity exists

### DIFF
--- a/connection-impl/src/main/java/com/terracotta/connection/entity/TerracottaEntityRef.java
+++ b/connection-impl/src/main/java/com/terracotta/connection/entity/TerracottaEntityRef.java
@@ -123,26 +123,33 @@ public class TerracottaEntityRef<T extends Entity, C> implements EntityRef<T, C>
   @Override
   public void create(C configuration) throws EntityNotProvidedException, EntityAlreadyExistsException, EntityVersionMismatchException {
     EntityID entityID = getEntityID();
-    this.maintenanceModeService.enterMaintenanceMode(this.type, this.name);
-    try {
-      this.entityManager.createEntity(entityID, this.version, Collections.singleton(VoltronEntityMessage.Acks.APPLIED), entityClientService.serializeConfiguration(configuration)).get();
-    } catch (EntityException e) {
-      // Note that we must externally only present the specific exception types we were expecting.  Thus, we need to check
-      // that this is one of those supported types, asserting that there was an unexpected wire inconsistency, otherwise.
-      if (e instanceof EntityNotProvidedException) {
-        throw (EntityNotProvidedException)e;
-      } else if (e instanceof EntityAlreadyExistsException) {
-        throw (EntityAlreadyExistsException)e;
-      } else if (e instanceof EntityVersionMismatchException) {
-        throw (EntityVersionMismatchException)e;
-      } else {
-        Assert.failure("Unsupported exception type returned to create", e);
+    // terracotta-core issue #212 - emulate fast-fail create() semantics
+    boolean didEnter = this.maintenanceModeService.tryEnterMaintenanceMode(this.type, this.name);
+    if (didEnter) {
+      try {
+        this.entityManager.createEntity(entityID, this.version, Collections.singleton(VoltronEntityMessage.Acks.APPLIED), entityClientService.serializeConfiguration(configuration)).get();
+      } catch (EntityException e) {
+        // Note that we must externally only present the specific exception types we were expecting.  Thus, we need to check
+        // that this is one of those supported types, asserting that there was an unexpected wire inconsistency, otherwise.
+        if (e instanceof EntityNotProvidedException) {
+          throw (EntityNotProvidedException)e;
+        } else if (e instanceof EntityAlreadyExistsException) {
+          throw (EntityAlreadyExistsException)e;
+        } else if (e instanceof EntityVersionMismatchException) {
+          throw (EntityVersionMismatchException)e;
+        } else {
+          // WARNING:  Assert.failure returns an exception, instead of throwing one.
+          throw Assert.failure("Unsupported exception type returned to create", e);
+        }
+      } catch (InterruptedException e) {
+        // We don't expect an interruption here.
+        throw new RuntimeException(e);
+      } finally {
+        this.maintenanceModeService.exitMaintenanceMode(this.type, this.name);
       }
-    } catch (InterruptedException e) {
-      // We don't expect an interruption here.
-      throw new RuntimeException(e);
-    } finally {
-      this.maintenanceModeService.exitMaintenanceMode(this.type, this.name);
+    } else {
+      // If we failed to enter the lock, we will assume that the entity exists since we no longer want to block in create().
+      throw new EntityAlreadyExistsException(entityID.getClassName(), entityID.getEntityName());
     }
   }
 


### PR DESCRIPTION
-this is a stop-gap to emulate a different locking scheme on top of the existing remnants of maintenance mode
-while it won't give the correct answer in all cases (for example, if the client holding a lock is trying to delete a non-existent entity), it will provide the correct response, and alleviate the locking behavior we no longer want, in the paths EhCache calls (where the lock is only held because the entity exists (a fetch), the entity is about to exist (create), or does exist and is about not to (destroy))

NOTE:  This should probably be rebased and merged _after_ the current set of in-flight PRs.