### PR TITLE
Lifecycle journaling broken 

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -528,9 +528,9 @@ public class ReplicatedTransactionHandler {
 
   private ServerEntityRequest activityToLocalRequest(SyncReplicationActivity activity) {
     ActivityType activityType = activity.getActivityType();
-    ClientID source = ClientID.NULL_ID;
-    TransactionID transactionID = TransactionID.NULL_ID;
-    TransactionID oldestTransactionID = TransactionID.NULL_ID;
+    ClientID source = activity.getSource();
+    TransactionID transactionID = activity.getTransactionID();
+    TransactionID oldestTransactionID = activity.getOldestTransactionOnClient();
     Assert.assertTrue(ActivityType.SYNC_BEGIN != activityType);
     return new BasicServerEntityRequest(decodeReplicationType(activityType), source, transactionID, oldestTransactionID);
   }

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -989,7 +989,7 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
       public void l2StateChanged(StateChangedEvent sce) {
         rcs.setCurrentState(sce.getCurrentState());
         final Set<ClientID> existingConnections = Collections.unmodifiableSet(persistor.getClientStatePersistor().loadClientIDs());
-        persistor.getEntityPersistor().setState(sce.getCurrentState(), existingConnections);
+        persistor.getEntityPersistor().removeOrphanedClientsFromJournal(existingConnections);
         if (sce.movedToActive()) {
           startActiveMode(sce.getOldState().equals(StateManager.PASSIVE_STANDBY));
           try {

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/ClientStatePersistor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/ClientStatePersistor.java
@@ -24,8 +24,9 @@ import com.tc.util.Assert;
 import com.tc.util.sequence.MutableSequence;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.terracotta.persistence.IPlatformPersistence;
 
 
@@ -35,18 +36,18 @@ public class ClientStatePersistor {
   
   
   private final IPlatformPersistence storageManager;
-  private final HashMap<ClientID, Boolean> clients;
+  private final ConcurrentHashMap<ClientID, Boolean> clients;
   private final MutableSequence clientIDSequence;
 
   @SuppressWarnings("unchecked")
   public ClientStatePersistor(IPlatformPersistence storageManager) {
     this.storageManager = storageManager;
     
-    HashMap<ClientID, Boolean> clientsMap = null;
+    ConcurrentHashMap<ClientID, Boolean> clientsMap = null;
     try {
-      clientsMap = (HashMap<ClientID, Boolean>) this.storageManager.loadDataElement(CLIENTS_MAP_FILE_NAME);
+      clientsMap = (ConcurrentHashMap<ClientID, Boolean>) this.storageManager.loadDataElement(CLIENTS_MAP_FILE_NAME);
       if (null == clientsMap) {
-        clientsMap = new HashMap<>();
+        clientsMap = new ConcurrentHashMap<>();
       }
     } catch (IOException e) {
       // We don't expect this during startup so just throw it as runtime.

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/EntityPersistor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/EntityPersistor.java
@@ -318,12 +318,7 @@ public class EntityPersistor {
     storeToDisk(ENTITIES_ALIVE_FILE_NAME, this.entities);
   }
   
-<<<<<<< Updated upstream
-  public synchronized void setState(State state, Set<ClientID> connectedClients) {
-    Set<ClientID> clients = new HashSet<>(this.entityLifeJournal.keySet());
-=======
   public synchronized void removeOrphanedClientsFromJournal(Set<ClientID> connectedClients) {
->>>>>>> Stashed changes
     this.entityLifeJournal.entrySet().removeIf(e->!connectedClients.contains(e.getKey()));
     storeToDisk(JOURNAL_CONTAINER_FILE_NAME, this.entityLifeJournal);
   }

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/EntityPersistor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/EntityPersistor.java
@@ -318,15 +318,13 @@ public class EntityPersistor {
     storeToDisk(ENTITIES_ALIVE_FILE_NAME, this.entities);
   }
   
+<<<<<<< Updated upstream
   public synchronized void setState(State state, Set<ClientID> connectedClients) {
-    Set<ClientID> clients = new HashSet<>();
-    for (ClientID c : connectedClients) {
-      clients.add(c);
-    }
-    clients.removeAll(this.entityLifeJournal.keySet());
-    for (ClientID client : clients) {
-      this.entityLifeJournal.remove(client);
-    }
+    Set<ClientID> clients = new HashSet<>(this.entityLifeJournal.keySet());
+=======
+  public synchronized void removeOrphanedClientsFromJournal(Set<ClientID> connectedClients) {
+>>>>>>> Stashed changes
+    this.entityLifeJournal.entrySet().removeIf(e->!connectedClients.contains(e.getKey()));
     storeToDisk(JOURNAL_CONTAINER_FILE_NAME, this.entityLifeJournal);
   }
   

--- a/dso-l2/src/test/java/com/tc/objectserver/persistence/EntityPersistorTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/persistence/EntityPersistorTest.java
@@ -21,6 +21,7 @@ package com.tc.objectserver.persistence;
 import com.tc.net.ClientID;
 import com.tc.object.EntityID;
 import com.tc.test.TCTestCase;
+import java.util.Collections;
 
 import org.junit.Assert;
 import org.terracotta.exception.EntityException;
@@ -220,5 +221,11 @@ public class EntityPersistorTest extends TCTestCase {
     } catch (EntityException e) {
       // Expected.
     }
+  }
+  
+  public void testOrphanedClientGC() throws Exception {
+    this.entityPersistor.entityCreated(client, 1L, 0L, new EntityID("test", "test"), 1L, 1L, true, new byte[0]);
+    this.entityPersistor.removeOrphanedClientsFromJournal(Collections.emptySet());
+    Assert.assertFalse(this.entityPersistor.wasEntityCreatedInJournal(client, 1L));
   }
 }


### PR DESCRIPTION
On passives, since client source information was not propagated, lifecycle operations are not journaled.  As a result, resent lifecycle operations can give the wrong answer.

TODO: add testing.