### PR TITLE
Populate consumerID in PlatformEntity

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/core/api/ITopologyEventCollector.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/core/api/ITopologyEventCollector.java
@@ -76,9 +76,10 @@ public interface ITopologyEventCollector {
    * Called when an entity is explicitly created in response to a request from a client.
    * 
    * @param id The unique identifier for this entity.
+   * @param consumerID The unique consumerID associated with this entity for its interaction with services.
    * @param isActive Whether or not it was created in active mode.
    */
-  public void entityWasCreated(EntityID id, boolean isActive);
+  public void entityWasCreated(EntityID id, long consumerID, boolean isActive);
 
   /**
    * Called when an entity is explicitly destroyed in response to a request from a client.
@@ -92,9 +93,10 @@ public interface ITopologyEventCollector {
    * of passive to active (which is potentially in-memory, only, as the server process remains).
    * 
    * @param id The unique identifier for this entity.
+   * @param consumerID The unique consumerID associated with this entity for its interaction with services.
    * @param isActive Whether or not it was created in active mode.
    */
-  public void entityWasReloaded(EntityID id, boolean isActive);
+  public void entityWasReloaded(EntityID id, long consumerID, boolean isActive);
 
   /**
    * Called when a given client successfully fetches a specific entity.  Note that the same client can fetch a given entity

--- a/dso-l2/src/main/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollector.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollector.java
@@ -206,12 +206,12 @@ public class ManagementTopologyEventCollector implements ITopologyEventCollector
   }
 
   @Override
-  public synchronized void entityWasCreated(EntityID id, boolean isActive) {
+  public synchronized void entityWasCreated(EntityID id, long consumerID, boolean isActive) {
     // Ensure that this is the expected state.
     Assert.assertTrue(isActive == this.isActiveState);
     // Ensure that this entity didn't already exist.
     Assert.assertFalse(this.entities.contains(id));
-    addEntityToTracking(id, isActive);
+    addEntityToTracking(id, consumerID, isActive);
   }
 
   @Override
@@ -223,13 +223,13 @@ public class ManagementTopologyEventCollector implements ITopologyEventCollector
   }
 
   @Override
-  public synchronized void entityWasReloaded(EntityID id, boolean isActive) {
+  public synchronized void entityWasReloaded(EntityID id, long consumerID, boolean isActive) {
     // Ensure that this is the expected state.
     // NOTE:  We currently can't verify the isActiveState since the reload path sets it _after_ the entities are reloaded.
     // Note that this could happen due to promotion or reloading from restart so we can't know if it already is in our set.
     if (!this.entities.contains(id)) {
       // Seems to be new so add it to the set.
-      addEntityToTracking(id, isActive);
+      addEntityToTracking(id, consumerID, isActive);
     }
   }
 
@@ -304,14 +304,14 @@ public class ManagementTopologyEventCollector implements ITopologyEventCollector
   }
 
 
-  private void addEntityToTracking(EntityID id, boolean isActive) {
+  private void addEntityToTracking(EntityID id, long consumerID, boolean isActive) {
     this.entities.add(id);
     
     // Add it to the monitoring interface.
     if (null != this.serviceInterface) {
       String entityClassName = id.getClassName();
       String entityName = id.getEntityName();
-      PlatformEntity record = new PlatformEntity(entityClassName, entityName, isActive);
+      PlatformEntity record = new PlatformEntity(entityClassName, entityName, consumerID, isActive);
       String entityIdentifier = entityIdentifierForService(id);
       this.serviceInterface.addNode(PlatformMonitoringConstants.ENTITIES_PATH, entityIdentifier, record);
     }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/EntityManagerImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/EntityManagerImpl.java
@@ -22,7 +22,6 @@ import org.terracotta.entity.EntityMessage;
 import org.terracotta.entity.EntityServerService;
 import org.terracotta.entity.StateDumper;
 import org.terracotta.exception.EntityException;
-import org.terracotta.exception.EntityNotFoundException;
 import org.terracotta.exception.EntityVersionMismatchException;
 
 import com.tc.object.EntityID;
@@ -41,9 +40,7 @@ import java.util.function.BiConsumer;
 import org.terracotta.entity.EntityResponse;
 import org.terracotta.entity.MessageCodec;
 import org.terracotta.entity.SyncMessageCodec;
-import org.terracotta.exception.EntityAlreadyExistsException;
 import org.terracotta.exception.EntityNotProvidedException;
-import org.terracotta.exception.PermanentEntityException;
 
 
 public class EntityManagerImpl implements EntityManager {
@@ -104,7 +101,7 @@ public class EntityManagerImpl implements EntityManager {
   public ManagedEntity createEntity(EntityID id, long version, long consumerID, boolean canDelete) throws EntityException {
     // Valid entity versions start at 1.
     Assert.assertTrue(version > 0);
-    ManagedEntity temp = new ManagedEntityImpl(id, version, noopLoopback, serviceRegistry.subRegistry(consumerID),
+    ManagedEntity temp = new ManagedEntityImpl(id, version, consumerID, noopLoopback, serviceRegistry.subRegistry(consumerID),
         clientEntityStateManager, this.eventCollector, processorPipeline, getVersionCheckedService(id, version), this.shouldCreateActiveEntities, canDelete);
     ManagedEntity exists = entities.putIfAbsent(id, temp);
     return exists != null ? exists : temp;
@@ -114,7 +111,7 @@ public class EntityManagerImpl implements EntityManager {
   public void loadExisting(EntityID entityID, long recordedVersion, long consumerID, boolean canDelete, byte[] configuration) throws EntityException {
     // Valid entity versions start at 1.
     Assert.assertTrue(recordedVersion > 0);
-    ManagedEntity temp = new ManagedEntityImpl(entityID, recordedVersion, noopLoopback, serviceRegistry.subRegistry(consumerID), clientEntityStateManager, this.eventCollector, processorPipeline, getVersionCheckedService(entityID, recordedVersion), this.shouldCreateActiveEntities, canDelete);
+    ManagedEntity temp = new ManagedEntityImpl(entityID, recordedVersion, consumerID, noopLoopback, serviceRegistry.subRegistry(consumerID), clientEntityStateManager, this.eventCollector, processorPipeline, getVersionCheckedService(entityID, recordedVersion), this.shouldCreateActiveEntities, canDelete);
     if (entities.putIfAbsent(entityID, temp) != null) {
       throw new IllegalStateException("Double create for entity " + entityID);
     }    

--- a/dso-l2/src/test/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollectorTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollectorTest.java
@@ -104,13 +104,14 @@ public class ManagementTopologyEventCollectorTest {
   @Test
   public void testCreatePromoteDestroy() throws Exception {
     EntityID id = mock(EntityID.class);
+    long consumerID = 1;
     // Note that we start in passive state.
     boolean isActive = false;
     
     // We should fail to create an entity as active.
     boolean didSucceed = false;
     try {
-      this.collector.entityWasCreated(id, true);
+      this.collector.entityWasCreated(id, consumerID, true);
       didSucceed = true;
     } catch (AssertionError e) {
       // Expected.
@@ -118,11 +119,11 @@ public class ManagementTopologyEventCollectorTest {
     Assert.assertFalse(didSucceed);
     
     // Create it as passive.
-    this.collector.entityWasCreated(id, isActive);
+    this.collector.entityWasCreated(id, consumerID, isActive);
     // We should fail to create it a second time.
     didSucceed = false;
     try {
-      this.collector.entityWasCreated(id, isActive);
+      this.collector.entityWasCreated(id, consumerID, isActive);
       didSucceed = true;
     } catch (AssertionError e) {
       // Expected.
@@ -134,7 +135,7 @@ public class ManagementTopologyEventCollectorTest {
     isActive = true;
     
     // Promote the entity to active.
-    this.collector.entityWasReloaded(id, isActive);
+    this.collector.entityWasReloaded(id, consumerID, isActive);
     
     // Now, destroy the entity.
     this.collector.entityWasDestroyed(id);
@@ -153,6 +154,7 @@ public class ManagementTopologyEventCollectorTest {
   @Test
   public void testFetchReleaseActiveEntity() throws Exception {
     EntityID id = mock(EntityID.class);
+    long consumerID = 1;
     MessageChannel channel = mock(MessageChannel.class);
     ClientID client = mock(ClientID.class);
     ClientDescriptor clientDescriptor = mock(ClientDescriptor.class);
@@ -162,7 +164,7 @@ public class ManagementTopologyEventCollectorTest {
     boolean isActive = true;
     
     // Create the entity.
-    this.collector.entityWasCreated(id, isActive);
+    this.collector.entityWasCreated(id, consumerID, isActive);
     
     // Connect the client.
     this.collector.clientDidConnect(channel, client);
@@ -266,8 +268,9 @@ public class ManagementTopologyEventCollectorTest {
     
     String typeName = "typeName";
     String entityName = "entityName";
+    long consumerID = 1;
     boolean isActive = false;
-    PlatformEntity originalEntity = new PlatformEntity(typeName, entityName, isActive);
+    PlatformEntity originalEntity = new PlatformEntity(typeName, entityName, consumerID, isActive);
     
     String serverName = "serverName";
     String host = "host";

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
@@ -58,7 +58,6 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.BiConsumer;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.mockito.Matchers;
@@ -84,6 +83,7 @@ public class ManagedEntityImplTest {
   private EntityID entityID;
   private ClientInstanceID clientInstanceID;
   private long version;
+  private long consumerID;
   private ManagedEntityImpl managedEntity;
   private BiConsumer<EntityID, Long> loopback;
   private InternalServiceRegistry serviceRegistry;
@@ -115,6 +115,7 @@ public class ManagedEntityImplTest {
     entityID = new EntityID(TestEntity.class.getName(), "foo");
     clientInstanceID = new ClientInstanceID(1);
     version = 1;
+    consumerID = 1;
     entityDescriptor = new EntityDescriptor(entityID, clientInstanceID, version);
     serviceRegistry = mock(InternalServiceRegistry.class);
     
@@ -128,7 +129,7 @@ public class ManagedEntityImplTest {
     eventCollector = mock(ITopologyEventCollector.class);
     // We will start this in a passive state, as the general test case.
     boolean isInActiveState = false;
-    managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, isInActiveState, true);
+    managedEntity = new ManagedEntityImpl(entityID, version, consumerID, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, isInActiveState, true);
     clientDescriptor = new ClientDescriptorImpl(nodeID, entityDescriptor);
     Mockito.doAnswer(new Answer<Object>() {
       @Override
@@ -236,7 +237,7 @@ public class ManagedEntityImplTest {
       }
     });
     // create a ManagedEntity which is in active state
-    ManagedEntityImpl activeEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, true, true);
+    ManagedEntityImpl activeEntity = new ManagedEntityImpl(entityID, version, consumerID, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, true, true);
     // We want to pretend that we are the expected thread.
     Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
     ServerEntityRequest request = mockCreateEntityRequest();
@@ -251,7 +252,7 @@ public class ManagedEntityImplTest {
   public void testGetEntityMissing() throws Exception {
     TestingResponse response = mockResponse();
     // create a ManagedEntity which is in active state
-    ManagedEntityImpl managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, true, true);
+    ManagedEntityImpl managedEntity = new ManagedEntityImpl(entityID, version, consumerID, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, true, true);
     Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
     
     com.tc.net.ClientID requester = new com.tc.net.ClientID(0);
@@ -338,7 +339,7 @@ public class ManagedEntityImplTest {
         return Collections.singleton(1);
       }
     });
-    managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, false, true);
+    managedEntity = new ManagedEntityImpl(entityID, version, consumerID, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, false, true);
     TestingResponse resp = mockResponse();
     managedEntity.addRequestMessage(mockCreateEntityRequest(), MessagePayload.EMPTY,  resp::complete, resp::failure);
     resp.waitFor();
@@ -401,7 +402,7 @@ public class ManagedEntityImplTest {
         return Collections.singleton(1);
       }
     });
-    managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, false, true);
+    managedEntity = new ManagedEntityImpl(entityID, version, consumerID, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, false, true);
     managedEntity.addRequestMessage(mockCreateEntityRequest(), MessagePayload.EMPTY,  response::complete, response::failure);
     response.waitFor();
     managedEntity.promoteEntity();
@@ -501,7 +502,7 @@ public class ManagedEntityImplTest {
     when(this.serverEntityService.getConcurrencyStrategy(any(byte[].class))).thenReturn(basic);
     when(this.serverEntityService.getMessageCodec()).thenReturn(codec);
     TestingResponse response = mockResponse();
-    managedEntity = new ManagedEntityImpl(entityID, version, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, false, true);
+    managedEntity = new ManagedEntityImpl(entityID, version, consumerID, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, false, true);
     managedEntity.addRequestMessage(mockCreateEntityRequest(), MessagePayload.EMPTY, response::complete, response::failure);
     response.waitFor();
     managedEntity.promoteEntity();

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
     <tc-shader.version>1.2</tc-shader.version>
     <skip.deploy>false</skip.deploy>
 
-    <terracotta-apis.version>1.0.5.beta</terracotta-apis.version>
-    <terracotta-configuration.version>10.0.5.beta</terracotta-configuration.version>
+    <terracotta-apis.version>1.0.6.beta</terracotta-apis.version>
+    <terracotta-configuration.version>10.0.6.beta</terracotta-configuration.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
-updated dependencies for terracotta-apis 1.0.6.beta and terracotta-configuration 10.0.6.beta
-this is mostly just plumbing the consumerID down through ManagementTopologyEventCollector