### PR TITLE
Fix #454 - Entity Sync

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/api/ManagedEntity.java
@@ -59,19 +59,18 @@ public interface ManagedEntity extends StateDumpable {
   SimpleCompletion addRequestMessage(ServerEntityRequest request, MessagePayload data, Consumer<byte[]> completion, Consumer<EntityException> exception);
 
   /**
-   * Called when passive sync wants to communicate how to instantiate this entity.
-   * 
-   * @return The message tuple describing how to instantiate this entity (or null if it can't be synced).
-   */
-  public SyncReplicationActivity.EntityCreationTuple getCreationDataForSync();
-
-  /**
    * Called to sync an entity.  Caller initiates sync of an entity through this method.  
    * 
    * @param passive target passive
    */
   void sync(NodeID passive);
-    
+  /**
+  * Called when passive sync wants to start sync on this entity.
+  * 
+  * @return The message tuple describing how to instantiate this entity (or null if it can't be synced).
+  */
+  SyncReplicationActivity.EntityCreationTuple startSync();
+  
   void loadEntity(byte[] configuration) throws ConfigurationException;
   
   void promoteEntity() throws ConfigurationException;

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/PlatformEntity.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/PlatformEntity.java
@@ -87,14 +87,13 @@ public class PlatformEntity implements ManagedEntity {
   }
 
   @Override
-  public SyncReplicationActivity.EntityCreationTuple getCreationDataForSync() {
-    // This is a special-case, since it is part of the platform and cannot be "created" or "synced".
-    return null;
-  }
-
-  @Override
   public void sync(NodeID passive) {
   //  never sync
+  }
+  
+  @Override
+  public SyncReplicationActivity.EntityCreationTuple  startSync() {
+    return null;
   }
   
   @Override


### PR DESCRIPTION
Make sure entities are not altered by lifecycle during sync.  This is done by doing the following at the beginning sync of an entity under snapshot lock.  

Block the process transaction handler from scheduling new operations on an entity.  Then making sure any operations in the deferment queue are scheduled.  Then only creating supplying creation data only if the entity is valid and not destroyed.