### PR TITLE
Implement passive results

### DIFF
--- a/dso-l2/src/main/java/com/tc/l2/state/StateManagerImpl.java
+++ b/dso-l2/src/main/java/com/tc/l2/state/StateManagerImpl.java
@@ -20,6 +20,7 @@ package com.tc.l2.state;
 
 import com.tc.async.api.Sink;
 import com.tc.async.api.StageManager;
+import com.tc.exception.TCServerRestartException;
 import com.tc.exception.ZapDirtyDbServerNodeException;
 import com.tc.l2.context.StateChangedEvent;
 import com.tc.l2.ha.L2HAZapNodeRequestProcessor;
@@ -228,7 +229,8 @@ public class StateManagerImpl implements StateManager {
       if (!state.equals(PASSIVE_STANDBY) && !state.equals(PASSIVE_UNINITIALIZED)) {
 // TODO:  make sure this is the proper way to handle this.
         logger.fatal("Passive only partially synced when active disappeared.  Restarting");
-        throw new ZapDirtyDbServerNodeException("Passive only partially synced when active disappeared.  Restarting"); 
+        clusterStatePersistor.setDBClean(false);
+        throw new TCServerRestartException("Passive only partially synced when active disappeared.  Restarting"); 
       }
       info("Moved to " + state, true);
       fireStateChangedOperatorEvent();
@@ -242,7 +244,8 @@ public class StateManagerImpl implements StateManager {
       if (!syncdTo.equals(winningEnrollment.getNodeID())) {
 // TODO:  make sure this is the proper way to handle this.
         logger.fatal("Passive only partially synced when active disappeared.  Restarting");
-        throw new ZapDirtyDbServerNodeException("Passive only partially synced when active disappeared.  Restarting");
+        clusterStatePersistor.setDBClean(false);
+        throw new TCServerRestartException("Passive only partially synced when active disappeared.  Restarting");
       }
     } else if (state == ACTIVE_COORDINATOR) {
       // TODO:: Support this later
@@ -502,7 +505,8 @@ public class StateManagerImpl implements StateManager {
       if (state == PASSIVE_SYNCING && syncdTo.equals(disconnectedNode)) {
         //  need to zap and start over.  The active being synced to is gone.
         logger.fatal("Passive only partially synced when active disappeared.  Restarting");
-        throw new ZapDirtyDbServerNodeException("Passive only partially synced when active disappeared.  Restarting"); 
+        clusterStatePersistor.setDBClean(false);
+        throw new TCServerRestartException("Passive only partially synced when active disappeared.  Restarting"); 
       } else if (state != ACTIVE_COORDINATOR && activeNode.isNull()) {
         elect = true;
       }

--- a/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
@@ -24,11 +24,11 @@ import org.terracotta.entity.MessageCodec;
 import com.tc.net.ClientID;
 import com.tc.net.NodeID;
 import com.tc.object.EntityID;
-import com.tc.objectserver.entity.ActivePassiveAckWaiter;
 import com.tc.objectserver.entity.MessagePayload;
 import com.tc.objectserver.entity.SimpleCompletion;
 import com.tc.objectserver.handler.RetirementManager;
 import java.util.function.Consumer;
+import org.terracotta.entity.ConfigurationException;
 
 import org.terracotta.entity.StateDumpable;
 import org.terracotta.exception.EntityException;
@@ -72,9 +72,9 @@ public interface ManagedEntity extends StateDumpable {
    */
   void sync(NodeID passive);
   
-  void loadEntity(byte[] configuration);
+  void loadEntity(byte[] configuration) throws ConfigurationException;
   
-  void promoteEntity();
+  void promoteEntity() throws ConfigurationException;
     
   boolean isDestroyed();
   

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -317,7 +317,7 @@ public class ManagedEntityImpl implements ManagedEntity {
   private void invokeLifecycleOperation(final ServerEntityRequest request, MessagePayload payload, ResultCapture resp) {
     Lock read = reconnectAccessLock.readLock();
     if (logger.isDebugEnabled()) {
-      logger.debug("Client:" + request.getNodeID() + " Invoking lifecycle " + request.getAction() + " on " + getID());
+      logger.info("Client:" + request.getNodeID() + " Invoking lifecycle " + request.getAction() + " on " + getID());
     }
     read.lock();
     try {

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/NoReplicationBroker.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/NoReplicationBroker.java
@@ -32,7 +32,7 @@ public class NoReplicationBroker implements PassiveReplicationBroker {
   
   private boolean isActive = false;
   
-  public static final ActivePassiveAckWaiter NOOP_WAITER = new ActivePassiveAckWaiter(Collections.emptySet());
+  public static final ActivePassiveAckWaiter NOOP_WAITER = new ActivePassiveAckWaiter(Collections.emptySet(), null);
 
   @Override
   public void enterActiveState() {
@@ -50,4 +50,11 @@ public class NoReplicationBroker implements PassiveReplicationBroker {
   public ActivePassiveAckWaiter replicateMessage(ReplicationMessage msg, Set<NodeID> passives) {
     return NOOP_WAITER;
   }
+
+  @Override
+  public void zapAndWait(NodeID node) {
+    //  do nothing
+  }
+  
+  
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
@@ -180,13 +180,5 @@ public class RequestProcessor {
     synchronized boolean isDone() {
       return done;
     }
-    
-    public void waitForPassives() {
-      try {
-        this.replicationWaiter.waitForCompleted();
-      } catch (InterruptedException ie) {
-        throw new RuntimeException(ie);
-      }
-    }
   }
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -726,7 +726,7 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
 // setup replication    
     final Stage<ReplicationEnvelope> replicationDriver = stageManager.createStage(ServerConfigurationContext.ACTIVE_TO_PASSIVE_DRIVER_STAGE, ReplicationEnvelope.class, new ReplicationSender(groupCommManager), 1, maxStageSize);
     
-    final ActiveToPassiveReplication passives = new ActiveToPassiveReplication(l2Coordinator.getReplicatedClusterStateManager().getPassives(), processTransactionHandler.getEntityList(), this.persistor.getEntityPersistor(), replicationDriver.getSink());
+    final ActiveToPassiveReplication passives = new ActiveToPassiveReplication(l2Coordinator.getReplicatedClusterStateManager().getPassives(), processTransactionHandler.getEntityList(), this.persistor.getEntityPersistor(), replicationDriver.getSink(), this.getGroupManager());
     processor.setReplication(passives); 
 //  routing for passive to receive replication    
     Stage<ReplicationMessage> replicationStage = stageManager.createStage(ServerConfigurationContext.PASSIVE_REPLICATION_STAGE, ReplicationMessage.class, 

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ActivePassiveAckWaiterTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ActivePassiveAckWaiterTest.java
@@ -18,6 +18,8 @@
  */
 package com.tc.objectserver.entity;
 
+import com.tc.l2.msg.ReplicationMessageAck;
+import com.tc.l2.msg.ReplicationResultCode;
 import com.tc.net.NodeID;
 import com.tc.util.Assert;
 
@@ -37,7 +39,7 @@ public class ActivePassiveAckWaiterTest {
   @Test
   public void testEmptyWait() throws Exception {
     Set<NodeID> passives = Collections.emptySet();
-    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives);
+    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives, null);
     // This can run in a single thread.
     Assert.assertTrue(waiter.isCompleted());
     waiter.waitForReceived();
@@ -50,14 +52,14 @@ public class ActivePassiveAckWaiterTest {
     Set<NodeID> passives = new HashSet<NodeID>();
     NodeID onePassive = mock(NodeID.class);
     passives.add(onePassive);
-    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives);
+    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives, null);
     Interlock interlock = new Interlock(1);
     LockStep lockStep = new LockStep(waiter, interlock);
     lockStep.start();
     interlock.waitOnStarts();
     waiter.didReceiveOnPassive(onePassive);
     interlock.waitOnReceivesOnly();
-    boolean waiterIsDone = waiter.didCompleteOnPassive(onePassive, true);
+    boolean waiterIsDone = waiter.didCompleteOnPassive(onePassive, true, ReplicationResultCode.SUCCESS);
     Assert.assertTrue(waiterIsDone);
     interlock.waitOnCompletes();
     lockStep.join();
@@ -70,7 +72,7 @@ public class ActivePassiveAckWaiterTest {
     passives.add(onePassive);
     NodeID twoPassive = mock(NodeID.class);
     passives.add(twoPassive);
-    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives);
+    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives, null);
     Interlock interlock = new Interlock(1);
     LockStep lockStep = new LockStep(waiter, interlock);
     lockStep.start();
@@ -78,9 +80,9 @@ public class ActivePassiveAckWaiterTest {
     waiter.didReceiveOnPassive(onePassive);
     waiter.didReceiveOnPassive(twoPassive);
     interlock.waitOnReceivesOnly();
-    boolean waiterIsDone = waiter.didCompleteOnPassive(twoPassive, true);
+    boolean waiterIsDone = waiter.didCompleteOnPassive(twoPassive, true, ReplicationResultCode.SUCCESS);
     Assert.assertFalse(waiterIsDone);
-    waiterIsDone = waiter.didCompleteOnPassive(onePassive, true);
+    waiterIsDone = waiter.didCompleteOnPassive(onePassive, true, ReplicationResultCode.SUCCESS);
     Assert.assertTrue(waiterIsDone);
     interlock.waitOnCompletes();
     lockStep.join();
@@ -93,7 +95,7 @@ public class ActivePassiveAckWaiterTest {
     passives.add(onePassive);
     NodeID twoPassive = mock(NodeID.class);
     passives.add(twoPassive);
-    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives);
+    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives, null);
     Interlock interlock = new Interlock(2);
     LockStep lockStep1 = new LockStep(waiter, interlock);
     LockStep lockStep2 = new LockStep(waiter, interlock);
@@ -103,9 +105,9 @@ public class ActivePassiveAckWaiterTest {
     waiter.didReceiveOnPassive(onePassive);
     waiter.didReceiveOnPassive(twoPassive);
     interlock.waitOnReceivesOnly();
-    boolean waiterIsDone = waiter.didCompleteOnPassive(twoPassive, true);
+    boolean waiterIsDone = waiter.didCompleteOnPassive(twoPassive, true, ReplicationResultCode.SUCCESS);
     Assert.assertFalse(waiterIsDone);
-    waiterIsDone = waiter.didCompleteOnPassive(onePassive, true);
+    waiterIsDone = waiter.didCompleteOnPassive(onePassive, true, ReplicationResultCode.SUCCESS);
     Assert.assertTrue(waiterIsDone);
     interlock.waitOnCompletes();
     lockStep1.join();
@@ -119,14 +121,14 @@ public class ActivePassiveAckWaiterTest {
     passives.add(onePassive);
     NodeID twoPassive = mock(NodeID.class);
     passives.add(twoPassive);
-    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives);
+    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives, null);
     Interlock interlock = new Interlock(1);
     LockStep lockStep = new LockStep(waiter, interlock);
     lockStep.start();
     interlock.waitOnStarts();
-    boolean waiterIsDone = waiter.didCompleteOnPassive(twoPassive, true);
+    boolean waiterIsDone = waiter.didCompleteOnPassive(twoPassive, true, ReplicationResultCode.SUCCESS);
     Assert.assertFalse(waiterIsDone);
-    waiterIsDone = waiter.didCompleteOnPassive(onePassive, true);
+    waiterIsDone = waiter.didCompleteOnPassive(onePassive, true, ReplicationResultCode.SUCCESS);
     Assert.assertTrue(waiterIsDone);
     interlock.waitOnCompletes();
     lockStep.join();
@@ -137,18 +139,18 @@ public class ActivePassiveAckWaiterTest {
     Set<NodeID> passives = new HashSet<NodeID>();
     NodeID onePassive = mock(NodeID.class);
     passives.add(onePassive);
-    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives);
+    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives, null);
     Interlock interlock = new Interlock(1);
     LockStep lockStep = new LockStep(waiter, interlock);
     lockStep.start();
     interlock.waitOnStarts();
     waiter.didReceiveOnPassive(onePassive);
     interlock.waitOnReceivesOnly();
-    boolean waiterIsDone = waiter.didCompleteOnPassive(onePassive, true);
+    boolean waiterIsDone = waiter.didCompleteOnPassive(onePassive, true, ReplicationResultCode.SUCCESS);
     Assert.assertTrue(waiterIsDone);
     boolean didFail = false;
     try {
-      waiter.didCompleteOnPassive(onePassive, true);
+      waiter.didCompleteOnPassive(onePassive, true, ReplicationResultCode.SUCCESS);
     } catch (AssertionError e) {
       // We expect this to fail on double-complete.
       didFail = true;
@@ -163,17 +165,17 @@ public class ActivePassiveAckWaiterTest {
     Set<NodeID> passives = new HashSet<NodeID>();
     NodeID onePassive = mock(NodeID.class);
     passives.add(onePassive);
-    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives);
+    ActivePassiveAckWaiter waiter = new ActivePassiveAckWaiter(passives, null);
     Interlock interlock = new Interlock(1);
     LockStep lockStep = new LockStep(waiter, interlock);
     lockStep.start();
     interlock.waitOnStarts();
     waiter.didReceiveOnPassive(onePassive);
     interlock.waitOnReceivesOnly();
-    boolean waiterIsDone = waiter.didCompleteOnPassive(onePassive, true);
+    boolean waiterIsDone = waiter.didCompleteOnPassive(onePassive, true, ReplicationResultCode.SUCCESS);
     Assert.assertTrue(waiterIsDone);
     // We will try to complete, again, but this won't assert, since we are stating that it is not a normal complete.
-    waiterIsDone = waiter.didCompleteOnPassive(onePassive, false);
+    waiterIsDone = waiter.didCompleteOnPassive(onePassive, false, ReplicationResultCode.SUCCESS);
     Assert.assertTrue(waiterIsDone);
     interlock.waitOnCompletes();
     lockStep.join();

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ActiveToPassiveReplicationTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ActiveToPassiveReplicationTest.java
@@ -22,6 +22,7 @@ import com.tc.async.api.Sink;
 import com.tc.l2.msg.ReplicationEnvelope;
 import com.tc.l2.msg.ReplicationMessage;
 import com.tc.net.ServerID;
+import com.tc.net.groups.GroupManager;
 import com.tc.net.groups.MessageID;
 import com.tc.objectserver.api.ManagedEntity;
 import com.tc.objectserver.persistence.EntityPersistor;
@@ -71,7 +72,7 @@ public class ActiveToPassiveReplicationTest {
         return null;
       }
     }).when(replicate).addSingleThreaded(Matchers.any());
-    replication = new ActiveToPassiveReplication(Collections.singleton(passive), entities, mock(EntityPersistor.class), replicate);
+    replication = new ActiveToPassiveReplication(Collections.singleton(passive), entities, mock(EntityPersistor.class), replicate, mock(GroupManager.class));
   }
   
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
     <tc-shader.version>1.2</tc-shader.version>
     <skip.deploy>false</skip.deploy>
 
-    <terracotta-apis.version>1.0.13.beta</terracotta-apis.version>
-    <terracotta-configuration.version>10.0.13.beta</terracotta-configuration.version>
+    <terracotta-apis.version>1.0.14.beta</terracotta-apis.version>
+    <terracotta-configuration.version>10.0.14.beta</terracotta-configuration.version>
   </properties>
 
   <modules>

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessageAck.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessageAck.java
@@ -33,7 +33,9 @@ public class ReplicationMessageAck extends AbstractGroupMessage {
   public static final int RECEIVED                = 2; // Means that the replicated action has been received by the passive
   public static final int COMPLETED                = 3; // response that the replicated action completed
   public static final int START_SYNC                = 4; // Sent from the passive when it wants the active to start passive sync.
-
+  
+  public ReplicationResultCode result = ReplicationResultCode.NONE;
+  
   // Factory methods.
   public static ReplicationMessageAck createSyncRequestMessage() {
     return new ReplicationMessageAck(START_SYNC);
@@ -47,7 +49,10 @@ public class ReplicationMessageAck extends AbstractGroupMessage {
     return new ReplicationMessageAck(COMPLETED, requestToAck);
   }
 
-
+  public static ReplicationMessageAck createCompletedAck(MessageID requestToAck, ReplicationResultCode payload) {
+    return new ReplicationMessageAck(COMPLETED, requestToAck, payload);
+  }
+  
   public ReplicationMessageAck() {
     super(INVALID);
   }
@@ -60,14 +65,19 @@ public class ReplicationMessageAck extends AbstractGroupMessage {
   private ReplicationMessageAck(int type, MessageID requestID) {
     super(type, requestID);
   }
-
+  
+  private ReplicationMessageAck(int type, MessageID requestID, ReplicationResultCode code) {
+    super(type, requestID);
+    result = code;
+  }
+  
   @Override
   protected void basicDeserializeFrom(TCByteBufferInput in) throws IOException {
-    // Do nothing - no instance variables.
+    result = ReplicationResultCode.decode(in.read());
   }
 
   @Override
   protected void basicSerializeTo(TCByteBufferOutput out) {
-    // Do nothing - no instance variables.
+    out.write(result.code());
   }
 }

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationResultCode.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationResultCode.java
@@ -16,16 +16,39 @@
  *  Terracotta, Inc., a Software AG company
  *
  */
-package com.tc.objectserver.entity;
+package com.tc.l2.msg;
 
-import com.tc.l2.msg.ReplicationMessage;
-import com.tc.net.NodeID;
-import java.util.Set;
+/**
+ *
+ */
+public enum ReplicationResultCode {
+  NONE, SUCCESS {
+    @Override
+    byte code() {
+      return 1;
+    }
+  }, FAIL {
+    @Override
+    byte code() {
+      return 2;
+    }
+  };
 
+  static ReplicationResultCode decode(int code) {
+    switch (code) {
+      case 0:
+        return NONE;
+      case 1:
+        return SUCCESS;
+      case 2:
+        return FAIL;
+      default:
+        throw new RuntimeException("bad code");
+    }
+  }
 
-public interface PassiveReplicationBroker {
-  ActivePassiveAckWaiter replicateMessage(ReplicationMessage msg, Set<NodeID> passives);
-  void zapAndWait(NodeID node);
-  Set<NodeID> passives();
-  void enterActiveState();
+  byte code() {
+    return 0;
+  }
+  
 }


### PR DESCRIPTION
Handles ConfigurationException coming from the entity implementation.   If an entity throws a ConfigurationException in a lifecycle operation and all nodes of a stripe agree, EntityConfigurationException is returned to the client.  If some succeed and some fail, the failing nodes are zapped and success is communicated back to the client.

Also in this PR is a small fix to logging

A Fix to handling of partially sync'd restartable nodes