### PR TITLE
Several steps in handling the pushBestEfforts, along with a unit test

### DIFF
--- a/dso-l2/src/main/java/com/tc/l2/handler/PlatformInfoRequestHandler.java
+++ b/dso-l2/src/main/java/com/tc/l2/handler/PlatformInfoRequestHandler.java
@@ -68,8 +68,8 @@ public class PlatformInfoRequestHandler {
             case PlatformInfoRequest.RESPONSE_REMOVE:
               PlatformInfoRequestHandler.this.monitoringSupport.handleRemoteRemove((ServerID)context.messageFrom(), context.getConsumerID(), context.getParents(), context.getNodeName());
               break;
-            case PlatformInfoRequest.BEST_EFFORTS:
-              PlatformInfoRequestHandler.this.monitoringSupport.handleRemoteBestEfforts((ServerID)context.messageFrom(), context.getConsumerID(), context.getNodeName(), context.getNodeValue());
+            case PlatformInfoRequest.BEST_EFFORTS_BATCH:
+              PlatformInfoRequestHandler.this.monitoringSupport.handleRemoteBestEffortsBatch((ServerID)context.messageFrom(), context.getConsumerIDs(), context.getKeys(), context.getValues());
               break;
             default:
               break;
@@ -114,14 +114,12 @@ public class PlatformInfoRequestHandler {
       }
       @Override
       public void pushBestEffortsBatch(long[] consumerIDs, String[] keys, Serializable[] values) {
-        for (int i = 0; i < consumerIDs.length; ++i) {
-          PlatformInfoRequest message = PlatformInfoRequest.createBestEfforts(consumerIDs[i], keys[i], values[i]);
-          try {
-            groupManager.sendTo(requester, message);
-          } catch (GroupException e) {
-            // If there is something wrong in sending the monitoring data, this isn't critical so just log the error.
-            LOGGER.error(e.getLocalizedMessage());
-          }
+        PlatformInfoRequest message = PlatformInfoRequest.createBestEffortsBatch(consumerIDs, keys, values);
+        try {
+          groupManager.sendTo(requester, message);
+        } catch (GroupException e) {
+          // If there is something wrong in sending the monitoring data, this isn't critical so just log the error.
+          LOGGER.error(e.getLocalizedMessage());
         }
       }
     };

--- a/dso-l2/src/main/java/com/tc/l2/handler/PlatformInfoRequestHandler.java
+++ b/dso-l2/src/main/java/com/tc/l2/handler/PlatformInfoRequestHandler.java
@@ -113,13 +113,15 @@ public class PlatformInfoRequestHandler {
         }
       }
       @Override
