### PR TITLE
Update to account for new createNew() exception

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -664,12 +664,12 @@ public class ManagedEntityImpl implements ManagedEntity {
         entityToCreate = this.passiveServerEntity;
       }
     }
-    this.isDestroyed = false;
-    eventCollector.entityWasCreated(id, this.consumerID, isInActiveState);
-    response.complete();
     // We currently don't support loading an entity from a persistent back-end and this call is in response to creating a new
     //  instance so make that call.
     entityToCreate.createNew();
+    this.isDestroyed = false;
+    eventCollector.entityWasCreated(id, this.consumerID, isInActiveState);
+    response.complete();
   }
 
   private void performSync(ResultCapture response, Set<NodeID> passives, int concurrencyKey) {

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
     <tc-shader.version>1.2</tc-shader.version>
     <skip.deploy>false</skip.deploy>
 
-    <terracotta-apis.version>1.2.0-pre9</terracotta-apis.version>
-    <terracotta-configuration.version>10.2.0-pre9</terracotta-configuration.version>
+    <terracotta-apis.version>1.2.0-pre12</terracotta-apis.version>
+    <terracotta-configuration.version>10.2.0-pre12</terracotta-configuration.version>
     <galvan.version>1.2.0-pre7</galvan.version>
   </properties>
 


### PR DESCRIPTION
-this also re-orders the monitoring events since we recently loosened the expectations that these followed any specific order, relative to entity API calls