### PR TITLE
Fix replication on multiple passives when one of the passives takes over

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -414,7 +414,7 @@ public class ManagedEntityImpl implements ManagedEntity {
       try {
         read.lock();
         if (logger.isDebugEnabled()) {
-          logger.debug("Invoking " + request.getAction() + " on " + getID() + "/" + concurrencyKey);
+          logger.debug(request.getAction() + " on " + getID() + "/" + concurrencyKey + " with " + message);
         }
         switch (request.getAction()) {
           case INVOKE_ACTION:

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/MessagePayload.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/MessagePayload.java
@@ -93,4 +93,9 @@ public class MessagePayload {
   public boolean shouldReplicate() {
     return replicate;
   }
+
+  @Override
+  public String toString() {
+    return "MessagePayload{" + "debugId=" + debugId + '}';
+  }
 }

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationReplicateMessageIntent.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationReplicateMessageIntent.java
@@ -33,7 +33,17 @@ public class ReplicationReplicateMessageIntent extends ReplicationIntent {
     }
     return new ReplicationReplicateMessageIntent(dest, msg, null, droppedWithoutSend);
   }
-
+  
+  public static ReplicationReplicateMessageIntent createReplicatedMessageDebugEnvelope(NodeID dest, ReplicationMessage msg, Runnable sent, Runnable droppedWithoutSend) {
+    Assert.assertNotNull(dest);
+    Assert.assertNotNull(msg);
+    boolean isReplicatedNoop = ((ReplicationMessage.REPLICATE == msg.getType()) && (SyncReplicationActivity.ActivityType.NOOP == msg.getReplicationType()));
+    if (isReplicatedNoop) {
+      // This better be a real client (otherwise, the synthetic path should have been used).
+      Assert.assertFalse(msg.getSource().isNull());
+    }
+    return new ReplicationReplicateMessageIntent(dest, msg, sent, droppedWithoutSend);
+  }
 
   private final ReplicationMessage msg;
 


### PR DESCRIPTION
This fixes the case when one of multiple passives takes over and the remaining passives join as passive standby.  Rather than not send any messages when sync has never happened, messages always need to be sent to passives when sync has not been started or has finished.  During sync the filter is utilized.  It is up to the receiving passive to decide how to handle incoming messages before sync.  If PASSIVE_UNINITIALIZED, the passive does nothing other than ack the message.  The passive has requested sync and it should be coming soon.  If PASSIVE_STANDBY, the passive will apply the messages as both the newly promoted active and remaining passive standby's are resuming from the same place.