### PR TITLE
Ship lifecycle log

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/EntityManagerImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/EntityManagerImpl.java
@@ -18,6 +18,8 @@
  */
 package com.tc.objectserver.entity;
 
+import com.tc.logging.TCLogger;
+import com.tc.logging.TCLogging;
 import org.terracotta.entity.EntityMessage;
 import org.terracotta.entity.EntityServerService;
 import org.terracotta.entity.StateDumper;
@@ -44,6 +46,7 @@ import org.terracotta.exception.EntityNotProvidedException;
 
 
 public class EntityManagerImpl implements EntityManager {
+  private static final TCLogger LOGGER = TCLogging.getLogger(EntityManagerImpl.class);
   private final ConcurrentMap<EntityID, ManagedEntity> entities = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, EntityServerService<EntityMessage, EntityResponse>> entityServices = new ConcurrentHashMap<>();
 
@@ -104,6 +107,9 @@ public class EntityManagerImpl implements EntityManager {
     ManagedEntity temp = new ManagedEntityImpl(id, version, consumerID, noopLoopback, serviceRegistry.subRegistry(consumerID),
         clientEntityStateManager, this.eventCollector, processorPipeline, getVersionCheckedService(id, version), this.shouldCreateActiveEntities, canDelete);
     ManagedEntity exists = entities.putIfAbsent(id, temp);
+    if (exists == null) {
+      LOGGER.debug("created " + id);
+    }
     return exists != null ? exists : temp;
   }
 
@@ -126,6 +132,9 @@ public class EntityManagerImpl implements EntityManager {
       if (entities.remove(id) != null) {
         removed = true;
       }
+    }
+    if (removed) {
+      LOGGER.debug("removed " + id);
     }
     return removed;
   }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -708,17 +708,19 @@ public class ManagedEntityImpl implements ManagedEntity {
     // Can't enter active state twice.
     Assert.assertFalse(this.isInActiveState);
     Assert.assertNull(this.activeServerEntity);
-    
-    this.isInActiveState = true;
-    if (null != this.passiveServerEntity) {
-      this.activeServerEntity = factory.createActiveEntity(this.registry, this.constructorInfo);
-      this.concurrencyStrategy = factory.getConcurrencyStrategy(this.constructorInfo);
-      this.activeServerEntity.loadExisting();
-      this.passiveServerEntity = null;
-      // Fire the event that the entity was reloaded.
-      this.eventCollector.entityWasReloaded(this.getID(), this.consumerID, true);
-    } else {
-      throw new IllegalStateException("no entity to promote");
+//  checking destroyed here should be fine.  no other threads should be touching during promote
+    if (!this.isDestroyed) {
+      this.isInActiveState = true;
+      if (null != this.passiveServerEntity) {
+        this.activeServerEntity = factory.createActiveEntity(this.registry, this.constructorInfo);
+        this.concurrencyStrategy = factory.getConcurrencyStrategy(this.constructorInfo);
+        this.activeServerEntity.loadExisting();
+        this.passiveServerEntity = null;
+        // Fire the event that the entity was reloaded.
+        this.eventCollector.entityWasReloaded(this.getID(), this.consumerID, true);
+      } else {
+        throw new IllegalStateException("no entity to promote");
+      }
     }
   }
   

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
@@ -109,7 +109,7 @@ public class RequestProcessor implements StateChangeListener {
         actionCode = ReplicationMessage.ReplicationType.NOOP;
         break;
       case RELEASE_ENTITY:
-        actionCode = ReplicationMessage.ReplicationType.RELEASE_ENTITY;
+        actionCode = ReplicationMessage.ReplicationType.NOOP;
         break;
       case REQUEST_SYNC_ENTITY:
 //  this marks the start of entity sync for a concurrency key.  practically, this means that

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -50,6 +50,9 @@ import com.tc.objectserver.entity.ServerEntityRequestResponse;
 import com.tc.objectserver.persistence.EntityPersistor;
 import com.tc.objectserver.persistence.TransactionOrderPersistor;
 import com.tc.util.Assert;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
@@ -362,6 +365,11 @@ public class ReplicatedTransactionHandler {
           MessagePayload payload = new MessagePayload(sync.getExtendedData(), null, sync.getConcurrency());
           platform.addRequestMessage(make(sync), payload, (result)-> {
             if (sync.getReplicationType() == ReplicationMessage.ReplicationType.SYNC_END) {
+              try {
+                entityPersistor.layer(new ObjectInputStream(new ByteArrayInputStream(payload.getRawPayload())));
+              } catch (IOException ioe) {
+                throw new RuntimeException(ioe);
+              }
               moveToPassiveStandBy();
             }
             acknowledge(sync);

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -354,7 +354,9 @@ public class ReplicatedTransactionHandler {
           entity.get().addRequestMessage(makeNoop(eid, version), MessagePayload.EMPTY, null, null);
         }
       } else {
-        if (!eid.equals(EntityID.NULL_ID)) {
+        if (sync.getReplicationType() == ReplicationMessage.ReplicationType.NOOP) {
+          acknowledge(sync);
+        } else if (!eid.equals(EntityID.NULL_ID)) {
           throw new AssertionError();
         } else {
           MessagePayload payload = new MessagePayload(sync.getExtendedData(), null, sync.getConcurrency());
@@ -503,8 +505,6 @@ public class ReplicatedTransactionHandler {
         return ServerEntityAction.RECONFIGURE_ENTITY;
       case INVOKE_ACTION:
         return ServerEntityAction.INVOKE_ACTION;
-      case RELEASE_ENTITY:
-        return ServerEntityAction.RELEASE_ENTITY;
       case DESTROY_ENTITY:
         return ServerEntityAction.DESTROY_ENTITY;
       case SYNC_ENTITY_BEGIN:

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/EntityData.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/EntityData.java
@@ -80,9 +80,12 @@ public class EntityData {
     public long transactionID;
     // reconfigureResponse is only used to store the result of RECONFIGURE.
     public byte[] reconfigureResponse;
-    // didFind is only used to store the result of DOES_EXIST.
-    public boolean didFind;
     // The exception in CREATE/DESTROY is saved here, null on success.
     public EntityException failure;
+
+    @Override
+    public String toString() {
+      return "JournalEntry{" + "operation=" + operation + ", transactionID=" + transactionID + '}';
+    }
   }
 }

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ActiveToPassiveReplicationTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ActiveToPassiveReplicationTest.java
@@ -24,6 +24,7 @@ import com.tc.l2.msg.ReplicationMessage;
 import com.tc.net.ServerID;
 import com.tc.net.groups.MessageID;
 import com.tc.objectserver.api.ManagedEntity;
+import com.tc.objectserver.persistence.EntityPersistor;
 import com.tc.util.Assert;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
@@ -70,7 +71,7 @@ public class ActiveToPassiveReplicationTest {
         return null;
       }
     }).when(replicate).addSingleThreaded(Matchers.any());
-    replication = new ActiveToPassiveReplication(Collections.singleton(passive), entities, replicate);
+    replication = new ActiveToPassiveReplication(Collections.singleton(passive), entities, mock(EntityPersistor.class), replicate);
   }
   
   @Test

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
@@ -152,7 +152,7 @@ public class ReplicatedTransactionHandlerTest {
     this.loopbackSink.addSingleThreaded(msg);
     this.loopbackSink.addSingleThreaded(PassiveSyncMessage.createEndEntityKeyMessage(eid, 1, rand));
     this.loopbackSink.addSingleThreaded(PassiveSyncMessage.createEndEntityMessage(eid, 1));
-    this.loopbackSink.addSingleThreaded(PassiveSyncMessage.createEndSyncMessage());
+    this.loopbackSink.addSingleThreaded(PassiveSyncMessage.createEndSyncMessage(new byte[0]));
 //  verify there was an attempt to decode the invoke message
     verify(msg).getExtendedData();
     verify(entity).getCodec();
@@ -188,7 +188,7 @@ public class ReplicatedTransactionHandlerTest {
       return null;
     }).when(entity).addRequestMessage(Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any());
     this.loopbackSink.addSingleThreaded(PassiveSyncMessage.createStartSyncMessage());
-    this.loopbackSink.addSingleThreaded(PassiveSyncMessage.createEndSyncMessage());
+    this.loopbackSink.addSingleThreaded(PassiveSyncMessage.createEndSyncMessage(new byte[0]));
     this.loopbackSink.addSingleThreaded(msg);
     verify(msg).getExtendedData();
     verify(msg).getConcurrency();  // make sure RTH is pulling the concurrency from the message
@@ -313,7 +313,7 @@ public class ReplicatedTransactionHandlerTest {
     send(createMockReplicationMessage(eid, VERSION, ByteBuffer.wrap(new byte[Integer.BYTES]).putInt(6).array(), 4));
     send(PassiveSyncMessage.createEndEntityKeyMessage(eid, 1, 4)); 
     send(PassiveSyncMessage.createEndEntityMessage(eid, VERSION));
-    send(PassiveSyncMessage.createEndSyncMessage());
+    send(PassiveSyncMessage.createEndSyncMessage(new byte[0]));
   }
 
   private long send(ReplicationMessage msg) throws EventHandlerException {

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicationSenderTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicationSenderTest.java
@@ -94,7 +94,6 @@ public class ReplicationSenderTest {
       case INVOKE_ACTION:
       case NOOP:
       case RECONFIGURE_ENTITY:
-      case RELEASE_ENTITY:
         return ReplicationMessage.createReplicatedMessage(new EntityDescriptor(entity, ClientInstanceID.NULL_ID, 1), ClientID.NULL_ID, TransactionID.NULL_ID, TransactionID.NULL_ID, type, new byte[0], 0);
       case SYNC_BEGIN:
         return PassiveSyncMessage.createStartSyncMessage();

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicationSenderTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicationSenderTest.java
@@ -98,7 +98,7 @@ public class ReplicationSenderTest {
       case SYNC_BEGIN:
         return PassiveSyncMessage.createStartSyncMessage();
       case SYNC_END:
-        return PassiveSyncMessage.createEndSyncMessage();
+        return PassiveSyncMessage.createEndSyncMessage(new byte[0]);
       case SYNC_ENTITY_BEGIN:
         return PassiveSyncMessage.createStartEntityMessage(entity, 1, new byte[0], true);
       case SYNC_ENTITY_CONCURRENCY_BEGIN:

--- a/tc-messaging/src/main/java/com/tc/l2/msg/PassiveSyncMessage.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/PassiveSyncMessage.java
@@ -43,8 +43,8 @@ public class PassiveSyncMessage extends ReplicationMessage {
   public static PassiveSyncMessage createStartSyncMessage() {
     return new PassiveSyncMessage(SYNC_BEGIN, EntityID.NULL_ID, NO_VERSION, 0, null);
   }
-  public static PassiveSyncMessage createEndSyncMessage() {
-    return new PassiveSyncMessage(SYNC_END, EntityID.NULL_ID, NO_VERSION, 0, null);
+  public static PassiveSyncMessage createEndSyncMessage(byte[] extras) {
+    return new PassiveSyncMessage(SYNC_END, EntityID.NULL_ID, NO_VERSION, 0, extras);
   }
   public static PassiveSyncMessage createStartEntityMessage(EntityID id, long version, byte[] configPayload, boolean canDelete) {
  //  repurposed concurrency id to tell passive if entity can be deleted 0 for deletable and 1 for not deletable

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
@@ -24,6 +24,7 @@ import com.tc.io.TCByteBufferOutput;
 import com.tc.net.ClientID;
 import com.tc.net.NodeID;
 import com.tc.net.groups.AbstractGroupMessage;
+import com.tc.net.groups.MessageID;
 import com.tc.object.ClientInstanceID;
 import com.tc.object.EntityDescriptor;
 import com.tc.object.EntityID;
@@ -46,7 +47,6 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
     CREATE_ENTITY,
     RECONFIGURE_ENTITY,
     INVOKE_ACTION,
-    RELEASE_ENTITY,
     DESTROY_ENTITY,
     
     SYNC_BEGIN,
@@ -128,6 +128,10 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
   
   public void setReplicationID(long rid) {
     this.rid = rid;
+  }
+  
+  public void setNoop() {
+    this.action = ReplicationType.NOOP;
   }
 
   @Override


### PR DESCRIPTION
*  Fix an issue with promotion of a destroyed entity
*  Ship the entity lifecycle log as the last part of passive sync
*  Clean the lifecycle log after each state transition
*  Fix NOOP use in replication
*  Fix ordering on the passive of filtered transactions