### PR TITLE
Fix intermittent hang in ManagedEntitySyncInteropTest

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntitySyncInterop.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntitySyncInterop.java
@@ -19,13 +19,13 @@
 package com.tc.objectserver.entity;
 
 import com.tc.util.Assert;
-import java.io.Serializable;
+
 
 /**
  * Special control structure to make sure sync and lifecycle operations
  * are properly controlled through the sync process
  */
-public final class ManagedEntitySyncInterop implements Serializable {
+public final class ManagedEntitySyncInterop {
 //  single threaded lifecycle
   private int lifecycleOccuring;
 //  multiple sync threads possible

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntitySyncInteropTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntitySyncInteropTest.java
@@ -63,8 +63,8 @@ public class ManagedEntitySyncInteropTest {
   public void testMultipleAccessToSync() throws Exception {
     ManagedEntitySyncInterop instance = new ManagedEntitySyncInterop();
 // start two syncs
-    Future f1 = run(()->{instance.startSync();return null;});
-    Future f2 = run(()->{instance.startSync();return null;});
+    Future<Void> f1 = run(()->{instance.startSync();return null;});
+    Future<Void> f2 = run(()->{instance.startSync();return null;});
     try {
       f1.get(5, TimeUnit.SECONDS);
       f2.get(5, TimeUnit.SECONDS);
@@ -81,10 +81,10 @@ public class ManagedEntitySyncInteropTest {
     // lifecycle will block and this test is expecting the blocking in the opposite order so it will hang.
     
     // Start the lifecycle operation
-    Future f1 = run(()->{instance.startLifecycle();return null;});
+    Future<Void> f1 = run(()->{instance.startLifecycle();return null;});
     f1.get();
     // Now, start the sync (it should block).
-    Future f2 = run(()->{instance.startSync();return null;});
+    Future<Void> f2 = run(()->{instance.startSync();return null;});
     try {
       f2.get(1, TimeUnit.SECONDS);
       Assert.fail();
@@ -107,10 +107,10 @@ public class ManagedEntitySyncInteropTest {
     // sync will block and this test is expecting the blocking in the opposite order so it will hang.
     
     // Start the sync
-    Future f1 = run(()->{instance.startSync();return null;});
+    Future<Void> f1 = run(()->{instance.startSync();return null;});
     // Wait for the sync to start BEFORE we attempt the reference so we know it will block (and not the sync).
     f1.get();
-    Future f2 = run(()->{instance.startReference();return null;});
+    Future<Void> f2 = run(()->{instance.startReference();return null;});
     f1.get();
     try {
       f2.get(1, TimeUnit.SECONDS);
@@ -140,10 +140,10 @@ public class ManagedEntitySyncInteropTest {
     // sync will block and this test is expecting the blocking in the opposite order so it will hang.
     
     // Start the sync
-    Future f1 = run(()->{instance.startSync();return null;});
+    Future<Void> f1 = run(()->{instance.startSync();return null;});
     // Wait for the sync to start BEFORE we attempt the lifecycle start so we know it will block (and not the sync).
     f1.get();
-    Future f2 = run(()->{instance.startLifecycle();return null;});
+    Future<Void> f2 = run(()->{instance.startLifecycle();return null;});
     // We expect the lifecycle operation to be blocked since the sync is in-progress.
     try {
       f2.get(1, TimeUnit.SECONDS);

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntitySyncInteropTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntitySyncInteropTest.java
@@ -76,10 +76,15 @@ public class ManagedEntitySyncInteropTest {
   @Test
   public void testLifecyleBlocksSync() throws Exception {
     ManagedEntitySyncInterop instance = new ManagedEntitySyncInterop();
-// start two syncs
+    // WARNING:  run(Callable) will potentially run the given Callable instances concurrently.
+    // This means that we need to wait on the startLifecycle() finishing before the startSync() since, otherwise, the
+    // lifecycle will block and this test is expecting the blocking in the opposite order so it will hang.
+    
+    // Start the lifecycle operation
     Future f1 = run(()->{instance.startLifecycle();return null;});
-    Future f2 = run(()->{instance.startSync();return null;});
     f1.get();
+    // Now, start the sync (it should block).
+    Future f2 = run(()->{instance.startSync();return null;});
     try {
       f2.get(1, TimeUnit.SECONDS);
       Assert.fail();
@@ -97,8 +102,14 @@ public class ManagedEntitySyncInteropTest {
   @Test
   public void testSyncStartBlockReference() throws Exception {
     ManagedEntitySyncInterop instance = new ManagedEntitySyncInterop();
-// start two syncs
+    // WARNING:  run(Callable) will potentially run the given Callable instances concurrently.
+    // This means that we need to wait on the startSync() finishing before the startReference() since, otherwise, the
+    // sync will block and this test is expecting the blocking in the opposite order so it will hang.
+    
+    // Start the sync
     Future f1 = run(()->{instance.startSync();return null;});
+    // Wait for the sync to start BEFORE we attempt the reference so we know it will block (and not the sync).
+    f1.get();
     Future f2 = run(()->{instance.startReference();return null;});
     f1.get();
     try {
@@ -115,19 +126,32 @@ public class ManagedEntitySyncInteropTest {
     }
   }
 
+  /**
+   * This test demonstrates that lifecycle operations are blocked once a sync is started but will progress once it is
+   * finished.
+   * 
+   * @throws Exception An error in the test
+   */
   @Test
   public void testSyncBlockLifecycle() throws Exception {
     ManagedEntitySyncInterop instance = new ManagedEntitySyncInterop();
-// start two syncs
+    // WARNING:  run(Callable) will potentially run the given Callable instances concurrently.
+    // This means that we need to wait on the startSync() finishing before the startLifecycle() since, otherwise, the
+    // sync will block and this test is expecting the blocking in the opposite order so it will hang.
+    
+    // Start the sync
     Future f1 = run(()->{instance.startSync();return null;});
-    Future f2 = run(()->{instance.startLifecycle();return null;});
+    // Wait for the sync to start BEFORE we attempt the lifecycle start so we know it will block (and not the sync).
     f1.get();
+    Future f2 = run(()->{instance.startLifecycle();return null;});
+    // We expect the lifecycle operation to be blocked since the sync is in-progress.
     try {
       f2.get(1, TimeUnit.SECONDS);
       Assert.fail();
     } catch (TimeoutException to) {
     // EXPECTED
     }
+    // We progress with the sync, meanwhile we still expect the lifecycle to be blocked.
     instance.syncStarted();
     try {
       f2.get(1, TimeUnit.SECONDS);
@@ -135,6 +159,7 @@ public class ManagedEntitySyncInteropTest {
     } catch (TimeoutException to) {
     // EXPECTED
     }
+    // We finish the sync and observe that the lifecycle operation can now complete.
     instance.syncFinished();
     try {
       f2.get(5, TimeUnit.SECONDS);


### PR DESCRIPTION
This was blocking the release build.  I will self-merge this but assign to @myronkscott in case he has any insight, when he returns (to make sure I did this in a way which makes sense to him).