### PR TITLE
Fix a possible race condition causing an assert in LocalMonitoringPro…

### DIFF
--- a/dso-l2/src/main/java/com/tc/services/LocalMonitoringProducer.java
+++ b/dso-l2/src/main/java/com/tc/services/LocalMonitoringProducer.java
@@ -224,6 +224,16 @@ public class LocalMonitoringProducer implements ImplementationProvidedServicePro
     }
   }
 
+  /**
+   * @return True if the receiver is in a mode to receive events from passives, as the active.  False is returned if
+   * the receiver still believes it is running in a passive mode.
+   */
+  public synchronized boolean isReadyToReceiveRemoteEvents() {
+    // The presence of cachedTreeRoot implies that we are still caching, as a passive, so null means we are active.
+    return (null == this.cachedTreeRoot);
+  }
+
+
   private synchronized boolean addNodeFromShim(long consumerID, IStripeMonitoring underlyingCollector, String[] parents, String name, Serializable value) {
     boolean didStore = false;
     // First off, see if we have a cache - this determines if we are in active or passive mode.


### PR DESCRIPTION
…ducer

-this is an unusual case where it is possible that a new server could join a stripe and send its initial monitoring data between the time the active decides to become active and when it requests that the passives send that data
-it is a hard-to-hit timing hole but is possible if the active is under heavy load