### PR TITLE
Re #439: Sort entities by consumerID before promotion or restart

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
@@ -18,10 +18,8 @@
  */
 package com.tc.objectserver.api;
 
-import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.entity.MessageCodec;
 
-import com.tc.net.ClientID;
 import com.tc.net.NodeID;
 import com.tc.object.EntityID;
 import com.tc.objectserver.entity.MessagePayload;
@@ -96,4 +94,11 @@ public interface ManagedEntity extends StateDumpable {
    * @return The entity's local RetirementManager instance.
    */
   public RetirementManager getRetirementManager();
+
+  /**
+   * Called in cases where the entities need to be sorted, for example.
+   * 
+   * @return The unique ID associated with the receiver.
+   */
+  public long getConsumerID();
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -853,6 +853,12 @@ public class ManagedEntityImpl implements ManagedEntity {
     interop.startSync();
   }
 
+  @Override
+  public long getConsumerID() {
+    return this.consumerID;
+  }
+
+
   private void loadExisting(byte[] constructorInfo) throws ConfigurationException {
     this.constructorInfo = constructorInfo;
     // Create the appropriate kind of entity, based on our active/passive state.

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/PlatformEntity.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/PlatformEntity.java
@@ -18,7 +18,6 @@
  */
 package com.tc.objectserver.entity;
 
-import com.tc.net.ClientID;
 import com.tc.net.NodeID;
 import com.tc.object.ClientInstanceID;
 import com.tc.object.EntityDescriptor;
@@ -29,8 +28,8 @@ import com.tc.objectserver.handler.RetirementManager;
 import com.tc.util.Assert;
 import java.util.function.Consumer;
 
-import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.entity.MessageCodec;
+import org.terracotta.entity.ServiceProvider;
 import org.terracotta.entity.StateDumper;
 import org.terracotta.exception.EntityException;
 
@@ -134,5 +133,11 @@ public class PlatformEntity implements ManagedEntity {
     // The platform entity doesn't expose this since it isn't expecting message interdependencies, internally.
     Assert.fail();
     return null;
+  }
+
+  @Override
+  public long getConsumerID() {
+    // The platform uses the consumerID 0 constant.
+    return ServiceProvider.PLATFORM_CONSUMER_ID;
   }
 }


### PR DESCRIPTION
-we want to promote and restart entities in the same order they were originally instantiated
-note that the passive sync case will be handled in a later commit

Ideally, this would merge after the other PR regarding diagnostic port support.