### PR TITLE
Try and do better weighting to prevent trivial races

### DIFF
--- a/common/src/main/java/com/tc/net/core/TCWorkerCommManager.java
+++ b/common/src/main/java/com/tc/net/core/TCWorkerCommManager.java
@@ -56,7 +56,11 @@ public class TCWorkerCommManager {
   }
 
   public CoreNIOServices getNextWorkerComm() {
-    CoreNIOServices leastWeightWorkerComm = getLeastWeightWorkerComm();
+    CoreNIOServices leastWeightWorkerComm = null;
+    
+    while (leastWeightWorkerComm == null) {
+      leastWeightWorkerComm = getLeastWeightWorkerComm();
+    }
     // We can't fail to get the least.
     Assert.assertTrue(null != leastWeightWorkerComm);
 
@@ -79,12 +83,9 @@ public class TCWorkerCommManager {
    */
   private CoreNIOServices getLeastWeightWorkerComm() {
     CoreNIOServices selectedWorkerComm = null;
-    int leastValue = Integer.MAX_VALUE;
     for (CoreNIOServices workerComm : workerCommThreads) {
-      int presentValue = workerComm.getWeight();
-      if (presentValue < leastValue) {
+      if (workerComm.compareWeights(selectedWorkerComm)) {
         selectedWorkerComm = workerComm;
-        leastValue = presentValue;
       }
     }
     return selectedWorkerComm;


### PR DESCRIPTION
This is an attempt to solve the intermittent failures in TCWorkerCommManagerTest.  The following seems to imply that the test is bogus as it is asserting on code that knows it is racy and is promising only best efforts.

https://github.com/Terracotta-OSS/terracotta-core/blob/master/common/src/main/java/com/tc/net/core/TCWorkerCommManager.java#L74-L79

This is an attempt to make thread selection and weighting more deterministic by saying that each CoreNIOServices worker can be in the process of selection by only one connection at a time.

Quite frankly, I am not totally confident in this change.  Please review and provide feedback.