### PR TITLE
Improve lifecycle and sync interaction

### DIFF
--- a/common/src/main/java/com/tc/exception/EntityBusyException.java
+++ b/common/src/main/java/com/tc/exception/EntityBusyException.java
@@ -1,0 +1,36 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.exception;
+
+import org.terracotta.exception.EntityException;
+
+/**
+ *  Internal exception to tell the client that the server is busy and to retry
+ */
+public class EntityBusyException extends EntityException {
+
+  public EntityBusyException(String className, String entityName, String description) {
+    super(className, entityName, description, null);
+  }  
+  
+  public EntityBusyException(String className, String entityName, Throwable cause) {
+    super(className, entityName, cause.getMessage(), cause);
+  }
+
+}

--- a/connection-impl/src/main/java/com/terracotta/connection/entity/TerracottaEntityRef.java
+++ b/connection-impl/src/main/java/com/terracotta/connection/entity/TerracottaEntityRef.java
@@ -162,6 +162,8 @@ public class TerracottaEntityRef<T extends Entity, C> implements EntityRef<T, C>
     } catch (EntityException e) {
       if (e instanceof EntityNotFoundException) {
         throw (EntityNotFoundException)e;
+      } else if (e instanceof PermanentEntityException) {
+        throw (PermanentEntityException)e;
       } else {
         throw new RuntimeException("unexpected", e);
       }

--- a/connection-impl/src/test/java/com/terracotta/connection/entity/TerracottaEntityRefTest.java
+++ b/connection-impl/src/test/java/com/terracotta/connection/entity/TerracottaEntityRefTest.java
@@ -84,7 +84,7 @@ public class TerracottaEntityRefTest {
   public void testTryDestroySuccess() throws Exception {
     // Set up the mocked infrastructure.
     ClientEntityManager mockClientEntityManager = mock(ClientEntityManager.class);
-    when(mockClientEntityManager.destroyEntity(any(EntityID.class), any(Long.class))).thenReturn(mock(InvokeFuture.class));
+    when(mockClientEntityManager.destroyEntity(any(EntityID.class), any(Long.class))).thenReturn(true);
     EntityClientService<Entity, Void, ? extends EntityMessage, ? extends EntityResponse> mockEntityClientService = mock(EntityClientService.class);
     
     // Now, run the test.
@@ -104,9 +104,7 @@ public class TerracottaEntityRefTest {
   public void testTryDestroyFailure() throws Exception {
     // Set up the mocked infrastructure.
     ClientEntityManager mockClientEntityManager = mock(ClientEntityManager.class);
-    InvokeFuture fut = mock(InvokeFuture.class);
-    when(fut.get()).thenThrow(EntityReferencedException.class);
-    when(mockClientEntityManager.destroyEntity(Mockito.any(EntityID.class), Mockito.anyLong())).thenReturn(fut);
+    when(mockClientEntityManager.destroyEntity(Mockito.any(EntityID.class), Mockito.anyLong())).thenReturn(Boolean.FALSE);
     EntityClientService<Entity, Void, ? extends EntityMessage, ? extends EntityResponse> mockEntityClientService = mock(EntityClientService.class);
     
     // Now, run the test.

--- a/dso-l1/src/main/java/com/tc/object/ClientEntityManager.java
+++ b/dso-l1/src/main/java/com/tc/object/ClientEntityManager.java
@@ -18,6 +18,7 @@
  */
 package com.tc.object;
 
+import com.tc.exception.EntityBusyException;
 import org.terracotta.entity.EntityClientEndpoint;
 import org.terracotta.entity.InvokeFuture;
 import org.terracotta.entity.MessageCodec;
@@ -28,6 +29,8 @@ import org.terracotta.exception.EntityException;
 import com.tc.object.handshakemanager.ClientHandshakeCallback;
 import com.tc.object.request.RequestResponseHandler;
 import com.tc.text.PrettyPrintable;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 
 
@@ -57,9 +60,9 @@ public interface ClientEntityManager extends PrettyPrintable, RequestResponseHan
    */
   void handleMessage(EntityDescriptor entityDescriptor, byte[] message);
 
-  InvokeFuture<byte[]> createEntity(EntityID entityID, long version, byte[] config);
+  byte[] createEntity(EntityID entityID, long version, byte[] config) throws EntityException;
   
-  InvokeFuture<byte[]> destroyEntity(EntityID entityID, long version);
+  boolean destroyEntity(EntityID entityID, long version) throws EntityException;
 
-  InvokeFuture<byte[]> reconfigureEntity(EntityID entityID, long version, byte[] config);
+  byte[] reconfigureEntity(EntityID entityID, long version, byte[] config) throws EntityException;
 }

--- a/dso-l1/src/main/java/com/tc/object/ExceptionUtils.java
+++ b/dso-l1/src/main/java/com/tc/object/ExceptionUtils.java
@@ -1,6 +1,7 @@
 package com.tc.object;
 
 import com.tc.exception.EntityBusyException;
+import com.tc.exception.EntityReferencedException;
 import org.terracotta.exception.EntityAlreadyExistsException;
 import org.terracotta.exception.EntityConfigurationException;
 import org.terracotta.exception.EntityException;
@@ -35,7 +36,9 @@ public class ExceptionUtils {
     } else if(e instanceof EntityBusyException) {
       wrappedException = new EntityBusyException(e.getClassName(), e.getEntityName(), e);
     } else {
-      wrappedException = new EntityException(e.getClassName(), e.getClassName(), e.getDescription(), e) {};
+//  just return the remote exception with remote stack, don't want to hide the type of the 
+//  exception in these cases.
+      return e;
     }
     StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
     //strip last two recent elements - getStackTrace() and this method

--- a/dso-l1/src/main/java/com/tc/object/ExceptionUtils.java
+++ b/dso-l1/src/main/java/com/tc/object/ExceptionUtils.java
@@ -1,5 +1,6 @@
 package com.tc.object;
 
+import com.tc.exception.EntityBusyException;
 import org.terracotta.exception.EntityAlreadyExistsException;
 import org.terracotta.exception.EntityConfigurationException;
 import org.terracotta.exception.EntityException;
@@ -31,6 +32,8 @@ public class ExceptionUtils {
       wrappedException = new EntityAlreadyExistsException(e.getClassName(), e.getEntityName(), e);
     } else if(e instanceof EntityConfigurationException) {
       wrappedException = new EntityConfigurationException(e.getClassName(), e.getEntityName(), e);
+    } else if(e instanceof EntityBusyException) {
+      wrappedException = new EntityBusyException(e.getClassName(), e.getEntityName(), e);
     } else {
       wrappedException = new EntityException(e.getClassName(), e.getClassName(), e.getDescription(), e) {};
     }

--- a/dso-l2/src/main/java/com/tc/objectserver/api/ServerEntityRequest.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/api/ServerEntityRequest.java
@@ -20,7 +20,6 @@ package com.tc.objectserver.api;
 
 import com.tc.net.ClientID;
 import org.terracotta.entity.ClientDescriptor;
-import org.terracotta.exception.EntityException;
 
 import com.tc.net.NodeID;
 import com.tc.object.tx.TransactionID;

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ActiveToPassiveReplication.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ActiveToPassiveReplication.java
@@ -46,7 +46,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Semaphore;
 
 
 /**

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -635,7 +635,7 @@ public class ManagedEntityImpl implements ManagedEntity {
               for (NodeID passive : passives) {
                 try {
                   byte[] message = runWithHelper(()->syncCodec.encode(concurrencyKey, payload));
-                  executor.scheduleSync(ReplicationMessage.createPayloadMessage(id, version, concurrencyKey, message), passive).waitForCompleted();
+                  executor.scheduleSync(ReplicationMessage.createPayloadMessage(id, version, concurrencyKey, message, ""), passive).waitForCompleted();
                 } catch (EntityUserException eu) {
                 // TODO: do something reasoned here
                   throw new RuntimeException(eu);

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -213,7 +213,7 @@ public class ManagedEntityImpl implements ManagedEntity {
           break;
         case FETCH_ENTITY:
         case RELEASE_ENTITY:
-          interop.startReference();
+          schedule = interop.tryStartReference();
           break;
         default:
           throw new AssertionError("unexpected");
@@ -830,10 +830,8 @@ public class ManagedEntityImpl implements ManagedEntity {
           sectionComplete.waitForCompletion();
           executor.scheduleSync(ReplicationMessage.createEndEntityKeyMessage(id, version, concurrency), passive).waitForCompleted();
         }
-      }
   //  end passive sync for an entity
   // wait for future is ok, occuring on sync executor thread
-      if (!this.isDestroyed) {
         executor.scheduleSync(ReplicationMessage.createEndEntityMessage(id, version), passive).waitForCompleted();
       }
     } finally {

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntitySyncInterop.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntitySyncInterop.java
@@ -1,0 +1,99 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.objectserver.entity;
+
+import com.tc.util.Assert;
+import java.io.Serializable;
+
+/**
+ * Special control structure to make sure sync and lifecycle operations
+ * are properly controlled through the sync process
+ */
+public final class ManagedEntitySyncInterop implements Serializable {
+//  single threaded lifecycle
+  private int lifecycleOccuring;
+//  multiple sync threads possible
+  private int syncsReadyToStart;
+  private int syncsStarted;
+
+  public ManagedEntitySyncInterop() {
+  }
+
+  public synchronized void startSync() {
+    try {
+      while (lifecycleOccuring > 0) {
+        this.wait();
+      }
+      syncsReadyToStart += 1;
+    } catch (InterruptedException ie) {
+      throw new RuntimeException(ie);
+    }
+  }
+
+  public synchronized void startLifecycle() {
+    try {
+      while (syncsStarted > 0 || syncsReadyToStart > 0) {
+        this.wait();
+      }
+      lifecycleOccuring += 1;
+    } catch (InterruptedException ie) {
+      throw new RuntimeException(ie);
+    }
+  }
+  
+  public synchronized boolean tryStartLifecycle() {
+    if (syncsStarted > 0 || syncsReadyToStart > 0) {
+      return false;
+    } else {
+      lifecycleOccuring += 1;
+      return true;
+    }
+  }
+  
+  public synchronized void startReference() {
+    try {
+      while (syncsReadyToStart > 0) {
+        this.wait();
+      }
+      lifecycleOccuring += 1;
+    } catch (InterruptedException ie) {
+      throw new RuntimeException(ie);
+    }
+  } 
+  
+  public synchronized void syncStarted() {
+    Assert.assertTrue(syncsReadyToStart > 0);
+    Assert.assertTrue(lifecycleOccuring == 0);
+    syncsReadyToStart -= 1;
+    syncsStarted += 1;
+    notifyAll();
+  }
+  
+  public synchronized void syncFinished() {
+    Assert.assertTrue(syncsStarted > 0);
+    syncsStarted -= 1;
+    notifyAll();
+  }
+  
+  public synchronized void finishLifecycle() {
+    Assert.assertTrue(lifecycleOccuring > 0);
+    lifecycleOccuring -= 1;
+    notifyAll();
+  }
+}

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntitySyncInterop.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntitySyncInterop.java
@@ -76,6 +76,15 @@ public final class ManagedEntitySyncInterop implements Serializable {
       throw new RuntimeException(ie);
     }
   } 
+
+  public synchronized boolean tryStartReference() {
+    if (syncsReadyToStart > 0) {
+      return false;
+    } else {
+      lifecycleOccuring += 1;
+      return true;
+    }
+  } 
   
   public synchronized void syncStarted() {
     Assert.assertTrue(syncsReadyToStart > 0);

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
@@ -22,6 +22,8 @@ import com.tc.async.api.MultiThreadedEventContext;
 import com.tc.async.api.Sink;
 import com.tc.l2.msg.ReplicationMessage;
 import com.tc.l2.msg.SyncReplicationActivity;
+import com.tc.logging.TCLogger;
+import com.tc.logging.TCLogging;
 import com.tc.net.ClientID;
 import com.tc.net.NodeID;
 import com.tc.object.EntityDescriptor;
@@ -38,6 +40,7 @@ public class RequestProcessor {
   private PassiveReplicationBroker passives;
   private final Sink<Runnable> requestExecution;
   private boolean isActive = false;
+  private static final TCLogger PLOGGER = TCLogging.getLogger(MessagePayload.class);
 //  TODO: do some accounting for transaction de-dupping on failover
 
   public RequestProcessor(Sink<Runnable> requestExecution) {
@@ -72,6 +75,9 @@ public class RequestProcessor {
             request.getTransaction(), request.getOldestTransactionOnClient(), payload, concurrencyKey), replicateTo)
         : NoReplicationBroker.NOOP_WAITER;
     EntityRequest entityRequest =  new EntityRequest(entity, call, concurrencyKey, token);
+    if (PLOGGER.isDebugEnabled()) {
+      PLOGGER.debug("SCHEDULING:" + payload.getDebugId() + " on " + entity + ":" + concurrencyKey);
+    }
     requestExecution.addMultiThreaded(entityRequest);
     return token;
   }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/RequestProcessor.java
@@ -153,10 +153,6 @@ public class RequestProcessor {
         this.replicationWaiter.waitForReceived();
         // We can now run the invoke.
         invoke.run();
-        // Now that we are done, wait for the passive to finish.
-        this.replicationWaiter.waitForCompleted();
-        // We are now completely finished.
-        finish();
     }
 
     @Override
@@ -164,15 +160,6 @@ public class RequestProcessor {
 // anything on the management key needs a complete flush of all the queues
 // the hydrate stage does not need to be flushed as each client 
       return (key == ConcurrencyStrategy.MANAGEMENT_KEY);
-    }
-    
-    private synchronized void finish() {
-      done = true;
-      this.notifyAll();
-    }
-    
-    synchronized boolean isDone() {
-      return done;
     }
   }
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -70,6 +70,7 @@ import org.terracotta.exception.EntityException;
 
 
 public class ReplicatedTransactionHandler {
+  private static final TCLogger PLOGGER = TCLogging.getLogger(MessagePayload.class);
   private static final TCLogger LOGGER = TCLogging.getLogger(ReplicatedTransactionHandler.class);
   private final EntityManager entityManager;
   private final EntityPersistor entityPersistor;
@@ -180,6 +181,9 @@ public class ReplicatedTransactionHandler {
   }
 
   private void processMessage(ReplicationMessage rep) throws EntityException {
+    if (PLOGGER.isDebugEnabled()) {
+      PLOGGER.debug("RECEIVED:" + rep.getDebugId());
+    }
     switch (rep.getType()) {
       case ReplicationMessage.REPLICATE:
         if (state.ignore(rep)) {

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -651,7 +651,10 @@ public class ReplicatedTransactionHandler {
     }
     
     private boolean ignore(ReplicationMessage rep) {
-      assertStarted(rep);
+      if (!started) {
+ // this passive has never been sync'd to anything, ignore all messages
+        return true;
+      }
       if (finished) {
 //  done with sync, need to apply everything now
         return false;
@@ -716,25 +719,21 @@ public class ReplicatedTransactionHandler {
     }
     
     /**
-     * Note that this state machine has several special-cases but the started flag can be used to assert consistency in most
-     * of them.
+     * Note that this state machine the started flag can be used to assert consistency.
      * 
-     * The cases where it is OK to NOT be started:
-     * -SYNC_BEGIN:  The message which IS the start message isn't checked here but is obviously ok.
-     * -the replicated message is a CREATE call:  Creates can happen concurrently with sync but they are also independent of
-     *  it so it is possible for one to arrive before the sync even starts.
-     * -the replicated message applies to an entity we already synced:  This is a corollary to the CREATE exemption since it
-     *  might be another message replicated to that entity (which is unrelated to the sync).
+     * The start flag starts the valid stream for a passive.  A passive can only accept valid 
+     * messages after sync has started on the server.  Prior to that, everything is invalid
+     * and can be safely ignored.  Messages can be received prior to the start sync message
+     * because replication started as soon as the active detects a connect from a passive.
      * 
-     * @param rep The replicated message being processed (can be null if this is a sync case, but those cases must all have
-     *  already started, unless this is the start message).
+     * Sync start begins after the passive has successfully connected and requested to be sync'd
+     * 
+     * NOTE: it is possible in the multiple passive scenario, for a stream to start a new 
+     * active but in this case, the server will have already been sync'd and thus valid
      */
     private void assertStarted(ReplicationMessage rep) {
       // These should short-circuit quickly, not creating an expensive check overhead.
-      Assert.assertTrue(rep, started
-          || (SyncReplicationActivity.ActivityType.CREATE_ENTITY == rep.getReplicationType())
-          || (this.syncdEntities.contains(rep.getEntityID()))
-      );
+      Assert.assertTrue(rep, started);
     }
   }
  

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -597,6 +597,9 @@ public class ReplicatedTransactionHandler {
       assertStarted(null);
       Assert.assertNull(syncing);
       syncing = eid;
+// these keys are never sync'd only replicated so add them to the set
+      syncdKeys.add(ConcurrencyStrategy.MANAGEMENT_KEY);
+      syncdKeys.add(ConcurrencyStrategy.UNIVERSAL_KEY);
       LOGGER.debug("Starting " + eid);
     }
     

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicationSender.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicationSender.java
@@ -30,6 +30,7 @@ import com.tc.net.NodeID;
 import com.tc.net.groups.GroupException;
 import com.tc.net.groups.GroupManager;
 import com.tc.object.EntityID;
+import com.tc.objectserver.entity.MessagePayload;
 import com.tc.util.Assert;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -46,6 +47,7 @@ public class ReplicationSender extends AbstractEventHandler<ReplicationEnvelope>
   private final Map<NodeID, AtomicLong> ordering = new HashMap<>();
   private final Map<NodeID, SyncState> filtering = new HashMap<>();
   private static final TCLogger logger           = TCLogging.getLogger(ReplicationSender.class);
+  private static final TCLogger PLOGGER = TCLogging.getLogger(MessagePayload.class);
 
   public ReplicationSender(GroupManager group) {
     this.group = group;
@@ -86,6 +88,9 @@ public class ReplicationSender extends AbstractEventHandler<ReplicationEnvelope>
         msg.setReplicationID(rOrder.getAndIncrement());
         if (logger.isDebugEnabled()) {
           logger.debug("WIRE:" + msg);
+        }
+        if (PLOGGER.isDebugEnabled()) {
+          PLOGGER.debug("SENDING:" + msg.getDebugId());
         }
         group.sendTo(nodeid, msg);
         if (msg.getType() == ReplicationMessage.START) {

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntitySyncInteropTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntitySyncInteropTest.java
@@ -1,0 +1,147 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.objectserver.entity;
+
+import com.tc.util.Assert;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ */
+public class ManagedEntitySyncInteropTest {
+  
+  static ExecutorService service;
+  
+  public ManagedEntitySyncInteropTest() {
+  }
+  
+  @BeforeClass
+  public static void setUpClass() {
+     service = Executors.newCachedThreadPool();
+  }
+  
+  @AfterClass
+  public static void tearDownClass() {
+    service.shutdownNow();
+  }
+  
+  @Before
+  public void setUp() {
+  }
+  
+  @After
+  public void tearDown() {
+  }
+
+  @Test
+  public void testMultipleAccessToSync() throws Exception {
+    ManagedEntitySyncInterop instance = new ManagedEntitySyncInterop();
+// start two syncs
+    Future f1 = run(()->instance.startSync());
+    Future f2 = run(()->instance.startSync());
+    try {
+      f1.get(1, TimeUnit.SECONDS);
+      f2.get(1, TimeUnit.SECONDS);
+    } catch (TimeoutException to) {
+      Assert.fail("should not block");
+    }
+  }
+
+  @Test
+  public void testLifecyleBlocksSync() throws Exception {
+    ManagedEntitySyncInterop instance = new ManagedEntitySyncInterop();
+// start two syncs
+    Future f1 = run(()->instance.startLifecycle());
+    Future f2 = run(()->instance.startSync());
+    try {
+      f2.get(1, TimeUnit.SECONDS);
+      Assert.fail();
+    } catch (TimeoutException to) {
+    // EXPECTED
+    }
+    instance.finishLifecycle();
+    try {
+      f2.get(1, TimeUnit.SECONDS);
+    } catch (TimeoutException to) {
+      Assert.fail("should not block");
+    }
+  }
+
+  @Test
+  public void testSyncStartBlockReference() throws Exception {
+    ManagedEntitySyncInterop instance = new ManagedEntitySyncInterop();
+// start two syncs
+    Future f1 = run(()->instance.startSync());
+    Future f2 = run(()->instance.startReference());
+    try {
+      f2.get(1, TimeUnit.SECONDS);
+      Assert.fail();
+    } catch (TimeoutException to) {
+    // EXPECTED
+    }
+    instance.syncStarted();
+    try {
+      f2.get(1, TimeUnit.SECONDS);
+    } catch (TimeoutException to) {
+      Assert.fail("should not block");
+    }
+  }
+
+  @Test
+  public void testSyncBlockLifecycle() throws Exception {
+    ManagedEntitySyncInterop instance = new ManagedEntitySyncInterop();
+// start two syncs
+    Future f1 = run(()->instance.startSync());
+    Future f2 = run(()->instance.startLifecycle());
+    try {
+      f2.get(1, TimeUnit.SECONDS);
+      Assert.fail();
+    } catch (TimeoutException to) {
+    // EXPECTED
+    }
+    instance.syncStarted();
+    try {
+      f2.get(1, TimeUnit.SECONDS);
+      Assert.fail();
+    } catch (TimeoutException to) {
+    // EXPECTED
+    }
+    instance.syncFinished();
+    try {
+      f2.get(1, TimeUnit.SECONDS);
+    } catch (TimeoutException to) {
+      Assert.fail("should not block");
+    }
+  }
+  
+  private Future<?> run(Runnable r) {
+    return service.submit(r);
+  }
+  
+}

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
@@ -294,20 +294,20 @@ public class ReplicatedTransactionHandlerTest {
     send(ReplicationMessage.createStartSyncMessage());
     send(ReplicationMessage.createStartEntityMessage(eid, VERSION, config, 0));
     send(ReplicationMessage.createStartEntityKeyMessage(eid, VERSION, 1));
-    send(ReplicationMessage.createPayloadMessage(eid, VERSION, 1, config));
+    send(ReplicationMessage.createPayloadMessage(eid, VERSION, 1, config, ""));
     send(ReplicationMessage.createEndEntityKeyMessage(eid, VERSION, 1));
     send(ReplicationMessage.createStartEntityKeyMessage(eid, VERSION, 2));
-    send(ReplicationMessage.createPayloadMessage(eid, VERSION, 2, config));
+    send(ReplicationMessage.createPayloadMessage(eid, VERSION, 2, config, ""));
     send(ReplicationMessage.createEndEntityKeyMessage(eid, VERSION, 2));  
     send(ReplicationMessage.createStartEntityKeyMessage(eid, VERSION, 3));
-    send(ReplicationMessage.createPayloadMessage(eid, VERSION, 3, config));
+    send(ReplicationMessage.createPayloadMessage(eid, VERSION, 3, config, ""));
     send(ReplicationMessage.createEndEntityKeyMessage(eid, VERSION, 3));  
     send(ReplicationMessage.createStartEntityKeyMessage(eid, VERSION, 4));
 //  defer a few replicated messages with sequence as payload
     send(createMockReplicationMessage(eid, VERSION, ByteBuffer.wrap(new byte[Integer.BYTES]).putInt(1).array(), 4));
     send(createMockReplicationMessage(eid, VERSION, ByteBuffer.wrap(new byte[Integer.BYTES]).putInt(2).array(), 4));
     send(createMockReplicationMessage(eid, VERSION, ByteBuffer.wrap(new byte[Integer.BYTES]).putInt(3).array(), 4));
-    send(ReplicationMessage.createPayloadMessage(eid, 1, 4, config));
+    send(ReplicationMessage.createPayloadMessage(eid, 1, 4, config, ""));
 //  defer a few replicated messages with sequence as payload
     send(createMockReplicationMessage(eid, VERSION, ByteBuffer.wrap(new byte[Integer.BYTES]).putInt(4).array(), 4));
     send(createMockReplicationMessage(eid, VERSION, ByteBuffer.wrap(new byte[Integer.BYTES]).putInt(5).array(), 4));

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicationSenderTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicationSenderTest.java
@@ -103,7 +103,7 @@ public class ReplicationSenderTest {
       case SYNC_ENTITY_CONCURRENCY_END:
         return ReplicationMessage.createEndEntityKeyMessage(entity, 1, concurrency++);
       case SYNC_ENTITY_CONCURRENCY_PAYLOAD:
-        return ReplicationMessage.createPayloadMessage(entity, 1, concurrency, new byte[0]);
+        return ReplicationMessage.createPayloadMessage(entity, 1, concurrency, new byte[0], "");
       case SYNC_ENTITY_END:
         return ReplicationMessage.createEndEntityMessage(entity, 1);
       default:

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
@@ -83,10 +83,10 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
     SyncReplicationActivity activity = SyncReplicationActivity.createEndEntityKeyMessage(id, version, concurrency);
     return new ReplicationMessage(activity);
   }
-  public static ReplicationMessage createPayloadMessage(EntityID id, long version, int concurrency, byte[] payload) {
+  public static ReplicationMessage createPayloadMessage(EntityID id, long version, int concurrency, byte[] payload, String debugId) {
     // We can only synchronize positive-number keys.
     Assert.assertTrue(concurrency > 0);
-    SyncReplicationActivity activity = SyncReplicationActivity.createPayloadMessage(id, version, concurrency, payload);
+    SyncReplicationActivity activity = SyncReplicationActivity.createPayloadMessage(id, version, concurrency, payload, debugId);
     return new ReplicationMessage(activity);
   }
 
@@ -182,9 +182,9 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
         Assert.assertNotNull(this.activity);
         // Make sure that the message type and activity type are consistent.
         if (this.activity.action.ordinal() >= SyncReplicationActivity.ActivityType.SYNC_BEGIN.ordinal()) {
-          Assert.assertTrue(SYNC == messageType);
+          Assert.assertTrue(this.activity.action, SYNC == messageType);
         } else {
-          Assert.assertTrue(REPLICATE == messageType);
+          Assert.assertTrue(this.activity.action, REPLICATE == messageType);
         }
         break;
     }
@@ -207,6 +207,10 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
         this.activity.serializeTo(out);
         break;
     }
+  }
+  
+  public String getDebugId() {
+    return this.getType() + " " + ((this.activity != null) ? (this.activity.debugId.length() == 0 ? this.activity.action : this.activity.debugId) : "");
   }
 
   @Override

--- a/tc-messaging/src/main/java/com/tc/l2/msg/SyncReplicationActivity.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/SyncReplicationActivity.java
@@ -88,10 +88,10 @@ public class SyncReplicationActivity {
     return new SyncReplicationActivity(descriptorWithoutClient(id, version), ClientID.NULL_ID, TransactionID.NULL_ID, TransactionID.NULL_ID, ActivityType.SYNC_ENTITY_CONCURRENCY_END, null, concurrency, "");
   }
 
-  public static SyncReplicationActivity createPayloadMessage(EntityID id, long version, int concurrency, byte[] payload) {
+  public static SyncReplicationActivity createPayloadMessage(EntityID id, long version, int concurrency, byte[] payload, String debugId) {
     // We can only synchronize positive-number keys.
     Assert.assertTrue(concurrency > 0);
-    return new SyncReplicationActivity(descriptorWithoutClient(id, version), ClientID.NULL_ID, TransactionID.NULL_ID, TransactionID.NULL_ID, ActivityType.SYNC_ENTITY_CONCURRENCY_PAYLOAD, payload, concurrency, "");
+    return new SyncReplicationActivity(descriptorWithoutClient(id, version), ClientID.NULL_ID, TransactionID.NULL_ID, TransactionID.NULL_ID, ActivityType.SYNC_ENTITY_CONCURRENCY_PAYLOAD, payload, concurrency, debugId);
   }
 
   private static EntityDescriptor descriptorWithoutClient(EntityID id, long version) {
@@ -172,6 +172,10 @@ public class SyncReplicationActivity {
       out.writeInt(0);
     }
     out.writeInt(concurrency);
+    if (debugId == null) {
+      debugId = "";
+    }
+    out.writeString(debugId);
   }
 
   public static SyncReplicationActivity deserializeFrom(TCByteBufferInput in) throws IOException {
@@ -187,7 +191,8 @@ public class SyncReplicationActivity {
     byte[] payload = new byte[length];
     in.readFully(payload);
     int concurrency = in.readInt();
-    return new SyncReplicationActivity(descriptor, source, tid, oldest, action, payload, concurrency, "");
+    String debug = in.readString();
+    return new SyncReplicationActivity(descriptor, source, tid, oldest, action, payload, concurrency, debug);
   }
 
   @Override

--- a/tc-messaging/src/main/java/com/tc/object/EntityDescriptor.java
+++ b/tc-messaging/src/main/java/com/tc/object/EntityDescriptor.java
@@ -91,4 +91,9 @@ public class EntityDescriptor implements TCSerializable<EntityDescriptor> {
   public static EntityDescriptor readFrom(TCByteBufferInput serialInput) throws IOException {
     return new EntityDescriptor(EntityID.readFrom(serialInput), ClientInstanceID.readFrom(serialInput), serialInput.readLong());
   }
+
+  @Override
+  public String toString() {
+    return "EntityDescriptor{" + "entityID=" + entityID + ", clientInstanceID=" + clientInstanceID + '}';
+  }
 }


### PR DESCRIPTION
Lifecycle and sync interaction is improved by not blocking the process transaction handler

Small improvement to not wait for message completion on passives with execution was designated to be only active.

debug message logging

fix an improper assertion about start the start of a replicated message stream.