### PR TITLE
Fix destroy

### DIFF
--- a/dso-l1/src/main/java/com/tc/object/ClientEntityManagerImpl.java
+++ b/dso-l1/src/main/java/com/tc/object/ClientEntityManagerImpl.java
@@ -456,7 +456,7 @@ public class ClientEntityManagerImpl implements ClientEntityManager {
     // We need to provide fully blocking semantics with this call so we will wait for the "APPLIED" ack.
     Set<VoltronEntityMessage.Acks> requestedAcks = EnumSet.of(VoltronEntityMessage.Acks.APPLIED);
     // A "RELEASE" doesn't matter to the passive.
-    boolean requiresReplication = false;
+    boolean requiresReplication = true;
     byte[] payload = new byte[0];
     NetworkVoltronEntityMessage message = createMessageWithDescriptor(entityDescriptor, requiresReplication, payload, VoltronEntityMessage.Type.RELEASE_ENTITY);
     synchronousWaitForResponse(message, requestedAcks);
@@ -496,7 +496,7 @@ public class ClientEntityManagerImpl implements ClientEntityManager {
     // We need to provide fully blocking semantics with this call so we will wait for the "APPLIED" ack.
     Set<VoltronEntityMessage.Acks> requestedAcks = EnumSet.of(VoltronEntityMessage.Acks.APPLIED);
     // We don't care about whether a "FETCH" is replicated.
-    boolean requiresReplication = false;
+    boolean requiresReplication = true;
     byte[] payload = new byte[0];
     NetworkVoltronEntityMessage message = createMessageWithDescriptor(entityDescriptor, requiresReplication, payload, VoltronEntityMessage.Type.FETCH_ENTITY);
     return synchronousWaitForResponse(message, requestedAcks);

--- a/dso-l2/src/main/java/com/tc/objectserver/api/EntityManager.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/api/EntityManager.java
@@ -44,7 +44,7 @@ public interface EntityManager extends StateDumpable, MessageCodecSupplier {
    * @param version the version of the entity on the calling client
    * @param consumerID the unique consumerID this entity uses when interacting with services
    */
-  ManagedEntity createEntity(EntityID id, long version, long consumerID, boolean canDelete) throws EntityException;
+  ManagedEntity createEntity(EntityID id, long version, long consumerID, int reference) throws EntityException;
  
   /**
    * Once a ManagedEntity is destroyed it must be removed from the EntityManager manually. 

--- a/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
@@ -41,6 +41,8 @@ import org.terracotta.exception.EntityUserException;
  * Additionally, client-entity connections are rebuilt, after reconnect, using this interface.
  */
 public interface ManagedEntity extends StateDumpable {
+  public final static int UNDELETABLE_ENTITY = -1;
+  
   public EntityID getID();
   
   public long getVersion();

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ClientEntityStateManagerImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ClientEntityStateManagerImpl.java
@@ -157,7 +157,7 @@ public class ClientEntityStateManagerImpl implements ClientEntityStateManager {
 
     @Override
     public boolean doesRequireReplication() {
-      return false;
+      return true;
     }
 
     @Override

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/EntityManagerImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/EntityManagerImpl.java
@@ -111,11 +111,11 @@ public class EntityManagerImpl implements EntityManager {
   }
 
   @Override
-  public ManagedEntity createEntity(EntityID id, long version, long consumerID, boolean canDelete) throws EntityException {
+  public ManagedEntity createEntity(EntityID id, long version, long consumerID, int references) throws EntityException {
     // Valid entity versions start at 1.
     Assert.assertTrue(version > 0);
     ManagedEntity temp = new ManagedEntityImpl(id, version, consumerID, noopLoopback, serviceRegistry.subRegistry(consumerID),
-        clientEntityStateManager, this.eventCollector, processorPipeline, getVersionCheckedService(id, version), this.shouldCreateActiveEntities, canDelete);
+        clientEntityStateManager, this.eventCollector, processorPipeline, getVersionCheckedService(id, version), this.shouldCreateActiveEntities, references);
     ManagedEntity exists = entities.putIfAbsent(id, temp);
     if (exists == null) {
       LOGGER.debug("created " + id);
@@ -127,7 +127,7 @@ public class EntityManagerImpl implements EntityManager {
   public void loadExisting(EntityID entityID, long recordedVersion, long consumerID, boolean canDelete, byte[] configuration) throws EntityException {
     // Valid entity versions start at 1.
     Assert.assertTrue(recordedVersion > 0);
-    ManagedEntity temp = new ManagedEntityImpl(entityID, recordedVersion, consumerID, noopLoopback, serviceRegistry.subRegistry(consumerID), clientEntityStateManager, this.eventCollector, processorPipeline, getVersionCheckedService(entityID, recordedVersion), this.shouldCreateActiveEntities, canDelete);
+    ManagedEntity temp = new ManagedEntityImpl(entityID, recordedVersion, consumerID, noopLoopback, serviceRegistry.subRegistry(consumerID), clientEntityStateManager, this.eventCollector, processorPipeline, getVersionCheckedService(entityID, recordedVersion), this.shouldCreateActiveEntities, canDelete ? 0 : ManagedEntity.UNDELETABLE_ENTITY);
     if (entities.putIfAbsent(entityID, temp) != null) {
       throw new IllegalStateException("Double create for entity " + entityID);
     }    

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
@@ -32,7 +32,6 @@ import com.tc.util.Assert;
 import java.util.Collections;
 import java.util.Set;
 import org.terracotta.entity.ConcurrencyStrategy;
-import org.terracotta.entity.ExecutionStrategy;
 
 
 public class RequestProcessor {
@@ -93,7 +92,7 @@ public class RequestProcessor {
         actionCode = ReplicationMessage.ReplicationType.DESTROY_ENTITY;
         break;
       case FETCH_ENTITY:
-        actionCode = ReplicationMessage.ReplicationType.NOOP;
+        actionCode = ReplicationMessage.ReplicationType.FETCH_ENTITY;
         break;
       case INVOKE_ACTION:
         actionCode = ReplicationMessage.ReplicationType.INVOKE_ACTION;
@@ -102,7 +101,7 @@ public class RequestProcessor {
         actionCode = ReplicationMessage.ReplicationType.NOOP;
         break;
       case RELEASE_ENTITY:
-        actionCode = ReplicationMessage.ReplicationType.NOOP;
+        actionCode = ReplicationMessage.ReplicationType.RELEASE_ENTITY;
         break;
       case REQUEST_SYNC_ENTITY:
 //  this marks the start of entity sync for a concurrency key.  practically, this means that

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/EntityExistenceHelpers.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/EntityExistenceHelpers.java
@@ -51,7 +51,7 @@ public class EntityExistenceHelpers {
       resultWasCached = true;
     } else {
       // There is no record of this, so give it a try.
-      entityManager.createEntity(entityID, version, consumerID, canDelete);
+      entityManager.createEntity(entityID, version, consumerID, canDelete ? 0 : ManagedEntity.UNDELETABLE_ENTITY);
     }
     return resultWasCached;
   }

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
@@ -236,7 +236,7 @@ public class ProcessTransactionHandler {
       long consumerID = this.entityPersistor.getNextConsumerID();
       serverEntityRequest.setAutoRetire();
       try {
-        ManagedEntity temp = entityManager.createEntity(entityID, descriptor.getClientSideVersion(), consumerID, !sourceNodeID.isNull());
+        ManagedEntity temp = entityManager.createEntity(entityID, descriptor.getClientSideVersion(), consumerID, !sourceNodeID.isNull() ? 0 : ManagedEntity.UNDELETABLE_ENTITY);
         temp.addRequestMessage(serverEntityRequest, entityMessage,
           (result) -> {
             if (!sourceNodeID.isNull()) {

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicationSender.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicationSender.java
@@ -263,6 +263,8 @@ public class ReplicationSender extends AbstractEventHandler<ReplicationEnvelope>
               return true;
             }
           case RECONFIGURE_ENTITY:
+          case FETCH_ENTITY:
+          case RELEASE_ENTITY:
             if (syncd.contains(eid) || eid.equals(syncingID)) {
 //  this entity is being or has been replicated, send the reconfigure through
               return true;

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -646,7 +646,7 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
         @Override
         public void channelCreated(MessageChannel channel) {
           ClientID cid = channelManager.getClientIDFor(channel.getChannelID());
-          if (l2Coordinator.getStateManager().isActiveCoordinator()) {
+          if (l2Coordinator.getStateManager().isActiveCoordinator() && channelManager.isActiveID(cid)) {
             eventCollector.clientDidConnect(channel, cid);
           }
         }

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/EntityManagerImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/EntityManagerImplTest.java
@@ -86,14 +86,14 @@ public class EntityManagerImplTest {
 
   @Test
   public void testCreateEntity() throws Exception {
-    entityManager.createEntity(id, version, consumerID, true);
+    entityManager.createEntity(id, version, consumerID, 0);
     assertThat(entityManager.getEntity(id, version).get().getID(), is(id));
   }
 
   @Test
   public void testCreateExistingEntity() throws Exception {
-    ManagedEntity entity = entityManager.createEntity(id, version, consumerID, true);
-    ManagedEntity second = entityManager.createEntity(id, version, consumerID, true);
+    ManagedEntity entity = entityManager.createEntity(id, version, consumerID, 0);
+    ManagedEntity second = entityManager.createEntity(id, version, consumerID, 0);
     Assert.assertEquals(entity, second);
   }
   
@@ -101,7 +101,7 @@ public class EntityManagerImplTest {
   public void testNullEntityChecks() throws Exception {
     Optional<ManagedEntity> check = entityManager.getEntity(EntityID.NULL_ID, 0);
     Assert.assertFalse(check.isPresent());
-    ManagedEntity entity = entityManager.createEntity(id, version, consumerID, true);
+    ManagedEntity entity = entityManager.createEntity(id, version, consumerID, 0);
     check = entityManager.getEntity(id, version);
     Assert.assertTrue(check.isPresent());
     check = entityManager.getEntity(id, 0);
@@ -115,7 +115,7 @@ public class EntityManagerImplTest {
   @Test
   public void testDestroyEntity() throws Exception {
     entityManager.enterActiveState();
-    ManagedEntity entity = entityManager.createEntity(id, version, consumerID, true);
+    ManagedEntity entity = entityManager.createEntity(id, version, consumerID, 0);
     Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
     ServerEntityRequest req = new ServerEntityRequest() {
       @Override

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
@@ -159,7 +159,7 @@ public class ManagedEntityImplTest {
     eventCollector = mock(ITopologyEventCollector.class);
     // We will start this in a passive state, as the general test case.
     boolean isInActiveState = false;
-    managedEntity = new ManagedEntityImpl(entityID, version, consumerID, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, isInActiveState, true);
+    managedEntity = new ManagedEntityImpl(entityID, version, consumerID, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, isInActiveState, 0);
     clientDescriptor = new ClientDescriptorImpl(nodeID, entityDescriptor);
     invokeOnTransactionHandler(()->Thread.currentThread().setName(ServerConfigurationContext.PASSIVE_REPLICATION_STAGE));
   }
@@ -437,7 +437,7 @@ public class ManagedEntityImplTest {
         return Collections.singleton(1);
       }
     });
-    managedEntity = new ManagedEntityImpl(entityID, version, consumerID, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, false, true);
+    managedEntity = new ManagedEntityImpl(entityID, version, consumerID, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, false, 0);
     TestingResponse resp = mockResponse();
     invokeOnTransactionHandler(()->managedEntity.addRequestMessage(mockCreateEntityRequest(), MessagePayload.EMPTY,  resp::complete, resp::failure));
     resp.waitFor();
@@ -501,7 +501,7 @@ public class ManagedEntityImplTest {
         return Collections.singleton(1);
       }
     });
-    managedEntity = new ManagedEntityImpl(entityID, version, consumerID, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, false, true);
+    managedEntity = new ManagedEntityImpl(entityID, version, consumerID, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, false, 0);
     invokeOnTransactionHandler(()->managedEntity.addRequestMessage(mockCreateEntityRequest(), MessagePayload.EMPTY,  response::complete, response::failure));
     response.waitFor();
     
@@ -586,7 +586,7 @@ public class ManagedEntityImplTest {
     when(this.serverEntityService.getConcurrencyStrategy(any(byte[].class))).thenReturn(basic);
     when(this.serverEntityService.getMessageCodec()).thenReturn(codec);
     TestingResponse response = mockResponse();
-    invokeOnTransactionHandler(()->managedEntity = new ManagedEntityImpl(entityID, version, consumerID, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, false, true));
+    invokeOnTransactionHandler(()->managedEntity = new ManagedEntityImpl(entityID, version, consumerID, loopback, serviceRegistry, clientEntityStateManager, eventCollector, requestMulti, serverEntityService, false, 0));
     invokeOnTransactionHandler(()->managedEntity.addRequestMessage(mockCreateEntityRequest(), MessagePayload.EMPTY, response::complete, response::failure));
     response.waitFor();
 

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
@@ -63,6 +63,7 @@ import java.util.function.Consumer;
 import org.junit.Test;
 import org.mockito.Matchers;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.times;
@@ -134,7 +135,7 @@ public class ReplicatedTransactionHandlerTest {
     when(msg.getExtendedData()).thenReturn(new byte[0]);
     when(entity.getCodec()).thenReturn(mock(MessageCodec.class));
     when(this.entityManager.getEntity(Matchers.any(), Matchers.anyInt())).thenReturn(Optional.empty());
-    when(this.entityManager.createEntity(Matchers.any(), anyLong(), anyLong(), anyBoolean())).then((invoke)->{
+    when(this.entityManager.createEntity(Matchers.any(), anyLong(), anyLong(), anyInt())).then((invoke)->{
       when(this.entityManager.getEntity(Matchers.any(), Matchers.anyInt())).thenReturn(Optional.of(entity));
       return entity;
     });
@@ -147,7 +148,7 @@ public class ReplicatedTransactionHandlerTest {
       return null;
     }).when(entity).addRequestMessage(Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any());
     this.loopbackSink.addSingleThreaded(PassiveSyncMessage.createStartSyncMessage());
-    this.loopbackSink.addSingleThreaded(PassiveSyncMessage.createStartEntityMessage(eid, 1, new byte[0], true));
+    this.loopbackSink.addSingleThreaded(PassiveSyncMessage.createStartEntityMessage(eid, 1, new byte[0], 0));
     this.loopbackSink.addSingleThreaded(PassiveSyncMessage.createStartEntityKeyMessage(eid, 1, rand));
     this.loopbackSink.addSingleThreaded(msg);
     this.loopbackSink.addSingleThreaded(PassiveSyncMessage.createEndEntityKeyMessage(eid, 1, rand));
@@ -210,7 +211,7 @@ public class ReplicatedTransactionHandlerTest {
     MessageCodec codec = mock(MessageCodec.class);
     SyncMessageCodec sync = mock(SyncMessageCodec.class);
     when(this.entityManager.getEntity(Matchers.eq(eid), Matchers.eq(VERSION))).thenReturn(Optional.empty());
-    when(this.entityManager.createEntity(Matchers.any(), anyLong(), anyLong(), anyBoolean())).then((invoke)->{
+    when(this.entityManager.createEntity(Matchers.any(), anyLong(), anyLong(), anyInt())).then((invoke)->{
       when(this.entityManager.getEntity(Matchers.any(), Matchers.anyInt())).thenReturn(Optional.of(entity));
       return entity;
     });
@@ -291,7 +292,7 @@ public class ReplicatedTransactionHandlerTest {
     long VERSION = 1;
     byte[] config = new byte[0];
     send(PassiveSyncMessage.createStartSyncMessage());
-    send(PassiveSyncMessage.createStartEntityMessage(eid, VERSION, config, true));
+    send(PassiveSyncMessage.createStartEntityMessage(eid, VERSION, config, 0));
     send(PassiveSyncMessage.createStartEntityKeyMessage(eid, VERSION, 1));
     send(PassiveSyncMessage.createPayloadMessage(eid, VERSION, 1, config));
     send(PassiveSyncMessage.createEndEntityKeyMessage(eid, VERSION, 1));

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicationSenderTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicationSenderTest.java
@@ -100,7 +100,7 @@ public class ReplicationSenderTest {
       case SYNC_END:
         return PassiveSyncMessage.createEndSyncMessage(new byte[0]);
       case SYNC_ENTITY_BEGIN:
-        return PassiveSyncMessage.createStartEntityMessage(entity, 1, new byte[0], true);
+        return PassiveSyncMessage.createStartEntityMessage(entity, 1, new byte[0], 0);
       case SYNC_ENTITY_CONCURRENCY_BEGIN:
         return PassiveSyncMessage.createStartEntityKeyMessage(entity, 1, concurrency);
       case SYNC_ENTITY_CONCURRENCY_END:

--- a/tc-messaging/src/main/java/com/tc/l2/msg/PassiveSyncMessage.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/PassiveSyncMessage.java
@@ -46,9 +46,9 @@ public class PassiveSyncMessage extends ReplicationMessage {
   public static PassiveSyncMessage createEndSyncMessage(byte[] extras) {
     return new PassiveSyncMessage(SYNC_END, EntityID.NULL_ID, NO_VERSION, 0, extras);
   }
-  public static PassiveSyncMessage createStartEntityMessage(EntityID id, long version, byte[] configPayload, boolean canDelete) {
+  public static PassiveSyncMessage createStartEntityMessage(EntityID id, long version, byte[] configPayload, int references) {
  //  repurposed concurrency id to tell passive if entity can be deleted 0 for deletable and 1 for not deletable
-    return new PassiveSyncMessage(SYNC_ENTITY_BEGIN, id, version, canDelete ? 0 : 1, configPayload);
+    return new PassiveSyncMessage(SYNC_ENTITY_BEGIN, id, version, references, configPayload);
   }
   public static PassiveSyncMessage createEndEntityMessage(EntityID id, long version) {
     return new PassiveSyncMessage(SYNC_ENTITY_END, id, version, 0, null);

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
@@ -48,6 +48,8 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
     RECONFIGURE_ENTITY,
     INVOKE_ACTION,
     DESTROY_ENTITY,
+    FETCH_ENTITY,
+    RELEASE_ENTITY,
     
     SYNC_BEGIN,
     SYNC_END,


### PR DESCRIPTION
Passive entities must be reference counted the same as actives so they are not deleted prematurely.