### PR TITLE
Fix #280 - Rapid lifecycle from multiple clients

### DIFF
--- a/dso-l1/src/main/java/com/tc/object/ClientEntityManagerImpl.java
+++ b/dso-l1/src/main/java/com/tc/object/ClientEntityManagerImpl.java
@@ -64,6 +64,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
 import org.terracotta.connection.ConnectionException;
+import org.terracotta.exception.EntityNotFoundException;
 
 
 public class ClientEntityManagerImpl implements ClientEntityManager {
@@ -315,6 +316,7 @@ public class ClientEntityManagerImpl implements ClientEntityManager {
   }
   
   private void throwClosedExceptionOnMessage(InFlightMessage msg) {
+    msg.received();
     msg.setResult(null, new EntityException(
         msg.getMessage().getEntityDescriptor().getEntityID().getClassName(),
         msg.getMessage().getEntityDescriptor().getEntityID().getEntityName(),
@@ -352,6 +354,8 @@ public class ClientEntityManagerImpl implements ClientEntityManager {
                              + " [Identity Hashcode : 0x" + Integer.toHexString(System.identityHashCode(resolvedEndpoint)) + "] ");
       }
       this.objectStoreMap.put(entityDescriptor, resolvedEndpoint);
+    } catch (EntityNotFoundException notfound) {
+      throw notfound;
     } catch (EntityException e) {
       // Release the entity and re-throw to the higher level.
       internalRelease(entityDescriptor, null);

--- a/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
@@ -79,6 +79,8 @@ public interface ManagedEntity extends StateDumpable {
   boolean isDestroyed();
   
   boolean isActive();
+  
+  boolean isRemoveable();
 
   /**
    * Used when an external component (such as CommunicatorService) needs to translate to/from something specific to this

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/PlatformEntity.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/PlatformEntity.java
@@ -90,6 +90,11 @@ public class PlatformEntity implements ManagedEntity {
   }
 
   @Override
+  public boolean isRemoveable() {
+    return false;
+  }
+
+  @Override
   public void reconnectClient(ClientID clientID, ClientDescriptor clientDescriptor, byte[] extendedReconnectData) {
   // never reconnect
   }

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/EntityExistenceHelpers.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/EntityExistenceHelpers.java
@@ -66,8 +66,6 @@ public class EntityExistenceHelpers {
         entityPersistor.entityCreated(clientID, transactionID, oldestTransactionOnClient, entityID, version, consumerID, canDelete, configuration);
       } else {
         entityPersistor.entityCreateFailed(clientID, transactionID, oldestTransactionOnClient, exception);
-//  entityManager is holding a shell that is not valid, remove it
-        entityManager.removeDestroyed(entityID);
       }
     }
   }
@@ -95,7 +93,6 @@ public class EntityExistenceHelpers {
     
       // Record the success.
     if (exception == null) {
-      entityManager.removeDestroyed(entityID);
       entityPersistor.entityDestroyed(clientID, transactionID, oldestTransactionOnClient, entityID);
     } else {
       entityPersistor.entityDestroyFailed(clientID, transactionID, oldestTransactionOnClient, exception);


### PR DESCRIPTION
Fixes issues related to multiple lifecycle operations invoked from multiple clients.
* handle isDestroyed flag in ```ManagedEntity.destroyEntity```
* only remove ManagedEntity from entityManager after the very last NOOP is issued
* properly handle entity not found in ReplicatedTransactionHandler