### PR TITLE
Batching work

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/handler/GroupMessageBatchContext.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/GroupMessageBatchContext.java
@@ -1,0 +1,103 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.objectserver.handler;
+
+import com.tc.l2.msg.ReplicationMessage;
+import com.tc.l2.msg.SyncReplicationActivity;
+import com.tc.logging.TCLogger;
+import com.tc.logging.TCLogging;
+import com.tc.net.NodeID;
+import com.tc.net.groups.AbstractGroupMessage;
+import com.tc.net.groups.GroupException;
+import com.tc.net.groups.GroupManager;
+
+
+public class GroupMessageBatchContext {
+  private static final TCLogger LOGGER = TCLogging.getLogger(GroupMessageBatchContext.class);
+  
+  private final GroupManager<AbstractGroupMessage> groupManager;
+  private final NodeID target;
+  private boolean isWaitingForNetwork;
+  private ReplicationMessage cachedMessage;
+  private long nextReplicationID;
+  // Note that we may see this exception, asynchronously.  In that case, we will just hold it and fail in the next call.
+  private GroupException mostRecentException;
+
+
+  public GroupMessageBatchContext(GroupManager<AbstractGroupMessage> groupManager, NodeID target) {
+    this.groupManager = groupManager;
+    this.target = target;
+  }
+
+  private final Runnable handleMessageSend = new Runnable() {
+    @Override
+    public void run() {
+      handleNetworkDone();
+    }
+  };
+
+  public synchronized void batchAndSend(SyncReplicationActivity activity) throws GroupException {
+    if (null != this.mostRecentException) {
+      throw this.mostRecentException;
+    }
+    if (null == this.cachedMessage) {
+      this.cachedMessage = ReplicationMessage.createActivityContainer(activity);
+      this.cachedMessage.setReplicationID(this.nextReplicationID++);
+    } else {
+      this.cachedMessage.addActivity(activity);
+    }
+    
+    if (!isWaitingForNetwork) {
+      try {
+        synchronizedSendBatch();
+      } catch (GroupException e) {
+        // Set the exception, before throwing it, so the next call also fails.
+        this.mostRecentException = e;
+        throw e;
+      }
+    }
+  }
+
+  public synchronized void handleNetworkDone() {
+    this.isWaitingForNetwork = false;
+    if (null != this.cachedMessage) {
+      try {
+        synchronizedSendBatch();
+      } catch (GroupException e) {
+        // This happened asynchronously so we can't throw back to the caller (it thinks we already send this).
+        // Log that this happened and set our exception state so that this batch context will be assumed invalid.
+        LOGGER.warn("Asynchronous group exception in batched replication message", e);
+        this.mostRecentException = e;
+      }
+    }
+  }
+
+  private void synchronizedSendBatch() throws GroupException {
+    ReplicationMessage cachedBatch = this.cachedMessage;
+    this.cachedMessage = null;
+    this.isWaitingForNetwork = true;
+    try {
+      this.groupManager.sendToWithSentCallback(this.target, cachedBatch, this.handleMessageSend);
+    } catch (GroupException e) {
+      // We aren't going to be hearing back from this unset our waiting state.
+      this.isWaitingForNetwork = false;
+      throw e;
+    }
+  }
+}

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicationSender.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicationSender.java
@@ -23,7 +23,6 @@ import com.tc.async.api.ConfigurationContext;
 import com.tc.async.api.EventHandlerException;
 import com.tc.l2.msg.ReplicationAddPassiveIntent;
 import com.tc.l2.msg.ReplicationIntent;
-import com.tc.l2.msg.ReplicationMessage;
 import com.tc.l2.msg.ReplicationRemovePassiveIntent;
 import com.tc.l2.msg.ReplicationReplicateMessageIntent;
 import com.tc.l2.msg.SyncReplicationActivity;
