### PR TITLE
Perf testing and discussion

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -270,7 +270,12 @@ public class ManagedEntityImpl implements ManagedEntity {
     }
     
     SchedulingRunnable next = new SchedulingRunnable(desc, request, payload, r, ckey);
-    results.setWaitFor(next);
+    
+    if (isActive()) {
+// only if this is active is waiting required.  This is set to wait for the 
+// passives to complete before presenting results back to the client
+      results.setWaitFor(next);
+    }
     
     for (SchedulingRunnable msg : runnables) {
       msg.start();

--- a/tc-messaging/src/main/java/com/tc/l2/msg/SyncReplicationActivity.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/SyncReplicationActivity.java
@@ -339,9 +339,14 @@ public class SyncReplicationActivity implements OrderedEventContext {
       } else {
         out.writeInt(this.concurrency);
       }
+      if (this.debugId != null) {
+        byte[] data = this.debugId.getBytes();
+        out.writeInt(data.length);
+        out.write(data);
+      } else {
+        out.writeInt(0);
+      }
     }
-    String debugIdToWrite = (this.debugId != null) ? this.debugId : "";
-    out.writeString(debugIdToWrite);
   }
 
   public static SyncReplicationActivity deserializeFrom(TCByteBufferInput in) throws IOException {
@@ -357,6 +362,7 @@ public class SyncReplicationActivity implements OrderedEventContext {
     byte[] payload = null;
     int concurrency = 0;
     int referenceCount = 0;
+    String debug = null;
     if (ActivityType.SYNC_BEGIN == action) {
       int arraySize = in.readInt();
       entitiesForSyncStart = new EntityCreationTuple[arraySize];
@@ -383,8 +389,13 @@ public class SyncReplicationActivity implements OrderedEventContext {
       } else {
         concurrency = in.readInt();
       }
+      int dlen = in.readInt();
+      if (dlen > 0) {
+        byte[] data = new byte[dlen];
+        in.read(data);
+        debug = new String(data);
+      }
     }
-    String debug = in.readString();
     return new SyncReplicationActivity(activityID, entitiesForSyncStart, descriptor, source, tid, oldest, action, payload, concurrency, referenceCount, debug);
   }
 


### PR DESCRIPTION
After conversation it was discovered by @jd0-sag that creating replicated messages was unreasonably expensive.  See #465.  By generating load internally on the server, two hotspots were identified.  The first was the switch case statement in RequestProcessor. createReplicationActivity as a possible culprit.  Changed to an enum map and profiling data suggests that it has helped.  The debug statement optimization is probably trivial.