### PR TITLE
Issue 510: Add explit retirement deferment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <tc-shader.version>1.2</tc-shader.version>
     <skip.deploy>false</skip.deploy>
 
-    <terracotta-apis.version>1.3-SNAPSHOT</terracotta-apis.version>
+    <terracotta-apis.version>1.3.0-pre2</terracotta-apis.version>
     <terracotta-configuration.version>10.3.0-pre2</terracotta-configuration.version>
     <galvan.version>1.3.0-pre1</galvan.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
     <tc-shader.version>1.2</tc-shader.version>
     <skip.deploy>false</skip.deploy>
 
-    <terracotta-apis.version>1.3.0-pre1</terracotta-apis.version>
-    <terracotta-configuration.version>10.3.0-pre1</terracotta-configuration.version>
+    <terracotta-apis.version>1.3-SNAPSHOT</terracotta-apis.version>
+    <terracotta-configuration.version>10.3.0-pre2</terracotta-configuration.version>
     <galvan.version>1.3.0-pre1</galvan.version>
   </properties>
 


### PR DESCRIPTION
Adds support for explicit deferment. By decomposing the prior
"message & defer" call into "defer now, message later", we keep the
same well undesrtood implementation with the difference being,
the second message is not sent until the retirement handle is released,
via the release() method.

Note that this means that explicitly deferred messages *must* be
eventually released, or messages will simply hang around.