@@ -53,7 +52,7 @@ public class ReplicationSender extends AbstractEventHandler<ReplicationIntent> {
   private static final TCLogger PLOGGER = TCLogging.getLogger(MessagePayload.class);
   private static final boolean debugLogging = logger.isDebugEnabled();
   private static final boolean debugMessaging = PLOGGER.isDebugEnabled();
-  private final Map<NodeID, BatchContext> batchContexts = new HashMap<>();
+  private final Map<NodeID, GroupMessageBatchContext> batchContexts = new HashMap<>();
 
   public ReplicationSender(GroupManager<AbstractGroupMessage> group) {
     this.group = group;
@@ -140,7 +139,7 @@ public class ReplicationSender extends AbstractEventHandler<ReplicationIntent> {
     Assert.assertTrue(!batchContexts.containsKey(nodeid));
     SyncState state = new SyncState();
     filtering.put(nodeid, state);
-    this.batchContexts.put(nodeid, new BatchContext(this.group, nodeid));
+    this.batchContexts.put(nodeid, new GroupMessageBatchContext(this.group, nodeid));
   }
 
   private SyncState getSyncState(NodeID nodeid, SyncReplicationActivity activity) {
@@ -327,75 +326,6 @@ public class ReplicationSender extends AbstractEventHandler<ReplicationIntent> {
           throw new AssertionError("unexpected message type");
       }
       return type;
-    }
-  }
-
-
-  private static class BatchContext {
-    private final GroupManager<AbstractGroupMessage> groupManager;
-    private final NodeID target;
-    private boolean isWaitingForNetwork;
-    private ReplicationMessage cachedMessage;
-    private long nextReplicationID;
-    // Note that we may see this exception, asynchronously.  In that case, we will just hold it and fail in the next call.
-    private GroupException mostRecentException;
-    
-    public BatchContext(GroupManager<AbstractGroupMessage> groupManager, NodeID target) {
-      this.groupManager = groupManager;
-      this.target = target;
-    }
-    private final Runnable handleMessageSend = new Runnable() {
-      @Override
-      public void run() {
-        handleNetworkDone();
-      }
-    };
-    public synchronized void batchAndSend(SyncReplicationActivity activity) throws GroupException {
-      if (null != this.mostRecentException) {
-        throw this.mostRecentException;
-      }
-      if (null == this.cachedMessage) {
-        this.cachedMessage = ReplicationMessage.createActivityContainer(activity);
-        this.cachedMessage.setReplicationID(this.nextReplicationID++);
-      } else {
-        this.cachedMessage.addActivity(activity);
-      }
-      
-      if (!isWaitingForNetwork) {
-        try {
-          synchronizedSendBatch();
-        } catch (GroupException e) {
-          // Set the exception, before throwing it, so the next call also fails.
-          this.mostRecentException = e;
-          throw e;
-        }
-      }
-    }
-
-    public synchronized void handleNetworkDone() {
-      this.isWaitingForNetwork = false;
-      if (null != this.cachedMessage) {
-        try {
-          synchronizedSendBatch();
-        } catch (GroupException e) {
-          // This happened asynchronously so we can't throw back to the caller (it thinks we already send this).
-          // Log that this happened and set our exception state so that this batch context will be assumed invalid.
-          logger.warn("Asynchronous group exception in batched replication message", e);
-          this.mostRecentException = e;
-        }
-      }
-    }
-    private void synchronizedSendBatch() throws GroupException {
-      ReplicationMessage cachedBatch = this.cachedMessage;
-      this.cachedMessage = null;
-      this.isWaitingForNetwork = true;
-      try {
-        this.groupManager.sendToWithSentCallback(this.target, cachedBatch, this.handleMessageSend);
-      } catch (GroupException e) {
-        // We aren't going to be hearing back from this unset our waiting state.
-        this.isWaitingForNetwork = false;
-        throw e;
-      }
     }
   }
 }

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
@@ -82,8 +82,15 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
     return rid;
   }
 
-  public void addActivity(SyncReplicationActivity activity) {
+  /**
+   * Adds the given activity to the current batch, returning the new size of the batch.
+   * 
+   * @param activity The activity to add to the batch.
+   * @return The number of activities now in the message batch.
+   */
+  public int addActivity(SyncReplicationActivity activity) {
     this.activities.add(activity);
+    return this.activities.size();
   }
 
   public List<SyncReplicationActivity> getActivities() {


### PR DESCRIPTION
This changes some of the implementation around message batching.

Most of the work is around the higher-level batching to enable a "force-feeding" of the network, change the maximum batching size, and whether or not we will do any batching, at all.

The high-level catching can now be disabled with tc.property active-passive.inflight=0 (active-passive.inflight=1 is the default we had before this PR, active-passive.inflight=2 is the default now).

Some small lower-level changes were also made, to remove some duplicated calls and disable an optimization which probably wasn't helping (in any case, there would be a better way to make this optimization, if needed, which is a simple adaptation from what I created).