### PR TITLE
Fix #242:  Updated dependencies on terracotta-parent, terracotta-apis, and terracotta-configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>terracotta-parent</artifactId>
-    <version>5.0.0.alpha2</version>
+    <version>5.0.0</version>
     <relativePath/>
   </parent>
 
@@ -41,8 +41,8 @@
     <tc-shader.version>1.2</tc-shader.version>
     <skip.deploy>false</skip.deploy>
 
-    <terracotta-apis.version>1.0-SNAPSHOT</terracotta-apis.version>
-    <terracotta-configuration.version>10.0-SNAPSHOT</terracotta-configuration.version>
+    <terracotta-apis.version>1.0.0.beta</terracotta-apis.version>
+    <terracotta-configuration.version>10.0.0.beta</terracotta-configuration.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
-terracotta-parent: 5.0.0
-terracotta-apis: 1.0.0.beta
-terracotta-configuration: 10.0.0.beta