-      public void pushBestEfforts(long consumerID, String key, Serializable value) {
-        PlatformInfoRequest message = PlatformInfoRequest.createBestEfforts(consumerID, key, value);
-        try {
-          groupManager.sendTo(requester, message);
-        } catch (GroupException e) {
-          // If there is something wrong in sending the monitoring data, this isn't critical so just log the error.
-          LOGGER.error(e.getLocalizedMessage());
+      public void pushBestEffortsBatch(long[] consumerIDs, String[] keys, Serializable[] values) {
+        for (int i = 0; i < consumerIDs.length; ++i) {
+          PlatformInfoRequest message = PlatformInfoRequest.createBestEfforts(consumerIDs[i], keys[i], values[i]);
+          try {
+            groupManager.sendTo(requester, message);
+          } catch (GroupException e) {
+            // If there is something wrong in sending the monitoring data, this isn't critical so just log the error.
+            LOGGER.error(e.getLocalizedMessage());
+          }
         }
       }
     };

--- a/dso-l2/src/main/java/com/tc/l2/handler/PlatformInfoRequestHandler.java
+++ b/dso-l2/src/main/java/com/tc/l2/handler/PlatformInfoRequestHandler.java
@@ -33,10 +33,8 @@ import com.tc.net.ServerID;
 import com.tc.net.groups.AbstractGroupMessage;
 import com.tc.net.groups.GroupException;
 import com.tc.net.groups.GroupManager;
-import com.tc.server.TCServerMain;
 import com.tc.services.LocalMonitoringProducer;
 import com.tc.util.Assert;
-import com.tc.util.ProductInfo;
 
 
 public class PlatformInfoRequestHandler {
@@ -69,6 +67,9 @@ public class PlatformInfoRequestHandler {
               break;
             case PlatformInfoRequest.RESPONSE_REMOVE:
               PlatformInfoRequestHandler.this.monitoringSupport.handleRemoteRemove((ServerID)context.messageFrom(), context.getConsumerID(), context.getParents(), context.getNodeName());
+              break;
+            case PlatformInfoRequest.BEST_EFFORTS:
+              PlatformInfoRequestHandler.this.monitoringSupport.handleRemoteBestEfforts((ServerID)context.messageFrom(), context.getConsumerID(), context.getNodeName(), context.getNodeValue());
               break;
             default:
               break;
@@ -104,6 +105,16 @@ public class PlatformInfoRequestHandler {
       @Override
       public void removeNode(long consumerID, String[] parents, String name) {
         PlatformInfoRequest message = PlatformInfoRequest.createRemoveNode(consumerID, parents, name);
+        try {
+          groupManager.sendTo(requester, message);
+        } catch (GroupException e) {
+          // If there is something wrong in sending the monitoring data, this isn't critical so just log the error.
+          LOGGER.error(e.getLocalizedMessage());
+        }
+      }
+      @Override
+      public void pushBestEfforts(long consumerID, String key, Serializable value) {
+        PlatformInfoRequest message = PlatformInfoRequest.createBestEfforts(consumerID, key, value);
         try {
           groupManager.sendTo(requester, message);
         } catch (GroupException e) {

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -473,7 +473,7 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
     final ProductInfo pInfo = ProductInfo.getInstance();
     PlatformServer thisServer = new PlatformServer(server.getL2Identifier(), host, hostAddress, bindAddress, serverPort, l2DSOConfig.tsaGroupPort().getValue(), pInfo.buildVersion(), pInfo.buildID(), TCServerMain.getServer().getStartTime());
     
-    final LocalMonitoringProducer monitoringShimService = new LocalMonitoringProducer(this.serviceRegistry, thisServer);
+    final LocalMonitoringProducer monitoringShimService = new LocalMonitoringProducer(this.serviceRegistry, thisServer, this.timer);
     this.serviceRegistry.registerImplementationProvided(monitoringShimService);
     
     // ***** NOTE:  At this point, since we are about to create a subregistry for the platform, the serviceRegistry must be complete!

--- a/dso-l2/src/main/java/com/tc/services/BestEffortsMonitoring.java
+++ b/dso-l2/src/main/java/com/tc/services/BestEffortsMonitoring.java
@@ -19,7 +19,8 @@ import com.tc.util.Assert;
  */
 public class BestEffortsMonitoring {
   // We will flush 1 second after new data appears.
-  private static final long ASYNC_FLUSH_DELAY_MILLIS = 1000;
+  // (this is marked public for tests)
+  public static final long ASYNC_FLUSH_DELAY_MILLIS = 1000;
 
   private final SingleThreadedTimer timer;
   private final Map<Long, Map<String, Serializable>> bestEffortsCache;
@@ -32,7 +33,7 @@ public class BestEffortsMonitoring {
     this.bestEffortsCache = new HashMap<Long, Map<String, Serializable>>();
   }
 
-  public synchronized void flushAfterActivePromotion(PlatformServer thisServer , TerracottaServiceProviderRegistry globalRegistry) {
+  public synchronized void flushAfterActivePromotion(PlatformServer thisServer, TerracottaServiceProviderRegistry globalRegistry) {
     // We no longer care about the timer so clear it, if one exists.
     ensureTimerCancelled();
     
@@ -100,7 +101,7 @@ public class BestEffortsMonitoring {
         @Override
         public void run() {
           backgroundThreadFlush();
-        }}, ASYNC_FLUSH_DELAY_MILLIS);
+        }}, this.timer.currentTimeMillis() + ASYNC_FLUSH_DELAY_MILLIS);
       Assert.assertTrue(this.outstandingTimerToken > 0);
     }
   }

--- a/dso-l2/src/main/java/com/tc/services/BestEffortsMonitoring.java
+++ b/dso-l2/src/main/java/com/tc/services/BestEffortsMonitoring.java
@@ -11,16 +11,40 @@ import com.tc.services.LocalMonitoringProducer.ActivePipeWrapper;
  * Note that this interface is synchronized to ensure safe interaction with internal threads.
  */
 public class BestEffortsMonitoring {
+  private static final int BATCH_SIZE = 10;
+
   private ActivePipeWrapper activeWrapper;
+  private long[] consumerIDCache;
+  private String[] keyCache;
+  private Serializable[] valueCache;
+  private int nextIndex;
 
 
   public synchronized void attachToNewActive(ActivePipeWrapper activeWrapper) {
     // Note that it is possible that there already is an active and this is replacing it.
     this.activeWrapper = activeWrapper;
+    initializeCache();
   }
 
   public synchronized void pushBestEfforts(long consumerID, String name, Serializable data) {
-    // We currently don't cache anything - just pass this straight through.
-    this.activeWrapper.pushBestEfforts(consumerID, name, data);
+    // Put these in the cache.
+    this.consumerIDCache[this.nextIndex] = consumerID;
+    this.keyCache[this.nextIndex] = name;
+    this.valueCache[this.nextIndex] = data;
+    this.nextIndex += 1;
+    
+    // See if we need to flush the cache.
+    if (BATCH_SIZE == this.nextIndex) {
+      this.activeWrapper.pushBestEffortsBatch(this.consumerIDCache, this.keyCache, this.valueCache);
+      initializeCache();
+    }
+  }
+
+
+  private void initializeCache() {
+    this.consumerIDCache = new long[BATCH_SIZE];
+    this.keyCache = new String[BATCH_SIZE];
+    this.valueCache = new Serializable[BATCH_SIZE];
+    this.nextIndex = 0;
   }
 }

--- a/dso-l2/src/main/java/com/tc/services/BestEffortsMonitoring.java
+++ b/dso-l2/src/main/java/com/tc/services/BestEffortsMonitoring.java
@@ -1,0 +1,26 @@
+package com.tc.services;
+
+import java.io.Serializable;
+
+import com.tc.services.LocalMonitoringProducer.ActivePipeWrapper;
+
+
+/**
+ * Manages the cache and delayed dispatch of best-efforts data passed to IMonitoringProducer while the server is in passive
+ *  mode.
+ * Note that this interface is synchronized to ensure safe interaction with internal threads.
+ */
+public class BestEffortsMonitoring {
+  private ActivePipeWrapper activeWrapper;
+
+
+  public synchronized void attachToNewActive(ActivePipeWrapper activeWrapper) {
+    // Note that it is possible that there already is an active and this is replacing it.
+    this.activeWrapper = activeWrapper;
+  }
+
+  public synchronized void pushBestEfforts(long consumerID, String name, Serializable data) {
+    // We currently don't cache anything - just pass this straight through.
+    this.activeWrapper.pushBestEfforts(consumerID, name, data);
+  }
+}

--- a/dso-l2/src/main/java/com/tc/services/LocalMonitoringProducer.java
+++ b/dso-l2/src/main/java/com/tc/services/LocalMonitoringProducer.java
@@ -199,15 +199,17 @@ public class LocalMonitoringProducer implements ImplementationProvidedServicePro
     }
   }
 
-  public synchronized void handleRemoteBestEfforts(ServerID sender, long consumerID, String key, Serializable value) {
+  public synchronized void handleRemoteBestEffortsBatch(ServerID sender, long[] consumerIDs, String[] keys, Serializable[] values) {
     // If we are getting these, we MUST be in active mode.
     Assert.assertNull(this.cachedTreeRoot);
     
-    IStripeMonitoring underlyingCollector = this.globalRegistry.subRegistry(consumerID).getService(new BasicServiceConfiguration<IStripeMonitoring>(IStripeMonitoring.class));
-    if (null != underlyingCollector) {
-      PlatformServer sendingServer = this.otherServers.get(sender);
-      Assert.assertNotNull(sendingServer);
-      underlyingCollector.pushBestEffortsData(sendingServer, key, value);
+    for (int i = 0; i < consumerIDs.length; ++i) {
+      IStripeMonitoring underlyingCollector = this.globalRegistry.subRegistry(consumerIDs[i]).getService(new BasicServiceConfiguration<IStripeMonitoring>(IStripeMonitoring.class));
+      if (null != underlyingCollector) {
+        PlatformServer sendingServer = this.otherServers.get(sender);
+        Assert.assertNotNull(sendingServer);
+        underlyingCollector.pushBestEffortsData(sendingServer, keys[i], values[i]);
+      }
     }
   }
 

--- a/dso-l2/src/main/java/com/tc/services/LocalMonitoringProducer.java
+++ b/dso-l2/src/main/java/com/tc/services/LocalMonitoringProducer.java
@@ -300,7 +300,7 @@ public class LocalMonitoringProducer implements ImplementationProvidedServicePro
   public static interface ActivePipeWrapper {
     public void addNode(long consumerID, String[] parents, String name, Serializable value);
     public void removeNode(long consumerID, String[] parents, String name);
-    public void pushBestEfforts(long consumerID, String key, Serializable value);
+    public void pushBestEffortsBatch(long[] consumerIDs, String[] keys, Serializable[] values);
   }
 
 

--- a/dso-l2/src/main/java/com/tc/services/LocalMonitoringProducer.java
+++ b/dso-l2/src/main/java/com/tc/services/LocalMonitoringProducer.java
@@ -119,6 +119,9 @@ public class LocalMonitoringProducer implements ImplementationProvidedServicePro
             underlyingCollector.addNode(LocalMonitoringProducer.this.thisServer, parents, name, value);
           }});
       }
