### PR TITLE
Wrap RuntimeEntityExceptions in VoltronWrapperException

### DIFF
--- a/connection-impl/src/main/java/com/terracotta/connection/entity/TerracottaEntityRef.java
+++ b/connection-impl/src/main/java/com/terracotta/connection/entity/TerracottaEntityRef.java
@@ -38,7 +38,6 @@ import com.tc.logging.TCLogging;
 import com.tc.object.ClientEntityManager;
 import com.tc.object.ClientEntityManagerImpl;
 import com.tc.object.ClientInstanceID;
-import com.tc.object.EntityDescriptor;
 import com.tc.object.EntityID;
 import com.tc.util.Assert;
 import com.tc.util.Throwables;
@@ -166,12 +165,12 @@ public class TerracottaEntityRef<T extends Entity, C> implements EntityRef<T, C>
     } catch (EntityException e) {
       // Note that we must externally only present the specific exception types we were expecting.  Thus, we need to check
       // that this is one of those supported types, asserting that there was an unexpected wire inconsistency, otherwise.
+      // NOTE: PermanentEntityException is thrown by this method.
+      e = ExceptionUtils.addLocalStackTraceToEntityException(e);
       if (e instanceof EntityNotProvidedException) {
         throw (EntityNotProvidedException)e;
       } else if (e instanceof EntityNotFoundException) {
         throw (EntityNotFoundException)e;
-      } else if (e instanceof PermanentEntityException) {
-        throw (PermanentEntityException)e;
       } else {
         // This is something unsupported so there is probably some wire-level corruption so throw it as runtime so we can
         //  examine what went wrong, at a higher level.

--- a/dso-l1/src/main/java/com/tc/object/ExceptionUtils.java
+++ b/dso-l1/src/main/java/com/tc/object/ExceptionUtils.java
@@ -1,7 +1,9 @@
 package com.tc.object;
 
 import com.tc.exception.EntityBusyException;
-import com.tc.exception.EntityReferencedException;
+import com.tc.exception.VoltronWrapperException;
+import com.tc.util.Assert;
+
 import org.terracotta.exception.EntityAlreadyExistsException;
 import org.terracotta.exception.EntityConfigurationException;
 import org.terracotta.exception.EntityException;
@@ -10,20 +12,22 @@ import org.terracotta.exception.EntityNotProvidedException;
 import org.terracotta.exception.EntityUserException;
 import org.terracotta.exception.EntityVersionMismatchException;
 import org.terracotta.exception.PermanentEntityException;
+import org.terracotta.exception.RuntimeEntityException;
 
 import java.util.Arrays;
-/**
- * @author vmad
- */
+
+
 public class ExceptionUtils {
-  public static EntityException addLocalStackTraceToEntityException(EntityException e) {
+  public static EntityException addLocalStackTraceToEntityException(EntityException e) throws RuntimeEntityException {
     EntityException wrappedException;
     if(e instanceof EntityUserException) {
       wrappedException = new EntityUserException(e.getClassName(), e.getEntityName(), e);
     } else if(e instanceof EntityNotFoundException) {
       wrappedException = new EntityNotFoundException(e.getClassName(), e.getEntityName(), e);
-    } else if(e instanceof PermanentEntityException) {
-      wrappedException = new PermanentEntityException(e.getClassName(), e.getEntityName(), e);
+    } else if(e instanceof VoltronWrapperException) {
+      throwRuntimeExceptionWithLocalStack(((VoltronWrapperException)e).getWrappedException());
+      // We won't reach this point.
+      wrappedException = null;
     } else if(e instanceof EntityNotProvidedException) {
       wrappedException = new EntityNotProvidedException(e.getClassName(), e.getEntityName(), e);
     } else if(e instanceof EntityVersionMismatchException) {
@@ -44,5 +48,14 @@ public class ExceptionUtils {
     //strip last two recent elements - getStackTrace() and this method
     wrappedException.setStackTrace(Arrays.copyOfRange(stackTrace, 2, stackTrace.length));
     return wrappedException;
+  }
+
+  private static void throwRuntimeExceptionWithLocalStack(RuntimeEntityException wrappedException) throws RuntimeEntityException {
+    if (wrappedException instanceof PermanentEntityException) {
+      throw new PermanentEntityException(wrappedException.getClassName(), wrappedException.getEntityName(), wrappedException);
+    } else {
+      // Unknown exception - this must be populated.
+      Assert.fail("Unhandled runtime exception type");
+    }
   }
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -22,6 +22,7 @@ import com.tc.exception.EntityBusyException;
 import com.tc.exception.EntityReferencedException;
 import com.tc.exception.TCServerRestartException;
 import com.tc.exception.TCShutdownServerException;
+import com.tc.exception.VoltronWrapperException;
 import com.tc.l2.msg.SyncReplicationActivity;
 import com.tc.logging.TCLogger;
 import com.tc.logging.TCLogging;
@@ -597,7 +598,7 @@ public class ManagedEntityImpl implements ManagedEntity {
       // We want to ensure that nobody somehow has a reference to this entity.
       if (!this.canDelete) {
         Assert.assertTrue(clientReferenceCount < 0);
-        response.failure(new PermanentEntityException(entityDescriptor.getEntityID().getClassName(), entityDescriptor.getEntityID().getEntityName()));
+        response.failure(new VoltronWrapperException(new PermanentEntityException(entityDescriptor.getEntityID().getClassName(), entityDescriptor.getEntityID().getEntityName())));
       } else if (clientReferenceCount == 0) {
         Assert.assertTrue(!isInActiveState || clientEntityStateManager.verifyNoReferences(entityDescriptor.getEntityID()));
         Assert.assertFalse(this.isDestroyed);

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
     <tc-shader.version>1.2</tc-shader.version>
     <skip.deploy>false</skip.deploy>
 
-    <terracotta-apis.version>1.2.0-pre14</terracotta-apis.version>
-    <terracotta-configuration.version>10.2.0-pre14</terracotta-configuration.version>
+    <terracotta-apis.version>1.2.0-pre15</terracotta-apis.version>
+    <terracotta-configuration.version>10.2.0-pre15</terracotta-configuration.version>
     <galvan.version>1.2.0-pre7</galvan.version>
   </properties>
 

--- a/tc-messaging/src/main/java/com/tc/exception/VoltronWrapperException.java
+++ b/tc-messaging/src/main/java/com/tc/exception/VoltronWrapperException.java
@@ -1,0 +1,42 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.exception;
+
+import org.terracotta.exception.EntityException;
+import org.terracotta.exception.RuntimeEntityException;
+
+
+/**
+ * An implementation of the EntityException which is designed to wrap RuntimeEntityException instances so they don't
+ * require explicitly duplicated paths through the system.
+ */
+public class VoltronWrapperException extends EntityException {
+  private static final long serialVersionUID = 1L;
+
+  private final RuntimeEntityException exception;
+
+  public VoltronWrapperException(RuntimeEntityException exception) {
+    super(exception.getClassName(), exception.getEntityName(), exception.getDescription(), exception.getCause());
+    this.exception = exception;
+  }
+
+  public RuntimeEntityException getWrappedException() {
+    return this.exception;
+  }
+}


### PR DESCRIPTION
-this allows us to plumb these through the server, and over the wire, without creating a parallel path through the code for the different type of exception
-the client-side decoding just needs to be aware of this