### PR TITLE
Fix #342: Update deps and no longer explicitly create the IPersistentStorage

### DIFF
--- a/common/src/main/resources/com/tc/config/schema/setup/default-config.xml
+++ b/common/src/main/resources/com/tc/config/schema/setup/default-config.xml
@@ -25,7 +25,6 @@
   </services>
     <servers>
         <server>
-            <data>%(user.home)/terracotta/server-data</data>
             <logs>%(user.home)/terracotta/server-logs</logs>
         </server>
     </servers>

--- a/dso-l2/src/main/java/com/tc/config/schema/CommonL2Config.java
+++ b/dso-l2/src/main/java/com/tc/config/schema/CommonL2Config.java
@@ -28,11 +28,7 @@ import java.io.File;
  */
 public interface CommonL2Config extends Config<TcConfiguration> {
 
-  File dataPath();
-
   File logsPath();
-
-  File serverDbBackupPath();
 
   BindPort tsaPort();
 

--- a/dso-l2/src/main/java/com/tc/config/schema/CommonL2ConfigObject.java
+++ b/dso-l2/src/main/java/com/tc/config/schema/CommonL2ConfigObject.java
@@ -77,18 +77,8 @@ public class CommonL2ConfigObject implements CommonL2Config {
   }
 
   @Override
-  public File dataPath() {
-    return new File(server.getData());
-  }
-
-  @Override
   public File logsPath() {
     return new File(server.getLogs());
-  }
-
-  @Override
-  public File serverDbBackupPath() {
-    return new File(server.getDataBackup());
   }
 
   @Override

--- a/dso-l2/src/main/java/com/tc/config/schema/setup/L2ConfigurationSetupManagerImpl.java
+++ b/dso-l2/src/main/java/com/tc/config/schema/setup/L2ConfigurationSetupManagerImpl.java
@@ -18,7 +18,6 @@
  */
 package com.tc.config.schema.setup;
 
-import com.tc.classloader.ServiceLocator;
 import com.tc.config.TcProperty;
 import com.tc.config.schema.ActiveServerGroupConfig;
 import com.tc.config.schema.ActiveServerGroupsConfig;
@@ -28,8 +27,6 @@ import com.tc.config.schema.CommonL2ConfigObject;
 import com.tc.config.schema.ConfigTCProperties;
 import com.tc.config.schema.ConfigTCPropertiesFromObject;
 import com.tc.config.schema.setup.ConfigurationSetupException;
-import com.tc.logging.TCLogger;
-import com.tc.logging.TCLogging;
 import com.tc.management.TSAManagementEventPayload;
 import com.tc.management.TerracottaRemoteManagement;
 import com.tc.object.config.schema.L2Config;
@@ -70,9 +67,6 @@ import java.util.Set;
  * The standard implementation of {@link com.tc.config.schema.setup.L2ConfigurationSetupManager}.
  */
 public class L2ConfigurationSetupManagerImpl extends BaseConfigurationSetupManager implements L2ConfigurationSetupManager {
-
-  private static final TCLogger logger = TCLogging.getLogger(L2ConfigurationSetupManagerImpl.class);
-
   private final Map<String, L2ConfigData> l2ConfigData;
   private final String thisL2Identifier;
   private final L2ConfigData myConfigData;
@@ -232,8 +226,7 @@ public class L2ConfigurationSetupManagerImpl extends BaseConfigurationSetupManag
       this.name = name;
       Server s = findMyL2Bean(); // To get the exception in case things are screwed up
       this.commonL2Config = new CommonL2ConfigObject(s, configuration, secure);
-      boolean restartable = serversBean.getRestartable() != null && serversBean.getRestartable().isEnabled();
-      this.dsoL2Config = new L2ConfigObject(s, serversBean.getClientReconnectWindow(), restartable);
+      this.dsoL2Config = new L2ConfigObject(s, serversBean.getClientReconnectWindow());
     }
 
     public CommonL2Config commonL2Config() {

--- a/dso-l2/src/main/java/com/tc/object/config/schema/L2Config.java
+++ b/dso-l2/src/main/java/com/tc/object/config/schema/L2Config.java
@@ -25,7 +25,7 @@ import com.tc.config.schema.Config;
 /**
  * Represents all configuration read by the DSO L2 and which is independent of application.
  */
-public interface L2Config extends Config {
+public interface L2Config<T> extends Config<T> {
 
   public static final String OBJECTDB_DIRNAME                      = "objectdb";
   public static final String DIRTY_OBJECTDB_BACKUP_DIRNAME         = "dirty-objectdb-backup";
@@ -44,8 +44,6 @@ public interface L2Config extends Config {
   int clientReconnectWindow();
 
   String bind();
-
-  boolean getRestartable();
 
   boolean isJmxEnabled();
 

--- a/dso-l2/src/main/java/com/tc/object/config/schema/L2ConfigObject.java
+++ b/dso-l2/src/main/java/com/tc/object/config/schema/L2ConfigObject.java
@@ -33,9 +33,8 @@ import java.io.File;
 /**
  * The standard implementation of {@link L2Config}.
  */
-public class L2ConfigObject implements L2Config {
+public class L2ConfigObject implements L2Config<Server> {
   private static final TCLogger logger = TCLogging.getLogger(L2ConfigObject.class);
-  private static final String WILDCARD_IP = "0.0.0.0";
   private static final String LOCALHOST = "localhost";
   public static final short DEFAULT_JMXPORT_OFFSET_FROM_TSAPORT = 10;
   public static final short DEFAULT_GROUPPORT_OFFSET_FROM_TSAPORT = 20;
@@ -51,14 +50,11 @@ public class L2ConfigObject implements L2Config {
   private final String serverName;
   private final String bind;
   private final int clientReconnectWindow;
-  private final boolean restartable;
   private volatile boolean jmxEnabled;
 
-  public L2ConfigObject(Server s, int clientReconnectWindow, boolean restartable) {
+  public L2ConfigObject(Server s, int clientReconnectWindow) {
     Server server = s;
     this.clientReconnectWindow = clientReconnectWindow;
-    // TODO:  The platform should no longer assume that storage restartable and platform restartable are the same thing.
-    this.restartable = restartable;
 
     this.bind = server.getBind();
     this.host = server.getHost();
@@ -97,11 +93,6 @@ public class L2ConfigObject implements L2Config {
   @Override
   public BindPort managementPort() {
     return this.managementPort;
-  }
-
-  @Override
-  public boolean getRestartable() {
-    return this.restartable;
   }
 
   @Override

--- a/dso-l2/src/test/java/com/tc/config/schema/setup/BaseConfigurationSetupManagerTest.java
+++ b/dso-l2/src/test/java/com/tc/config/schema/setup/BaseConfigurationSetupManagerTest.java
@@ -18,7 +18,6 @@
  */
 package com.tc.config.schema.setup;
 
-import com.tc.util.runtime.Os;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
@@ -31,7 +30,6 @@ import org.terracotta.config.Servers;
 import com.tc.config.schema.beanfactory.TerracottaDomainConfigurationDocumentBeanFactory;
 import com.tc.config.schema.setup.BaseConfigurationSetupManager;
 import com.tc.config.schema.setup.ConfigurationCreator;
-import com.tc.config.schema.setup.ConfigurationSetupException;
 import com.tc.config.schema.setup.ConfigurationSetupException;
 import com.tc.config.schema.setup.ConfigurationSetupManagerFactory;
 import com.tc.config.schema.setup.ConfigurationSpec;
@@ -264,7 +262,7 @@ public class BaseConfigurationSetupManagerTest extends TCTestCase {
   public void testServerDirectoryPaths() throws IOException, ConfigurationSetupException {
     this.tcConfig = getTempFile("default-config.xml");
     String config = "<tc-config xmlns=\"http://www.terracotta.org/config\">" + "<servers>" + "<server>"
-                    + "<logs>xyz/abc/451</logs>" + "<data>abc/xyz/123</data>"  + "<data-backup>/qrt/opt/pqr</data-backup>" + "</server>"
+                    + "<logs>xyz/abc/451</logs>" + "</server>"
                     + "</servers>" + "</tc-config>";
 
     writeConfigFile(config);
@@ -295,7 +293,7 @@ public class BaseConfigurationSetupManagerTest extends TCTestCase {
   public void testServerSubsitutedDirectoryPaths() throws IOException, ConfigurationSetupException {
     this.tcConfig = getTempFile("default-config.xml");
     String config = "<tc-config xmlns=\"http://www.terracotta.org/config\">" + "<servers>" + "<server>"
-                    + "<logs>%i</logs>" + "<data>%h</data>" + "<data-backup>%H</data-backup>" + "</server>" + "</servers>"
+                    + "<logs>%i</logs>" + "</server>" + "</servers>"
                     + "</tc-config>";
 
     writeConfigFile(config);

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <skip.deploy>false</skip.deploy>
 
     <terracotta-apis.version>1.0.9.beta</terracotta-apis.version>
-    <terracotta-configuration.version>10.0.9.beta</terracotta-configuration.version>
+    <terracotta-configuration.version>10.0.9.beta2</terracotta-configuration.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
-we now assume that an implementation has been passed in, via the standard service configuration
-if we do NOT see an implementation of IPersistentStorage, we assume that we are NOT running in a restartable mode and will register an in-memory-only implementation of IPersistentStorage, as before
-also removed the data tag from the default config along with any other config-related objects depending on data, data-backup, or restartable existing in the config

Will self-merge, as discussed.