+      
+      // Flush any remaining best-efforts data to the collector.
+      this.bestEfforts.flushAfterActivePromotion(this.thisServer, this.globalRegistry);
     }
     
     this.cachedTreeRoot = null;

--- a/dso-l2/src/main/java/com/tc/services/LocalMonitoringProducer.java
+++ b/dso-l2/src/main/java/com/tc/services/LocalMonitoringProducer.java
@@ -49,12 +49,12 @@ public class LocalMonitoringProducer implements ImplementationProvidedServicePro
   private Map<Long, CacheNode> cachedTreeRoot;
   private BestEffortsMonitoring bestEfforts;
 
-  public LocalMonitoringProducer(TerracottaServiceProviderRegistry globalRegistry, PlatformServer thisServer) {
+  public LocalMonitoringProducer(TerracottaServiceProviderRegistry globalRegistry, PlatformServer thisServer, SingleThreadedTimer timer) {
     this.globalRegistry = globalRegistry;
     this.thisServer = thisServer;
     this.otherServers = new HashMap<ServerID, PlatformServer>();
     this.cachedTreeRoot = new HashMap<Long, CacheNode>();
-    this.bestEfforts = new BestEffortsMonitoring();
+    this.bestEfforts = new BestEffortsMonitoring(timer);
   }
 
   public PlatformServer getLocalServerInfo() {

--- a/dso-l2/src/test/java/com/tc/services/BestEffortsMonitoringTest.java
+++ b/dso-l2/src/test/java/com/tc/services/BestEffortsMonitoringTest.java
@@ -1,0 +1,306 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.services;
+
+import java.io.Serializable;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.terracotta.entity.ServiceConfiguration;
+import org.terracotta.monitoring.IStripeMonitoring;
+import org.terracotta.monitoring.PlatformServer;
+
+import com.tc.services.LocalMonitoringProducer.ActivePipeWrapper;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class BestEffortsMonitoringTest {
+  private TestTimeSource source;
+  private SingleThreadedTimer timer;
+  private BestEffortsMonitoring monitoring;
+
+
+  @Before
+  public void setUp() throws Exception {
+    this.source = new TestTimeSource(1);
+    this.timer = new SingleThreadedTimer(this.source);
+    this.monitoring = new BestEffortsMonitoring(this.timer);
+    this.timer.start();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    this.timer.stop();
+  }
+
+  @Test
+  public void testNoActive() throws Exception {
+    // Enqueue a bunch of data and just stop.
+    long id1 = 1;
+    long id2 = 2;
+    String name1 = "name1";
+    String name2 = "name2";
+    Serializable data1 = "data1";
+    Serializable data2 = "data2";
+    this.monitoring.pushBestEfforts(id1, name1, data1);
+    this.monitoring.pushBestEfforts(id2, name2, data2);
+  }
+
+  @Test
+  public void testImmediateActive() throws Exception {
+    // Change to active immediate, with no data.
+    TestPipeWrapper wrapper = new TestPipeWrapper();
+    this.monitoring.attachToNewActive(wrapper);
+    // Nothing should have happened.
+    Assert.assertEquals(0, wrapper.pushCount);
+    
+    // Step time ahead to make sure that nothing happens.
+    // (we currently push these, immediately when a new active arrives, so this check is just to make sure we don't enqueue something else).
+    this.source.passTime(BestEffortsMonitoring.ASYNC_FLUSH_DELAY_MILLIS);
+    this.timer.poke();
+    Assert.assertEquals(0, wrapper.pushCount);
+  }
+
+  @Test
+  public void testBecomeActive() throws Exception {
+    // Enqueue some data, then change to active.
+    long id1 = 1;
+    long id2 = 2;
+    String name1 = "name1";
+    String name2 = "name2";
+    Serializable data1 = "data1";
+    Serializable data2 = "data2";
+    this.monitoring.pushBestEfforts(id1, name1, data1);
+    this.monitoring.pushBestEfforts(id2, name2, data2);
+    
+    TestStripeMonitoring consumer1 = new TestStripeMonitoring();
+    TestStripeMonitoring consumer2 = new TestStripeMonitoring();
+    TerracottaServiceProviderRegistry globalRegistry = mockRegistry(consumer1, consumer2);
+    this.monitoring.flushAfterActivePromotion(mock(PlatformServer.class), globalRegistry);
+    Assert.assertEquals(1, consumer1.pushCount);
+    Assert.assertEquals(1, consumer2.pushCount);
+  }
+
+  @Test
+  public void testBecomeActiveWithRedundantWrites() throws Exception {
+    // Enqueue some data to the same key, then change to active.
+    long id1 = 1;
+    String name1 = "name1";
+    Serializable data1 = "data1";
+    Serializable data2 = "data2";
+    this.monitoring.pushBestEfforts(id1, name1, data1);
+    this.monitoring.pushBestEfforts(id1, name1, data2);
+    
+    TestStripeMonitoring consumer1 = new TestStripeMonitoring();
+    TestStripeMonitoring consumer2 = new TestStripeMonitoring();
+    TerracottaServiceProviderRegistry globalRegistry = mockRegistry(consumer1, consumer2);
+    this.monitoring.flushAfterActivePromotion(mock(PlatformServer.class), globalRegistry);
+    Assert.assertEquals(1, consumer1.pushCount);
+    Assert.assertEquals(0, consumer2.pushCount);
+  }
+
+  @Test
+  public void testBecomeActiveWhileInFlight() throws Exception {
+    // Attach an active, enqueue some data, then change to active while a timer is still pending.
+    TestPipeWrapper wrapper = new TestPipeWrapper();
+    this.monitoring.attachToNewActive(wrapper);
+    Assert.assertEquals(0, wrapper.pushCount);
+    
+    long id1 = 1;
+    String name1 = "name1";
+    Serializable data1 = "data1";
+    this.monitoring.pushBestEfforts(id1, name1, data1);
+    
+    TestStripeMonitoring consumer1 = new TestStripeMonitoring();
+    TerracottaServiceProviderRegistry globalRegistry = mockRegistry(consumer1, null);
+    this.monitoring.flushAfterActivePromotion(mock(PlatformServer.class), globalRegistry);
+    Assert.assertEquals(1, consumer1.pushCount);
+    
+    // Step time ahead to make sure that nothing happens.
+    this.source.passTime(BestEffortsMonitoring.ASYNC_FLUSH_DELAY_MILLIS);
+    this.timer.poke();
+  }
+
+  @Test
+  public void testActiveLater() throws Exception {
+    // Enqueue some data, then attach active.
+    long id1 = 1;
+    String name1 = "name1";
+    Serializable data1 = "data1";
+    this.monitoring.pushBestEfforts(id1, name1, data1);
+    
+    TestPipeWrapper wrapper = new TestPipeWrapper();
+    this.monitoring.attachToNewActive(wrapper);
+    // These should be pushed, immediately (at least in the current implementation).
+    Assert.assertEquals(1, wrapper.pushCount);
+    
+    // Step time ahead to make sure nothing changes.
+    this.source.passTime(BestEffortsMonitoring.ASYNC_FLUSH_DELAY_MILLIS);
+    this.timer.poke();
+    
+    // The same count should be there.
+    Assert.assertEquals(1, wrapper.pushCount);
+  }
+
+  @Test
+  public void testActiveChange() throws Exception {
+    // Enqueue some data, then attach active, then continue to enqueue data, then attach a new active (after any active timers have finished).
+    long id1 = 1;
+    String name1 = "name1";
+    Serializable data1 = "data1";
+    this.monitoring.pushBestEfforts(id1, name1, data1);
+    
+    TestPipeWrapper wrapper = new TestPipeWrapper();
+    this.monitoring.attachToNewActive(wrapper);
+    // These should be pushed, immediately (at least in the current implementation).
+    Assert.assertEquals(1, wrapper.pushCount);
+    
+    // Step time ahead to make sure nothing changes.
+    this.source.passTime(BestEffortsMonitoring.ASYNC_FLUSH_DELAY_MILLIS);
+    this.timer.poke();
+    
+    // Add some more data (we can send redundant data since we already received it).
+    this.monitoring.pushBestEfforts(id1, name1, data1);
+    // Nothing should change until the timer.
+    Assert.assertEquals(1, wrapper.pushCount);
+    this.source.passTime(BestEffortsMonitoring.ASYNC_FLUSH_DELAY_MILLIS);
+    this.timer.poke();
+    Assert.assertEquals(2, wrapper.pushCount);
+    
+    // Now, switch to a new active - it should see nothing.
+    TestPipeWrapper lateWrapper = new TestPipeWrapper();
+    this.monitoring.attachToNewActive(lateWrapper);
+    Assert.assertEquals(0, lateWrapper.pushCount);
+  }
+
+  @Test
+  public void testActiveChangeWhileInFlight() throws Exception {
+    // Enqueue some data, then attach active, then continue to enqueue data, then attach a new active while a timer is still
+    //  pending.
+    long id1 = 1;
+    String name1 = "name1";
+    Serializable data1 = "data1";
+    this.monitoring.pushBestEfforts(id1, name1, data1);
+    
+    TestPipeWrapper wrapper = new TestPipeWrapper();
+    this.monitoring.attachToNewActive(wrapper);
+    // These should be pushed, immediately (at least in the current implementation).
+    Assert.assertEquals(1, wrapper.pushCount);
+    
+    // Step time ahead to make sure nothing changes.
+    this.source.passTime(BestEffortsMonitoring.ASYNC_FLUSH_DELAY_MILLIS);
+    this.timer.poke();
+    
+    // Add some more data (we can send redundant data since we already received it).
+    this.monitoring.pushBestEfforts(id1, name1, data1);
+    // Nothing should change until the timer.
+    Assert.assertEquals(1, wrapper.pushCount);
+    // (a timer will have been requested so attach the new passive while there).
+    
+    // Now, switch to a new active - it should see the data.
+    TestPipeWrapper lateWrapper = new TestPipeWrapper();
+    this.monitoring.attachToNewActive(lateWrapper);
+    Assert.assertEquals(1, lateWrapper.pushCount);
+    
+    // Wait to make sure neither change from a stale timer (it should have been cancelled).
+    this.source.passTime(BestEffortsMonitoring.ASYNC_FLUSH_DELAY_MILLIS);
+    this.timer.poke();
+    Assert.assertEquals(1, wrapper.pushCount);
+    Assert.assertEquals(1, lateWrapper.pushCount);
+  }
+
+
+  @SuppressWarnings("unchecked")
+  private TerracottaServiceProviderRegistry mockRegistry(IStripeMonitoring consumer1, IStripeMonitoring consumer2) {
+    TerracottaServiceProviderRegistry globalRegistry = mock(TerracottaServiceProviderRegistry.class);
+    if (null != consumer1) {
+      InternalServiceRegistry registry1 = mock(InternalServiceRegistry.class);
+      when(registry1.getService(any(ServiceConfiguration.class))).thenReturn(consumer1);
+      when(globalRegistry.subRegistry(1)).thenReturn(registry1);
+    }
+    if (null != consumer2) {
+      InternalServiceRegistry registry2 = mock(InternalServiceRegistry.class);
+      when(registry2.getService(any(ServiceConfiguration.class))).thenReturn(consumer2);
+      when(globalRegistry.subRegistry(2)).thenReturn(registry2);
+    }
+    return globalRegistry;
+  }
+
+
+  private static class TestPipeWrapper implements ActivePipeWrapper {
+    public int pushCount = 0;
+    
+    @Override
+    public void addNode(long consumerID, String[] parents, String name, Serializable value) {
+      // No call expected.
+      Assert.fail();
+    }
+    @Override
+    public void removeNode(long consumerID, String[] parents, String name) {
+      // No call expected.
+      Assert.fail();
+    }
+    @Override
+    public void pushBestEffortsBatch(long[] consumerIDs, String[] keys, Serializable[] values) {
+      this.pushCount += 1;
+    }
+  }
+
+
+  private static class TestStripeMonitoring implements IStripeMonitoring {
+    public int pushCount = 0;
+    
+    @Override
+    public void serverDidBecomeActive(PlatformServer self) {
+      // No call expected.
+      Assert.fail();
+    }
+    @Override
+    public void serverDidJoinStripe(PlatformServer server) {
+      // No call expected.
+      Assert.fail();
+    }
+    @Override
+    public void serverDidLeaveStripe(PlatformServer server) {
+      // No call expected.
+      Assert.fail();
+    }
+    @Override
+    public boolean addNode(PlatformServer sender, String[] parents, String name, Serializable value) {
+      // No call expected.
+      Assert.fail();
+      return false;
+    }
+    @Override
+    public boolean removeNode(PlatformServer sender, String[] parents, String name) {
+      // No call expected.
+      Assert.fail();
+      return false;
+    }
+    @Override
+    public void pushBestEffortsData(PlatformServer sender, String name, Serializable data) {
+      this.pushCount += 1;
+    }
+  }
+}

--- a/dso-l2/src/test/java/com/tc/services/SingleThreadedTimerTest.java
+++ b/dso-l2/src/test/java/com/tc/services/SingleThreadedTimerTest.java
@@ -133,22 +133,4 @@ public class SingleThreadedTimerTest {
       Assert.assertTrue(didCancel);
     }
   }
-
-
-  private static class TestTimeSource implements SingleThreadedTimer.TimeSource {
-    private long currentTimeMillis;
-    
-    public TestTimeSource(long currentTimeMillis) {
-      this.currentTimeMillis = currentTimeMillis;
-    }
-    
-    public void passTime(long millis) {
-      this.currentTimeMillis += millis;
-    }
-    
-    @Override
-    public long currentTimeMillis() {
-      return this.currentTimeMillis;
-    }
-  }
 }

