### PR TITLE
Preparing poms for release

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -42,12 +42,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <terracotta-apis.version>1.0-SNAPSHOT</terracotta-apis.version>
     <slf4j.version>1.7.7</slf4j.version>
     <management-core-version>2.0.8</management-core-version>
-    <tc-messaging.version>2.0.0-SNAPSHOT</tc-messaging.version>
 
-    <tcconfig.version>10.0-SNAPSHOT</tcconfig.version>
     <gmaven-plugin.version>1.4</gmaven-plugin.version>
     <copy-maven-plugin.version>0.2.3.8</copy-maven-plugin.version>
     <surefire.version>2.15</surefire.version>
@@ -120,7 +117,7 @@
       <dependency>
         <groupId>org.terracotta.internal</groupId>
         <artifactId>tc-messaging</artifactId>
-        <version>${tc-messaging.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>log4j</groupId>
@@ -173,12 +170,12 @@
       <dependency>
         <groupId>org.terracotta.internal</groupId>
         <artifactId>tc-config-parser</artifactId>
-        <version>${tcconfig.version}</version>
+        <version>${terracotta-configuration.version}</version>
       </dependency>
       <dependency>
         <groupId>org.terracotta</groupId>
         <artifactId>tcconfig-schema</artifactId>
-        <version>${tcconfig.version}</version>
+        <version>${terracotta-configuration.version}</version>
       </dependency>
 
       <!-- tests -->

--- a/client-logging/pom.xml
+++ b/client-logging/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>org.terracotta.internal</groupId>
             <artifactId>dso-l1</artifactId>
-            <version>5.0.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/client-runtime/pom.xml
+++ b/client-runtime/pom.xml
@@ -15,22 +15,22 @@
         <dependency>
             <groupId>org.terracotta</groupId>
             <artifactId>connection-api</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>${terracotta-apis.version}</version>
         </dependency>
         <dependency>
             <groupId>org.terracotta.internal</groupId>
             <artifactId>dso-l1</artifactId>
-            <version>5.0.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.terracotta.internal</groupId>
             <artifactId>connection-loader</artifactId>
-            <version>5.0.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.terracotta.internal</groupId>
             <artifactId>connection-impl</artifactId>
-            <version>5.0.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -78,13 +78,13 @@ Apache Ivy version: 2.2.0 20100923230623
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>entity-server-api</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>${terracotta-apis.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>packaging-support</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>${terracotta-apis.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,9 @@
     <maven-forge-plugin.version>1.2.13</maven-forge-plugin.version>
     <tc-shader.version>1.2</tc-shader.version>
     <skip.deploy>false</skip.deploy>
+
+    <terracotta-apis.version>1.0-SNAPSHOT</terracotta-apis.version>
+    <terracotta-configuration.version>10.0-SNAPSHOT</terracotta-configuration.version>
   </properties>
 
   <modules>

--- a/tc-messaging/pom.xml
+++ b/tc-messaging/pom.xml
@@ -35,7 +35,6 @@
   <artifactId>tc-messaging</artifactId>
   <packaging>jar</packaging>
   <name>Terracotta Messaging</name>
-  <version>2.0.0-SNAPSHOT</version>
 
   <properties>
     <java.build.version>1.6</java.build.version>
@@ -59,7 +58,7 @@
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>entity-common-api</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>${terracotta-apis.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/terracotta-kit/pom.xml
+++ b/terracotta-kit/pom.xml
@@ -23,12 +23,12 @@
         <dependency>
             <groupId>org.terracotta.internal</groupId>
             <artifactId>client-runtime</artifactId>
-            <version>5.0.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.terracotta.internal</groupId>
             <artifactId>client-logging</artifactId>
-            <version>5.0.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
-inline version references replaced with properties
-tc-messaging no longer uses its own version

Someone with Maven knowledge:  does this change make sense and seem right?
It was basically some changes I also needed to make along-side the version release.