### PR TITLE
fix buggy/racy unit test for managed entities

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -716,8 +716,8 @@ public class ManagedEntityImpl implements ManagedEntity {
     Assert.assertFalse(this.isInActiveState);
     Assert.assertNull(this.activeServerEntity);
 //  checking destroyed here should be fine.  no other threads should be touching during promote
+    this.isInActiveState = true;
     if (!this.isDestroyed) {
-      this.isInActiveState = true;
       if (null != this.passiveServerEntity) {
         this.activeServerEntity = factory.createActiveEntity(this.registry, this.constructorInfo);
         this.concurrencyStrategy = factory.getConcurrencyStrategy(this.constructorInfo);


### PR DESCRIPTION
This test did not emulate platform threads properly.  Test threads would fail silently with assertion checks causing tests to fail in strange ways.  Even though these tests still use multiple threads.  Execution is much more linear with flushes of the execution and transaction handler threads being flushed at every point a completion is waited for.  This should clear up any racy behavior.