### PR TITLE
Lifecycle cleanup

### DIFF
--- a/connection-impl/src/main/java/com/terracotta/connection/TerracottaConnection.java
+++ b/connection-impl/src/main/java/com/terracotta/connection/TerracottaConnection.java
@@ -44,7 +44,7 @@ public class TerracottaConnection implements Connection {
 
   private boolean isShutdown = false;
 
-  public TerracottaConnection(ClientEntityManager entityManager, ClientLockManager clientLockManager, Runnable shutdown) {
+  public TerracottaConnection(ClientEntityManager entityManager, Runnable shutdown) {
     this.entityManager = entityManager;
     this.shutdown = shutdown;
   }

--- a/connection-impl/src/main/java/com/terracotta/connection/entity/TerracottaEntityRef.java
+++ b/connection-impl/src/main/java/com/terracotta/connection/entity/TerracottaEntityRef.java
@@ -113,7 +113,7 @@ public class TerracottaEntityRef<T extends Entity, C> implements EntityRef<T, C>
   public void create(C configuration) throws EntityNotProvidedException, EntityAlreadyExistsException, EntityVersionMismatchException {
     EntityID entityID = getEntityID();
     try {
-      this.entityManager.createEntity(entityID, this.version, Collections.singleton(VoltronEntityMessage.Acks.APPLIED), entityClientService.serializeConfiguration(configuration)).get();
+      this.entityManager.createEntity(entityID, this.version, entityClientService.serializeConfiguration(configuration)).get();
     } catch (EntityException e) {
       // Note that we must externally only present the specific exception types we were expecting.  Thus, we need to check
       // that this is one of those supported types, asserting that there was an unexpected wire inconsistency, otherwise.
@@ -139,7 +139,7 @@ public class TerracottaEntityRef<T extends Entity, C> implements EntityRef<T, C>
     EntityID entityID = getEntityID();
     try {
       return entityClientService.deserializeConfiguration(
-          this.entityManager.reconfigureEntity(entityID, this.version, Collections.singleton(VoltronEntityMessage.Acks.APPLIED), entityClientService.serializeConfiguration(configuration)).get()
+          this.entityManager.reconfigureEntity(entityID, this.version, entityClientService.serializeConfiguration(configuration)).get()
       );
     } catch (EntityException e) {
       throw ExceptionUtils.addLocalStackTraceToEntityException(e);
@@ -174,7 +174,7 @@ public class TerracottaEntityRef<T extends Entity, C> implements EntityRef<T, C>
 
   private boolean destroyEntity() throws EntityNotFoundException, InterruptedException {
     EntityID entityID = getEntityID();
-    InvokeFuture<byte[]> future = this.entityManager.destroyEntity(entityID, this.version, Collections.<VoltronEntityMessage.Acks>emptySet());
+    InvokeFuture<byte[]> future = this.entityManager.destroyEntity(entityID, this.version);
     boolean success = false;
     
     try {

--- a/connection-impl/src/test/java/com/terracotta/connection/entity/TerracottaEntityRefTest.java
+++ b/connection-impl/src/test/java/com/terracotta/connection/entity/TerracottaEntityRefTest.java
@@ -84,7 +84,7 @@ public class TerracottaEntityRefTest {
   public void testTryDestroySuccess() throws Exception {
     // Set up the mocked infrastructure.
     ClientEntityManager mockClientEntityManager = mock(ClientEntityManager.class);
-    when(mockClientEntityManager.destroyEntity(any(EntityID.class), any(Long.class), any(Set.class))).thenReturn(mock(InvokeFuture.class));
+    when(mockClientEntityManager.destroyEntity(any(EntityID.class), any(Long.class))).thenReturn(mock(InvokeFuture.class));
     EntityClientService<Entity, Void, ? extends EntityMessage, ? extends EntityResponse> mockEntityClientService = mock(EntityClientService.class);
     
     // Now, run the test.
@@ -106,7 +106,7 @@ public class TerracottaEntityRefTest {
     ClientEntityManager mockClientEntityManager = mock(ClientEntityManager.class);
     InvokeFuture fut = mock(InvokeFuture.class);
     when(fut.get()).thenThrow(EntityReferencedException.class);
-    when(mockClientEntityManager.destroyEntity(Mockito.any(EntityID.class), Mockito.anyLong(), Mockito.any(Set.class))).thenReturn(fut);
+    when(mockClientEntityManager.destroyEntity(Mockito.any(EntityID.class), Mockito.anyLong())).thenReturn(fut);
     EntityClientService<Entity, Void, ? extends EntityMessage, ? extends EntityResponse> mockEntityClientService = mock(EntityClientService.class);
     
     // Now, run the test.
@@ -117,6 +117,6 @@ public class TerracottaEntityRefTest {
     boolean didDestroy = testRef.tryDestroy();
     Assert.assertFalse(didDestroy);
     // We should never have asked for the destroy to happen.
-    verify(mockClientEntityManager).destroyEntity(any(EntityID.class), any(Long.class), any(Set.class));
+    verify(mockClientEntityManager).destroyEntity(any(EntityID.class), any(Long.class));
   }
 }

--- a/connection-loader/src/main/java/com/terracotta/connection/ClientHandle.java
+++ b/connection-loader/src/main/java/com/terracotta/connection/ClientHandle.java
@@ -19,7 +19,6 @@
 package com.terracotta.connection;
 
 import com.tc.object.ClientEntityManager;
-import com.tc.object.locks.ClientLockManager;
 
 
 public interface ClientHandle {
@@ -31,10 +30,4 @@ public interface ClientHandle {
    * @return The client entity manager for end-points managed by this client.
    */
   ClientEntityManager getClientEntityManager();
-  
-  /**
-   * Required for TerracottaConnectionService Connection instantiation.
-   * @return The client lock manager for end-points managed by this client.
-   */
-  ClientLockManager getClientLockManager();
 }

--- a/connection-loader/src/main/java/com/terracotta/connection/ClientHandleImpl.java
+++ b/connection-loader/src/main/java/com/terracotta/connection/ClientHandleImpl.java
@@ -20,9 +20,6 @@ package com.terracotta.connection;
 
 import com.tc.object.ClientEntityManager;
 import com.tc.object.DistributedObjectClient;
-import com.tc.object.locks.ClientLockManager;
-
-import java.util.Set;
 
 
 public class ClientHandleImpl implements ClientHandle {
@@ -41,10 +38,5 @@ public class ClientHandleImpl implements ClientHandle {
   @Override
   public ClientEntityManager getClientEntityManager() {
     return client.getEntityManager();
-  }
-  
-  @Override
-  public ClientLockManager getClientLockManager() {
-    return client.getLockManager();
   }
 }

--- a/connection-loader/src/main/java/com/terracotta/connection/TerracottaInternalClient.java
+++ b/connection-loader/src/main/java/com/terracotta/connection/TerracottaInternalClient.java
@@ -51,10 +51,4 @@ public interface TerracottaInternalClient {
    * @return The client entity manager for end-points managed by this client.
    */
   ClientEntityManager getClientEntityManager();
-  
-  /**
-   * Required for TerracottaConnectionService Connection instantiation.
-   * @return The client lock manager for end-points managed by this client.
-   */
-  ClientLockManager getClientLockManager();
 }

--- a/connection-loader/src/main/java/com/terracotta/connection/TerracottaInternalClientImpl.java
+++ b/connection-loader/src/main/java/com/terracotta/connection/TerracottaInternalClientImpl.java
@@ -98,9 +98,4 @@ public class TerracottaInternalClientImpl implements TerracottaInternalClient {
   public ClientEntityManager getClientEntityManager() {
     return clientHandle.getClientEntityManager();
   }
-  
-  @Override
-  public ClientLockManager getClientLockManager() {
-    return clientHandle.getClientLockManager();
-  }
 }

--- a/connection-loader/src/main/java/com/terracotta/connection/api/TerracottaConnectionService.java
+++ b/connection-loader/src/main/java/com/terracotta/connection/api/TerracottaConnectionService.java
@@ -93,7 +93,7 @@ public class TerracottaConnectionService implements ConnectionService {
       throw new ConnectionException(ie);
     }
 
-    return new TerracottaConnection(client.getClientEntityManager(), client.getClientLockManager(), new Runnable() {
+    return new TerracottaConnection(client.getClientEntityManager(), new Runnable() {
         public void run() {
           client.shutdown();
           }

--- a/dso-l1/src/main/java/com/tc/object/ClientEntityManager.java
+++ b/dso-l1/src/main/java/com/tc/object/ClientEntityManager.java
@@ -25,12 +25,10 @@ import org.terracotta.entity.EntityMessage;
 import org.terracotta.entity.EntityResponse;
 import org.terracotta.exception.EntityException;
 
-import com.tc.entity.VoltronEntityMessage;
 import com.tc.object.handshakemanager.ClientHandshakeCallback;
 import com.tc.object.request.RequestResponseHandler;
 import com.tc.text.PrettyPrintable;
 
-import java.util.Set;
 
 
 /**
@@ -59,9 +57,9 @@ public interface ClientEntityManager extends PrettyPrintable, RequestResponseHan
    */
   void handleMessage(EntityDescriptor entityDescriptor, byte[] message);
 
-  InvokeFuture<byte[]> createEntity(EntityID entityID, long version, Set<VoltronEntityMessage.Acks> requestedAcks, byte[] config);
+  InvokeFuture<byte[]> createEntity(EntityID entityID, long version, byte[] config);
   
-  InvokeFuture<byte[]> destroyEntity(EntityID entityID, long version, Set<VoltronEntityMessage.Acks> requestedAcks);
+  InvokeFuture<byte[]> destroyEntity(EntityID entityID, long version);
 
-  InvokeFuture<byte[]> reconfigureEntity(EntityID entityID, long version, Set<VoltronEntityMessage.Acks> requestedAcks, byte[] config);
+  InvokeFuture<byte[]> reconfigureEntity(EntityID entityID, long version, byte[] config);
 }

--- a/dso-l1/src/main/java/com/tc/object/StandardClientBuilder.java
+++ b/dso-l1/src/main/java/com/tc/object/StandardClientBuilder.java
@@ -100,10 +100,7 @@ public class StandardClientBuilder implements ClientBuilder {
                                              ThreadIDManager threadManager,
                                              ClientLockManagerConfig config,
                                              TaskRunner taskRunner) {
-    final RemoteLockManager remoteLockManager = new RemoteLockManagerImpl(channel, lockRequestMessageFactory,
-        taskRunner);
-    return new ClientLockManagerImpl(clientIDLogger, sessionManager, channel, remoteLockManager, threadManager, config,
-        taskRunner);
+    return null;
   }
 
   @Override

--- a/dso-l1/src/test/java/com/tc/object/ClientEntityManagerTest.java
+++ b/dso-l1/src/test/java/com/tc/object/ClientEntityManagerTest.java
@@ -355,7 +355,7 @@ public class ClientEntityManagerTest extends TestCase {
     EntityException resultException = null;
     TestRequestBatchMessage message = new TestRequestBatchMessage(this.manager, resultObject, resultException, true);
     when(channel.createMessage(TCMessageType.VOLTRON_ENTITY_MESSAGE)).thenReturn(message);
-    InvokeFuture<byte[]> waiter = this.manager.createEntity(entityID, version, Collections.<Acks>emptySet(), config);
+    InvokeFuture<byte[]> waiter = this.manager.createEntity(entityID, version, config);
     // We are waiting for no ACKs so this should be available since the send will trigger the delivery.
     waiter.get();
   }

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -323,6 +323,8 @@ public class ReplicatedTransactionHandler {
           ManagedEntity temp = this.entityManager.createEntity(eid, sync.getVersion(), consumerID, sync.getConcurrency() == 0);          
           // We record this in the persistor but not record it in the journal since it has no originating client and can't be re-sent. 
           this.entityPersistor.entityCreatedNoJournal(eid, version, consumerID, !sync.getSource().isNull(), sync.getExtendedData());
+        } else {
+          Assert.fail("this entity should not be here");
         }
       } catch (EntityException exception) {
 //  TODO: this needs to be controlled.  

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/EntityPersistor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/EntityPersistor.java
@@ -117,6 +117,10 @@ public class EntityPersistor {
     // Record this in the journal - null error on success.
     addToJournal(clientID, transactionID, oldestTransactionOnClient, EntityData.Operation.CREATE, null, false, null);
   }
+  
+  public void entityCreatedJustInJournal(ClientID clientID, long transactionID, long oldestTransactionOnClient, EntityID id, long version) {
+    addToJournal(clientID, transactionID, oldestTransactionOnClient, EntityData.Operation.CREATE, null, false, null);
+  }
 
   public void entityCreatedNoJournal(EntityID id, long version, long consumerID, boolean canDelete, byte[] configuration) {
     LOGGER.debug("entityCreatedNoJournal " + id);


### PR DESCRIPTION
remove lock manager from the client.  The server counterpart is already gone

make anything but invokes wait for full retire before sending more messages.  This is to address some lifecycle resend bugs and create entity messages in the context of sync.