### PR TITLE
Adding ability to add EntityMessage level toString to ReplicatedMessage debugging

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/MessagePayload.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/MessagePayload.java
@@ -32,6 +32,7 @@ public class MessagePayload {
   private EntityMessage message;
   private final int concurrency;
   private final boolean replicate;
+  private String debugId;
   
   public static final MessagePayload EMPTY = new MessagePayload(new byte[0], null, true);
   
@@ -46,12 +47,21 @@ public class MessagePayload {
   private MessagePayload(byte[] raw, EntityMessage message, int concurrency, boolean replicate) {
     this.raw = raw;
     this.message = message;
+    this.debugId = (message != null) ? message.toString() : "";
     this.concurrency = concurrency;
     this.replicate = replicate;
   }
   
   public byte[] getRawPayload() {
     return raw;
+  }
+  
+  public void setDebugId(String debugId) {
+    this.debugId = debugId;
+  }
+  
+  public String getDebugId() {
+    return debugId;
   }
   
   public EntityMessage decodeRawMessage(MessageCodec codec) {
@@ -65,6 +75,7 @@ public class MessagePayload {
   public EntityMessage decodeMessage(MessageCodec codec) throws MessageCodecException {
     if (message == null) {
       message = codec.decodeMessage(raw);
+      setDebugId(message.toString());
     }
     return message;
   }

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
@@ -92,11 +92,10 @@ public class ProcessTransactionHandler {
     @Override
     public void handleEvent(TCMessage context) throws EventHandlerException {
       invokeReturn.remove((ClientID)context.getDestinationNodeID(), context);
-      if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug("sending " + context);
-      }
       Assert.assertTrue(context.send());
-      
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("sent " + context);
+      }      
     }
   };
   public AbstractEventHandler<TCMessage> getMultiResponseSender() {

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicationSender.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicationSender.java
@@ -95,6 +95,7 @@ public class ReplicationSender extends AbstractEventHandler<ReplicationEnvelope>
 //  the only messages that are relevant before passive sync starts are create messages
       try {
         msg.setReplicationID(rOrder.getAndIncrement());
+        logger.debug("WIRE:" + msg);
         group.sendTo(nodeid, msg);
       }  catch (GroupException ge) {
         logger.info(msg, ge);

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
@@ -330,7 +330,7 @@ public class ReplicatedTransactionHandlerTest {
   
   private ReplicationMessage createMockReplicationMessage(EntityID eid, long VERSION, byte[] payload, int concurrency) {
     return ReplicationMessage.createReplicatedMessage(new EntityDescriptor(eid, ClientInstanceID.NULL_ID, VERSION), 
-        source, TransactionID.NULL_ID, TransactionID.NULL_ID, ReplicationMessage.ReplicationType.INVOKE_ACTION, payload, concurrency);
+        source, TransactionID.NULL_ID, TransactionID.NULL_ID, ReplicationMessage.ReplicationType.INVOKE_ACTION, payload, concurrency, "");
   }
 
   private static abstract class NoStatsSink<T> implements Sink<T> {

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicationSenderTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicationSenderTest.java
@@ -94,7 +94,7 @@ public class ReplicationSenderTest {
       case INVOKE_ACTION:
       case NOOP:
       case RECONFIGURE_ENTITY:
-        return ReplicationMessage.createReplicatedMessage(new EntityDescriptor(entity, ClientInstanceID.NULL_ID, 1), ClientID.NULL_ID, TransactionID.NULL_ID, TransactionID.NULL_ID, type, new byte[0], 0);
+        return ReplicationMessage.createReplicatedMessage(new EntityDescriptor(entity, ClientInstanceID.NULL_ID, 1), ClientID.NULL_ID, TransactionID.NULL_ID, TransactionID.NULL_ID, type, new byte[0], 0, "");
       case SYNC_BEGIN:
         return PassiveSyncMessage.createStartSyncMessage();
       case SYNC_END:

--- a/tc-messaging/src/main/java/com/tc/l2/msg/PassiveSyncMessage.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/PassiveSyncMessage.java
@@ -79,7 +79,7 @@ public class PassiveSyncMessage extends ReplicationMessage {
     super(SYNC);
     initialize(new EntityDescriptor(id, ClientInstanceID.NULL_ID, version), 
         ClientID.NULL_ID, TransactionID.NULL_ID, TransactionID.NULL_ID,
-        type, payload, concurrency);
+        type, payload, concurrency, "");
   }
 
   @Override

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
@@ -64,13 +64,13 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
   }
 
   public static ReplicationMessage createNoOpMessage(EntityID eid, long version) {
-    return new ReplicationMessage(new EntityDescriptor(eid, ClientInstanceID.NULL_ID, version), ClientID.NULL_ID, TransactionID.NULL_ID, TransactionID.NULL_ID, ReplicationMessage.ReplicationType.NOOP, new byte[0], 0);
+    return new ReplicationMessage(new EntityDescriptor(eid, ClientInstanceID.NULL_ID, version), ClientID.NULL_ID, TransactionID.NULL_ID, TransactionID.NULL_ID, ReplicationMessage.ReplicationType.NOOP, new byte[0], 0, "");
   }
 
   public static ReplicationMessage createReplicatedMessage(EntityDescriptor descriptor, ClientID src, 
       TransactionID tid, TransactionID oldest, 
-      ReplicationType action, byte[] payload, int concurrency) {
-    return new ReplicationMessage(descriptor, src, tid, oldest, action, payload, concurrency);
+      ReplicationType action, byte[] payload, int concurrency, String debugId) {
+    return new ReplicationMessage(descriptor, src, tid, oldest, action, payload, concurrency, debugId);
   }
 
   EntityDescriptor descriptor;
@@ -85,6 +85,8 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
   
   long rid = 0;
   
+  String debugId;
+  
   public ReplicationMessage() {
     super(INVALID);
     descriptor = new EntityDescriptor(EntityID.NULL_ID, ClientInstanceID.NULL_ID, 0);
@@ -98,14 +100,14 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
 //  a true replicated message
   private ReplicationMessage(EntityDescriptor descriptor, ClientID src, 
       TransactionID tid, TransactionID oldest, 
-      ReplicationType action, byte[] payload, int concurrency) {
+      ReplicationType action, byte[] payload, int concurrency, String debugId) {
     super(action.ordinal() >= ReplicationType.SYNC_BEGIN.ordinal() ? SYNC : REPLICATE);
-    initialize(descriptor, src, tid, oldest, action, payload, concurrency);
+    initialize(descriptor, src, tid, oldest, action, payload, concurrency, debugId);
   }
   
   protected final void initialize(EntityDescriptor descriptor, ClientID src, 
       TransactionID tid, TransactionID oldest, 
-      ReplicationType action, byte[] payload, int concurrency) {
+      ReplicationType action, byte[] payload, int concurrency, String debugId) {
     Assert.assertNotNull(tid);
     Assert.assertNotNull(oldest);
     Assert.assertNotNull(src);
@@ -116,6 +118,7 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
     this.action = action;
     this.payload = payload;
     this.concurrency = concurrency;
+    this.debugId = debugId;
   }
   
   public ReplicationEnvelope target(NodeID node) {
@@ -240,6 +243,6 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
 
   @Override
   public String toString() {
-    return "ReplicationMessage{rid=" + rid + ", id=" + descriptor.getEntityID() + ", src=" + src + ", tid=" + tid + ", oldest=" + oldest + ", action=" + action + ", concurrency=" + concurrency +'}';
+    return "ReplicationMessage{rid=" + rid + ", id=" + descriptor.getEntityID() + ", src=" + src + ", tid=" + tid + ", oldest=" + oldest + ", action=" + action + ", concurrency=" + concurrency + ", debug=" + debugId + '}';
   }
 }


### PR DESCRIPTION
This adds the ability to print entity message level information in the debug strings for ReplicationMessages.