### PR TITLE
FlatFileStorageServiceProvider now handles start-up locking

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -1047,10 +1047,6 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
     });
   }
 
-  public boolean isBlocking() {
-    return this.startupLock != null && this.startupLock.isBlocked();
-  }
-
   public void startActiveMode(boolean wasStandby) {
     if (!wasStandby && persistor.getClusterStatePersistor().getInitialState() == null) {
       Sink<VoltronEntityMessage> msgSink = this.seda.getStageManager().getStage(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE, VoltronEntityMessage.class).getSink();
@@ -1124,49 +1120,6 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
     final int configValue = l2DSOConfig.tsaGroupPort().getValue();
     if (configValue != 0) { return configValue; }
     return -1;
-  }
-
-  public synchronized void stop() {
-
-    this.seda.getStageManager().stopAll();
-
-    if (this.l1Listener != null) {
-      try {
-        this.l1Listener.stop(5000);
-      } catch (final TCTimeoutException e) {
-        logger.warn("timeout trying to stop listener: " + e.getMessage());
-      }
-    }
-
-    if ((this.communicationsManager != null)) {
-      this.communicationsManager.shutdown();
-    }
-
-    try {
-      this.persistor.close();
-    } catch (final Exception e) {
-      logger.warn(e);
-    }
-
-    if (this.sampledCounterManager != null) {
-      try {
-        this.sampledCounterManager.shutdown();
-      } catch (final Exception e) {
-        logger.error(e);
-      }
-    }
-
-    basicStop();
-  }
-
-  public void quickStop() {
-    basicStop();
-  }
-
-  private void basicStop() {
-    if (this.startupLock != null) {
-      this.startupLock.release();
-    }
   }
 
   public ConnectionIDFactory getConnectionIdFactory() {

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -65,7 +65,6 @@ import com.tc.handler.CallbackZapServerNodeExceptionAdapter;
 import com.tc.handler.LockInfoDumpHandler;
 import com.tc.io.TCFile;
 import com.tc.io.TCFileImpl;
-import com.tc.io.TCRandomFileAccessImpl;
 import com.tc.l2.api.L2Coordinator;
 import com.tc.l2.api.ReplicatedClusterStateManager;
 import com.tc.l2.context.StateChangedEvent;
@@ -214,7 +213,6 @@ import com.tc.stats.counter.sampled.derived.SampledRateCounterConfig;
 import com.tc.util.Assert;
 import com.tc.util.CommonShutDownHook;
 import com.tc.util.ProductInfo;
-import com.tc.util.StartupLock;
 import com.tc.util.TCTimeoutException;
 import com.tc.util.UUID;
 import com.tc.util.concurrent.Runners;
@@ -276,7 +274,6 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
   private CounterManager                         sampledCounterManager;
   private LockManagerImpl                        lockManager;
   private ServerManagementContext                managementContext;
-  private StartupLock                            startupLock;
   private Persistor                              persistor;
 
   private L2Coordinator                          l2Coordinator;
@@ -430,19 +427,6 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
     serverName = serverName.replace('.', '-');
     serverName = serverName.replace(':', '$');
 
-    final TCFile location = new TCFileImpl(dataLoc, serverName);
-    boolean retries = tcProperties.getBoolean(TCPropertiesConsts.L2_STARTUPLOCK_RETRIES_ENABLED);
-    this.startupLock = this.serverBuilder.createStartupLock(location, retries);
-
-    if (!this.startupLock.canProceed(new TCRandomFileAccessImpl())) {
-      consoleLogger.error("Another L2 process is using the directory " + location + " as data directory.");
-      if (!restartable) {
-        consoleLogger.error("This is not allowed with persistence mode set to temporary-swap-only.");
-      }
-      consoleLogger.error("Exiting...");
-      System.exit(1);
-    }
-
     final int maxStageSize = TCPropertiesImpl.getProperties().getInt(TCPropertiesConsts.L2_SEDA_STAGE_SINK_CAPACITY);
     final StageManager stageManager = this.seda.getStageManager();
     final SessionManager sessionManager = new NullSessionManager();
@@ -462,7 +446,11 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
       //  treating it as a core component of the platform but, in the future, it may move out and be loaded like user
       //  services or be discarded, entirely.
       FlatFileStorageServiceProvider flatFileService = new FlatFileStorageServiceProvider();
-      if (!flatFileService.initialize(new FlatFileStorageProviderConfiguration(location.getFile()), platformConfiguration)) {
+      final TCFile location = new TCFileImpl(dataLoc, serverName);
+      // We want to make sure that the directory exists before we configure the service.
+      location.forceMkdir();
+      boolean shouldBlockOnLock = tcProperties.getBoolean(TCPropertiesConsts.L2_STARTUPLOCK_RETRIES_ENABLED);
+      if (!flatFileService.initialize(new FlatFileStorageProviderConfiguration(location.getFile(), shouldBlockOnLock), platformConfiguration)) {
         throw new AssertionError("bad flat file initialization");
       }
       serviceRegistry.registerExternal(flatFileService);

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/ServerBuilder.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/ServerBuilder.java
@@ -23,7 +23,6 @@ import org.terracotta.entity.ServiceRegistry;
 import com.tc.async.api.PostInit;
 import com.tc.async.api.StageManager;
 import com.tc.config.schema.setup.L2ConfigurationSetupManager;
-import com.tc.io.TCFile;
 import com.tc.l2.api.L2Coordinator;
 import com.tc.l2.ha.WeightGeneratorFactory;
 import com.tc.l2.state.StateManager;
@@ -46,7 +45,6 @@ import com.tc.objectserver.locks.LockManager;
 import com.tc.objectserver.persistence.ClusterStatePersistor;
 import com.tc.objectserver.persistence.Persistor;
 import com.tc.runtime.logging.LongGCLogger;
-import com.tc.util.StartupLock;
 
 import java.io.IOException;
 
@@ -77,8 +75,6 @@ public interface ServerBuilder extends TCDumper, PostInit {
   Persistor createPersistor(ServiceRegistry serviceRegistry) throws IOException;
 
   LongGCLogger createLongGCLogger(long gcTimeOut);
-
-  StartupLock createStartupLock(TCFile location, boolean retries);
 
   GroupID getLocalGroupId();
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/StandardServerBuilder.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/StandardServerBuilder.java
@@ -24,7 +24,6 @@ import com.tc.async.api.ConfigurationContext;
 import com.tc.async.api.StageManager;
 import com.tc.config.HaConfig;
 import com.tc.config.schema.setup.L2ConfigurationSetupManager;
-import com.tc.io.TCFile;
 import com.tc.l2.api.L2Coordinator;
 import com.tc.l2.ha.L2HACoordinator;
 import com.tc.l2.ha.WeightGeneratorFactory;
@@ -53,8 +52,6 @@ import com.tc.objectserver.persistence.PersistentStorageServiceConfiguration;
 import com.tc.objectserver.persistence.Persistor;
 import com.tc.runtime.logging.LongGCLogger;
 import com.tc.util.Assert;
-import com.tc.util.NonBlockingStartupLock;
-import com.tc.util.StartupLock;
 import com.tc.util.runtime.ThreadDumpUtil;
 
 import org.terracotta.persistence.IPersistentStorage;
@@ -126,11 +123,6 @@ public class StandardServerBuilder implements ServerBuilder {
   @Override
   public LongGCLogger createLongGCLogger(long gcTimeOut) {
     return new LongGCLogger(gcTimeOut);
-  }
-
-  @Override
-  public StartupLock createStartupLock(TCFile location, boolean retries) {
-    return new NonBlockingStartupLock(location, retries);
   }
 
   @Override

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/FlatFileStorageProviderConfiguration.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/FlatFileStorageProviderConfiguration.java
@@ -27,15 +27,21 @@ import com.tc.util.Assert;
 
 public class FlatFileStorageProviderConfiguration implements ServiceProviderConfiguration {
   private final File basedir;
+  private final boolean shouldBlockOnLock;
 
-  public FlatFileStorageProviderConfiguration(File basedir) {
+  public FlatFileStorageProviderConfiguration(File basedir, boolean shouldBlockOnLock) {
     Assert.assertNotNull(basedir);
     Assert.assertTrue(basedir.isDirectory());
     this.basedir = basedir;
+    this.shouldBlockOnLock = shouldBlockOnLock;
   }
 
   public File getBasedir() {
     return this.basedir;
+  }
+
+  public boolean shouldBlockOnLock() {
+    return this.shouldBlockOnLock;
   }
 
   @Override

--- a/dso-l2/src/main/java/com/tc/server/TCServerImpl.java
+++ b/dso-l2/src/main/java/com/tc/server/TCServerImpl.java
@@ -217,15 +217,9 @@ public class TCServerImpl extends SEDA<HttpConnectionContext> implements TCServe
    */
   @Override
   public void stop() {
-    synchronized (this.stateLock) {
-      if (this.isStopped()) {
-        stopServer();
-        logger.info("Server stopped.");
-      } else {
-        logger.warn("Server in incorrect state (" + this.serverState + ") to be stopped.");
-      }
-    }
-
+    // XXX: This is part of the now-deprecated JMX 4.x Management interface called from TCServerInfo.
+    // TODO:  Remove the com.tc.mangement.beans package and then this method.
+    throw new UnsupportedOperationException("Management can no longer request a server shutdown");
   }
 
   @Override
@@ -380,31 +374,6 @@ public class TCServerImpl extends SEDA<HttpConnectionContext> implements TCServe
     return buf.toString();
   }
 
-  private void stopServer() {
-    // XXX: I have no idea if order of operations is correct here?
-
-    if (logger.isDebugEnabled()) {
-      consoleLogger.debug("Stopping TC server...");
-    }
-
-    try {
-      getStageManager().stopAll();
-    } catch (Exception e) {
-      logger.error("Error shutting down stage manager", e);
-    }
-
-    // this stops the jmx server then dso server
-    if (this.dsoServer != null) {
-      try {
-        this.dsoServer.quickStop();
-      } catch (Exception e) {
-        logger.error("Error shutting down TSA server", e);
-      } finally {
-        this.dsoServer = null;
-      }
-    }
-
-  }
 
   private class StartAction implements StartupAction {
     @Override

--- a/dso-l2/src/test/java/com/tc/objectserver/persistence/FlatFileStorageServiceProviderTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/persistence/FlatFileStorageServiceProviderTest.java
@@ -46,7 +46,8 @@ public class FlatFileStorageServiceProviderTest extends TCTestCase {
   @Override
   public void setUp() throws Exception {
     provider = new FlatFileStorageServiceProvider();
-    provider.initialize(new FlatFileStorageProviderConfiguration(getTempDirectory()), mock(PlatformConfiguration.class));
+    boolean shouldBlockOnLock = true;
+    provider.initialize(new FlatFileStorageProviderConfiguration(getTempDirectory(), shouldBlockOnLock), mock(PlatformConfiguration.class));
   }
 
   public void testServiceType() {


### PR DESCRIPTION
This mostly just moves the capability into the location we can use later on in the config change so that the core server doesn't need to worry about file locking or storage locations.  That will become purely a service concern.