--- a/dso-l2/src/test/java/com/tc/services/TestTimeSource.java
+++ b/dso-l2/src/test/java/com/tc/services/TestTimeSource.java
@@ -1,0 +1,40 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.services;
+
+
+/**
+ * A time source for use in tests which use a SingleThreadedTimer.
+ */
+public class TestTimeSource implements SingleThreadedTimer.TimeSource {
+  private long currentTimeMillis;
+  
+  public TestTimeSource(long currentTimeMillis) {
+    this.currentTimeMillis = currentTimeMillis;
+  }
+  
+  public void passTime(long millis) {
+    this.currentTimeMillis += millis;
+  }
+  
+  @Override
+  public long currentTimeMillis() {
+    return this.currentTimeMillis;
+  }
+}

--- a/tc-messaging/src/main/java/com/tc/l2/msg/PlatformInfoRequest.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/PlatformInfoRequest.java
@@ -56,7 +56,10 @@ public class PlatformInfoRequest extends AbstractGroupMessage {
   }
 
   public static PlatformInfoRequest createBestEffortsBatch(long[] consumerIDs, String[] keys, Serializable[] values) {
-    // Note that this would, ideally, use a different mechanism but the SEDA implementation routes based on type so we need to extend this class, for now.
+    // This should not be called if there is no data.
+    Assert.assertTrue(consumerIDs.length > 0);
+    // Note that this would, ideally, use a different mechanism but the SEDA implementation routes based on type so we need
+    //  to extend this class, for now.
     return new PlatformInfoRequest(BEST_EFFORTS_BATCH, -1, null, null, null, null, consumerIDs, keys, values);
   }
 


### PR DESCRIPTION
The final version of this uses the SingleThreadedTimer to grab any cached data and sent it to the active.

The unit tests try to demonstrate how it handles the interesting cases where state changes while the timer is pending.