### PR TITLE
(DO NOT MERGE) Update to use ConnectionClosedException

### DIFF
--- a/dso-l1/src/main/java/com/tc/object/ExceptionUtils.java
+++ b/dso-l1/src/main/java/com/tc/object/ExceptionUtils.java
@@ -4,6 +4,7 @@ import com.tc.exception.EntityBusyException;
 import com.tc.exception.VoltronWrapperException;
 import com.tc.util.Assert;
 
+import org.terracotta.exception.ConnectionClosedException;
 import org.terracotta.exception.EntityAlreadyExistsException;
 import org.terracotta.exception.EntityConfigurationException;
 import org.terracotta.exception.EntityException;
@@ -53,6 +54,8 @@ public class ExceptionUtils {
   private static void throwRuntimeExceptionWithLocalStack(RuntimeEntityException wrappedException) throws RuntimeEntityException {
     if (wrappedException instanceof PermanentEntityException) {
       throw new PermanentEntityException(wrappedException.getClassName(), wrappedException.getEntityName(), wrappedException);
+    } else if (wrappedException instanceof ConnectionClosedException) {
+      throw new ConnectionClosedException(wrappedException.getDescription(), wrappedException);
     } else {
       // Unknown exception - this must be populated.
       Assert.fail("Unhandled runtime exception type");

--- a/dso-l1/src/test/java/com/tc/object/ClientEntityManagerTest.java
+++ b/dso-l1/src/test/java/com/tc/object/ClientEntityManagerTest.java
@@ -32,13 +32,13 @@ import org.terracotta.entity.EntityMessage;
 import org.terracotta.entity.EntityResponse;
 import org.terracotta.entity.InvokeFuture;
 import org.terracotta.entity.MessageCodec;
+import org.terracotta.exception.ConnectionClosedException;
 import org.terracotta.exception.EntityException;
 import org.terracotta.exception.EntityNotFoundException;
 
 import com.tc.entity.NetworkVoltronEntityMessage;
 import com.tc.entity.VoltronEntityMessage;
 import com.tc.entity.VoltronEntityMessage.Acks;
-import com.tc.exception.TCNotRunningException;
 import com.tc.net.ClientID;
 import com.tc.net.NodeID;
 import com.tc.net.protocol.tcm.ClientMessageChannel;
@@ -264,7 +264,7 @@ public class ClientEntityManagerTest extends TestCase {
     try {
       fetcher.getResult();
       fail();
-    } catch (TCNotRunningException e) {
+    } catch (ConnectionClosedException e) {
       // Expected.
     } catch (Throwable t) {
       // Unexpected.
@@ -361,7 +361,7 @@ public class ClientEntityManagerTest extends TestCase {
     EntityException resultException = null;
     TestRequestBatchMessage message = new TestRequestBatchMessage(this.manager, resultObject, resultException, true);
     when(channel.createMessage(TCMessageType.VOLTRON_ENTITY_MESSAGE)).thenReturn(message);
-    byte[] waiter = this.manager.createEntity(entityID, version, config);
+    this.manager.createEntity(entityID, version, config);
     // We are waiting for no ACKs so this should be available since the send will trigger the delivery.
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
     <tc-shader.version>1.2</tc-shader.version>
     <skip.deploy>false</skip.deploy>
 
-    <terracotta-apis.version>1.2.0-pre15</terracotta-apis.version>
-    <terracotta-configuration.version>10.2.0-pre15</terracotta-configuration.version>
+    <terracotta-apis.version>1.2.0-pre16</terracotta-apis.version>
+    <terracotta-configuration.version>10.2.0-pre16</terracotta-configuration.version>
     <galvan.version>1.2.0-pre7</galvan.version>
   </properties>
 


### PR DESCRIPTION
-this replaces the previous failure scenarios which threw undefined runtime exceptions, making them all throw ConnectionClosedExceptions

NOTE: The pom.xml must be updated with API release before merging this.