### PR TITLE
address election corner case

### DIFF
--- a/dso-l2/src/main/java/com/tc/l2/state/StateManagerImpl.java
+++ b/dso-l2/src/main/java/com/tc/l2/state/StateManagerImpl.java
@@ -453,7 +453,11 @@ public class StateManagerImpl implements StateManager {
         // ACTIVE Node is gone
         setActiveNodeID(ServerID.NULL_ID);
       }
-      if (state != ACTIVE_COORDINATOR && activeNode.isNull()) {
+      if (state == PASSIVE_SYNCING && syncdTo.equals(disconnectedNode)) {
+        //  need to zap and start over.  The active being synced to is gone.
+        logger.fatal("Passive only partially synced when active disappeared.  Restarting");
+        throw new ZapDirtyDbServerNodeException("Passive only partially synced when active disappeared.  Restarting"); 
+      } else if (state != ACTIVE_COORDINATOR && activeNode.isNull()) {
         elect = true;
       }
     }


### PR DESCRIPTION
Partially synced servers cannot participate in elections.  If the server being synced from disappears, force the syncing server to zap itself.