### PR TITLE
workaround for solaris jvm that is unable to allocate more than 1.7GB…

### DIFF
--- a/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
+++ b/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
@@ -83,7 +83,9 @@ setPluginClasspath;
 start=true
 while "$start"
 do
-${JAVA_COMMAND} -Xms2g -Xmx2g -XX:+HeapDumpOnOutOfMemoryError \
+# the solaris 64-bit JVM has a bug that makes it fail to allocate more than 2GB of offheap when
+# the max heap is <= 2G, hence we set the heap size to a bit more than 2GB
+${JAVA_COMMAND} -Xms2049m -Xmx2049m -XX:+HeapDumpOnOutOfMemoryError \
    -Dcom.sun.management.jmxremote \
    -Dtc.install-root="${TC_INSTALL_DIR}" \
    -Dsun.rmi.dgc.server.gcInterval=31536000000\


### PR DESCRIPTION
… of offheap when it's started with 2G or less heap