### PR TITLE
Small fixes

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicationSender.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicationSender.java
@@ -59,19 +59,19 @@ public class ReplicationSender extends AbstractEventHandler<ReplicationEnvelope>
 // this is a flush of the replication channel.  shut it down and return;
       ordering.remove(nodeid);
       filtering.remove(nodeid);
-      context.release();
+      context.droppedWithoutSend();
     } else {
       SyncState syncing = getSyncState(nodeid, msg);
       AtomicLong rOrder = getOrdering(nodeid, msg);
       
       if (rOrder == null) {
 // this is message priming, the order is being established or the passive is gone
-        context.release();
+        context.droppedWithoutSend();
         return;
       }
 // check to make sure that this message is a type that is relevant to a passive
       if (!shouldReplicate(msg)) {
-        context.release();
+        context.droppedWithoutSend();
         return;
       }   
 // filter out messages based on sync state.

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ActiveToPassiveReplicationTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ActiveToPassiveReplicationTest.java
@@ -68,7 +68,7 @@ public class ActiveToPassiveReplicationTest {
     doAnswer(new Answer<Void>() {
       @Override
       public Void answer(InvocationOnMock invocation) throws Throwable {
-        ((ReplicationEnvelope)invocation.getArguments()[0]).release();
+        ((ReplicationEnvelope)invocation.getArguments()[0]).droppedWithoutSend();
         return null;
       }
     }).when(replicate).addSingleThreaded(Matchers.any());

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationEnvelope.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationEnvelope.java
@@ -20,19 +20,24 @@ package com.tc.l2.msg;
 
 import com.tc.net.NodeID;
 
-/**
- *
- */
+
 public class ReplicationEnvelope {
-  
   private final NodeID dest;
   private final ReplicationMessage msg;
-  private final Runnable waitRelease;
+  private final Runnable droppedWithoutSend;
 
-  public ReplicationEnvelope(NodeID dest, ReplicationMessage msg, Runnable waitRelease) {
+  /**
+   * Creates an envelope containing a replication message to be sent to the ReplicationSender for processing.
+   * 
+   * @param dest The destination node of the message.
+   * @param msg The message to send.
+   * @param droppedWithoutSend A runnable to run if the message is dropped by ReplicationSender and will NOT be replicated to
+   *  dest.
+   */
+  public ReplicationEnvelope(NodeID dest, ReplicationMessage msg, Runnable droppedWithoutSend) {
     this.dest = dest;
     this.msg = msg;
-    this.waitRelease = waitRelease;
+    this.droppedWithoutSend = droppedWithoutSend;
   }
   
   public NodeID getDestination() {
@@ -43,9 +48,9 @@ public class ReplicationEnvelope {
     return msg;
   }
   
-  public void release() {
-    if (waitRelease != null) {
-      waitRelease.run();
+  public void droppedWithoutSend() {
+    if (droppedWithoutSend != null) {
+      droppedWithoutSend.run();
     }
   }
 }


### PR DESCRIPTION
These changes most relate to the recently-added asserts in SyncState but also other concerns we had regarding handling of concurrent deletes during sync and some misleading names around the ReplicationEnvelope.