### PR TITLE
Perf changes.  Optimize the sequence storing

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ServerEntityRequestImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ServerEntityRequestImpl.java
@@ -24,6 +24,7 @@ import com.tc.object.EntityDescriptor;
 import com.tc.object.tx.TransactionID;
 import com.tc.objectserver.api.ServerEntityAction;
 import com.tc.objectserver.api.ServerEntityRequest;
+import java.util.Collections;
 import java.util.Set;
 import org.terracotta.entity.ClientDescriptor;
 
@@ -75,7 +76,7 @@ public class ServerEntityRequestImpl implements ServerEntityRequest {
 
   @Override
   public Set<NodeID> replicateTo(Set<NodeID> passives) {
-    return replicates;
+    return (action == ServerEntityAction.NOOP) ? Collections.emptySet() : replicates;
   }
 
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ServerEntityRequestResponse.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ServerEntityRequestResponse.java
@@ -26,6 +26,7 @@ import com.tc.objectserver.api.ServerEntityAction;
 import com.tc.util.Assert;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.exception.EntityException;
 
@@ -36,12 +37,12 @@ import org.terracotta.exception.EntityException;
  */
 public class ServerEntityRequestResponse extends AbstractServerEntityRequestResponse {
   private final EntityDescriptor descriptor;
-  protected final Optional<MessageChannel> returnChannel;
+  protected final Supplier<Optional<MessageChannel>> returnChannel;
   // We only track whether this is replicated to know that we should reject retire acks.
   private final boolean isReplicatedMessage;
 
   public ServerEntityRequestResponse(EntityDescriptor descriptor, ServerEntityAction action,  
-      TransactionID transaction, TransactionID oldest, ClientID src, Optional<MessageChannel> returnChannel, boolean isReplicatedMessage) {
+      TransactionID transaction, TransactionID oldest, ClientID src, Supplier<Optional<MessageChannel>> returnChannel, boolean isReplicatedMessage) {
     super(action, transaction, oldest, src);
     this.descriptor = descriptor;
     this.returnChannel = returnChannel;
@@ -50,7 +51,7 @@ public class ServerEntityRequestResponse extends AbstractServerEntityRequestResp
 
   @Override
   public Optional<MessageChannel> getReturnChannel() {
-    return returnChannel;
+    return returnChannel.get();
   }
 
   @Override

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -435,7 +435,7 @@ public class ReplicatedTransactionHandler {
   private ServerEntityRequest makeNoop(EntityID eid, long version) {
     // Anything created within this class represents a replicated message.
     boolean isReplicatedMessage = true;
-    return new ServerEntityRequestResponse(new EntityDescriptor(eid, ClientInstanceID.NULL_ID, version), ServerEntityAction.NOOP, TransactionID.NULL_ID, TransactionID.NULL_ID, ClientID.NULL_ID, Optional.empty(), isReplicatedMessage);
+    return new ServerEntityRequestResponse(new EntityDescriptor(eid, ClientInstanceID.NULL_ID, version), ServerEntityAction.NOOP, TransactionID.NULL_ID, TransactionID.NULL_ID, ClientID.NULL_ID, ()->Optional.empty(), isReplicatedMessage);
   }
       
   private ServerEntityRequest make(ReplicationMessage rep) {

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/TransactionOrderPersistor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/TransactionOrderPersistor.java
@@ -99,15 +99,17 @@ public class TransactionOrderPersistor {
     transaction.globalSequenceID = this.receivedTransactionCount;
     
     // We now pass this straight into the underlying storage.
-    Future<Void> syncFuture = this.storageManager.fastStoreSequence(source.toLong(), transaction, oldestTransactionOnClient.toLong());
+    if (!source.isNull()) {
+      Future<Void> syncFuture = this.storageManager.fastStoreSequence(source.toLong(), transaction, oldestTransactionOnClient.toLong());
     
     // TODO:  We need to float this future blocking on the sync further out.
-    try {
-      syncFuture.get();
-    } catch (InterruptedException e) {
-      Assert.fail(e.getLocalizedMessage());
-    } catch (ExecutionException e) {
-      Assert.fail(e.getLocalizedMessage());
+      try {
+        syncFuture.get();
+      } catch (InterruptedException e) {
+        Assert.fail(e.getLocalizedMessage());
+      } catch (ExecutionException e) {
+        Assert.fail(e.getLocalizedMessage());
+      }
     }
   }
 

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ServerEntityRequestImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ServerEntityRequestImplTest.java
@@ -78,7 +78,7 @@ public class ServerEntityRequestImplTest {
   public void testCompleteCreate() throws Exception {
     boolean requiresReplication = true;
     boolean isReplicatedMessage = false;
-    ServerEntityRequestResponse serverEntityRequest = new ServerEntityRequestResponse(entityDescriptor, ServerEntityAction.CREATE_ENTITY, transactionID, TransactionID.NULL_ID, nodeID, Optional.of(messageChannel), isReplicatedMessage);
+    ServerEntityRequestResponse serverEntityRequest = new ServerEntityRequestResponse(entityDescriptor, ServerEntityAction.CREATE_ENTITY, transactionID, TransactionID.NULL_ID, nodeID, ()->Optional.of(messageChannel), isReplicatedMessage);
 
     serverEntityRequest.complete();
     serverEntityRequest.retired();
@@ -109,6 +109,6 @@ public class ServerEntityRequestImplTest {
   private ServerEntityRequestResponse buildInvoke() {
     boolean requiresReplication = true;
     boolean isReplicatedMessage = false;
-    return new ServerEntityRequestResponse(entityDescriptor, ServerEntityAction.INVOKE_ACTION, transactionID, TransactionID.NULL_ID, nodeID, Optional.of(messageChannel), isReplicatedMessage);
+    return new ServerEntityRequestResponse(entityDescriptor, ServerEntityAction.INVOKE_ACTION, transactionID, TransactionID.NULL_ID, nodeID, ()->Optional.of(messageChannel), isReplicatedMessage);
   }
 }

--- a/tc-messaging/src/main/java/com/tc/entity/VoltronEntityMultiResponseImpl.java
+++ b/tc-messaging/src/main/java/com/tc/entity/VoltronEntityMultiResponseImpl.java
@@ -76,7 +76,7 @@ public class VoltronEntityMultiResponseImpl extends DSOMessageBase implements Vo
   public synchronized boolean addReceived(TransactionID tid) {
     if (!isSealed()) {
       if (receivedIDs == null) {
-        receivedIDs = new ArrayList<TransactionID>(16);
+        receivedIDs = new ArrayList<TransactionID>(128);
       }
       receivedIDs.add(tid);
       return true;
@@ -88,7 +88,7 @@ public class VoltronEntityMultiResponseImpl extends DSOMessageBase implements Vo
   public synchronized boolean addRetired(TransactionID tid) {
     if (!isSealed()) {
       if (retiredIDs == null) {
-        retiredIDs = new ArrayList<TransactionID>(16);
+        retiredIDs = new ArrayList<TransactionID>(128);
       }
       retiredIDs.add(tid);
       return true;


### PR DESCRIPTION
When there is no persistence, the transaction order sequence still needs to be stored.

Fix a retirement bug.  Late bind channel lookup.