### PR TITLE
Issue #350 Add more efficient shortest queue selection methods.

### DIFF
--- a/common/src/main/java/com/tc/async/impl/AbstractStageQueueImpl.java
+++ b/common/src/main/java/com/tc/async/impl/AbstractStageQueueImpl.java
@@ -1,0 +1,190 @@
+package com.tc.async.impl;
+
+import com.tc.async.api.EventHandler;
+import com.tc.async.api.EventHandlerException;
+import com.tc.async.api.Source;
+import com.tc.async.api.SpecializedEventContext;
+import com.tc.async.api.StageQueueStats;
+import com.tc.exception.TCRuntimeException;
+import com.tc.logging.TCLogger;
+import com.tc.util.UpdatableFixedHeap;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author cschanck
+ **/
+public class AbstractStageQueueImpl<EC> {
+
+
+  public AbstractStageQueueImpl() {
+  }
+
+  interface SourceQueue<W> extends Source<W> {
+    AbstractStageQueueImpl.StageQueueStatsCollector getStatsCollector();
+
+    void setStatsCollector(AbstractStageQueueImpl.StageQueueStatsCollector collector);
+
+    int clear();
+
+    @Override
+    boolean isEmpty();
+
+    @Override
+    W poll(long timeout) throws InterruptedException;
+
+    void put(W context) throws InterruptedException;
+
+    int size();
+
+    @Override
+    String getSourceName();
+  }
+
+  static abstract class StageQueueStatsCollector implements StageQueueStats {
+
+    public void logDetails(TCLogger statsLogger) {
+      statsLogger.info(getDetails());
+    }
+
+    public abstract void contextAdded();
+
+    public abstract void reset();
+
+    public abstract void contextRemoved();
+
+    protected String makeWidth(String name, int width) {
+      final int len = name.length();
+      if (len == width) {
+        return name;
+      }
+      if (len > width) {
+        return name.substring(0, width);
+      }
+
+      StringBuffer buf = new StringBuffer(name);
+      for (int i = len; i < width; i++) {
+        buf.append(' ');
+      }
+      return buf.toString();
+    }
+  }
+
+  static class NullStageQueueStatsCollector extends StageQueueStatsCollector {
+
+    private final String name;
+    private final String trimmedName;
+
+    public NullStageQueueStatsCollector(String stage) {
+      this.trimmedName = stage.trim();
+      this.name = makeWidth(stage, 40);
+    }
+
+    @Override
+    public String getDetails() {
+      return this.name + " : Not Monitored";
+    }
+
+    @Override
+    public void contextAdded() {
+      // NO-OP
+    }
+
+    @Override
+    public void contextRemoved() {
+      // NO-OP
+    }
+
+    @Override
+    public void reset() {
+      // NO-OP
+    }
+
+    @Override
+    public String getName() {
+      return this.trimmedName;
+    }
+
+    @Override
+    public int getDepth() {
+      return -1;
+    }
+  }
+
+  static class StageQueueStatsCollectorImpl extends StageQueueStatsCollector {
+
+    private final AtomicInteger count = new AtomicInteger(0);
+    private final String name;
+    private final String trimmedName;
+
+    public StageQueueStatsCollectorImpl(String stage) {
+      this.trimmedName = stage.trim();
+      this.name = makeWidth(stage, 40);
+    }
+
+    @Override
+    public String getDetails() {
+      return this.name + " : " + this.count;
+    }
+
+    @Override
+    public void contextAdded() {
+      this.count.incrementAndGet();
+    }
+
+    @Override
+    public void contextRemoved() {
+      this.count.decrementAndGet();
+    }
+
+    @Override
+    public void reset() {
+      this.count.set(0);
+    }
+
+    @Override
+    public String getName() {
+      return this.trimmedName;
+    }
+
+    @Override
+    public int getDepth() {
+      return this.count.get();
+    }
+  }
+
+  static class DirectExecuteContext<EC> implements ContextWrapper<EC> {
+    private final SpecializedEventContext context;
+
+    public DirectExecuteContext(SpecializedEventContext context) {
+      this.context = context;
+    }
+
+    @Override
+    public void runWithHandler(EventHandler<EC> handler) throws EventHandlerException {
+      this.context.execute();
+    }
+  }
+
+  static class HandledContext<C> implements ContextWrapper<C> {
+    private final C context;
+
+    public HandledContext(C context) {
+      this.context = context;
+    }
+
+    @Override
+    public void runWithHandler(EventHandler<C> handler) throws EventHandlerException {
+      handler.handleEvent(this.context);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (context.getClass().isInstance(obj)) {
+        return context.equals(obj);
+      }
+      return super.equals(obj);
+    }
+  }
+}

--- a/common/src/main/java/com/tc/async/impl/SingletonStageQueueImpl.java
+++ b/common/src/main/java/com/tc/async/impl/SingletonStageQueueImpl.java
@@ -1,0 +1,302 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.async.impl;
+
+import com.tc.async.api.EventHandler;
+import com.tc.async.api.EventHandlerException;
+import com.tc.async.api.MultiThreadedEventContext;
+import com.tc.async.api.Sink;
+import com.tc.async.api.Source;
+import com.tc.async.api.SpecializedEventContext;
+import com.tc.async.impl.AbstractStageQueueImpl.HandledContext;
+import com.tc.async.impl.AbstractStageQueueImpl.NullStageQueueStatsCollector;
+import com.tc.exception.TCRuntimeException;
+import com.tc.logging.TCLogger;
+import com.tc.logging.TCLoggerProvider;
+import com.tc.stats.Stats;
+import com.tc.util.Assert;
+import com.tc.util.concurrent.QueueFactory;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static com.tc.async.impl.AbstractStageQueueImpl.DirectExecuteContext;
+import static com.tc.async.impl.AbstractStageQueueImpl.SourceQueue;
+import static com.tc.async.impl.AbstractStageQueueImpl.StageQueueStatsCollector;
+import static com.tc.async.impl.AbstractStageQueueImpl.StageQueueStatsCollectorImpl;
+
+/**
+ * This StageQueueImpl represents the sink and gives a handle to the source. We are internally just using a queue
+ * since our queues are locally processed. This class can be replaced with a distributed queue to enable processing
+ * across process boundaries.
+ */
+public class SingletonStageQueueImpl<EC> implements StageQueue<EC> {
+
+  private final String stageName;
+  private final TCLogger logger;
+  private final SourceQueueImpl<ContextWrapper<EC>> sourceQueue;
+  private volatile boolean closed = false;
+
+  /**
+   * The Constructor.
+   *
+   * @param queueFactory : Factory used to create the queues
+   * @param loggerProvider : logger
+   * @param stageName : The stage name
+   * @param queueSize : Max queue Size allowed
+   */
+  @SuppressWarnings("unchecked")
+  SingletonStageQueueImpl(QueueFactory<ContextWrapper<EC>> queueFactory,
+                          TCLoggerProvider loggerProvider,
+                          String stageName,
+                          int queueSize) {
+
+    this.logger = loggerProvider.getLogger(Sink.class.getName() + ": " + stageName);
+    this.stageName = stageName;
+    this.sourceQueue = createWorkerQueue(queueFactory, queueSize, stageName);
+  }
+
+  private SourceQueueImpl<ContextWrapper<EC>> createWorkerQueue(QueueFactory<ContextWrapper<EC>> queueFactory,
+                                                                int queueSize,
+                                                                String stage) {
+    StageQueueStatsCollector statsCollector = new NullStageQueueStatsCollector(stage);
+    BlockingQueue<ContextWrapper<EC>> q = null;
+
+    Assert.eval(queueSize > 0);
+
+    q = queueFactory.createInstance(queueSize);
+    return new SourceQueueImpl<ContextWrapper<EC>>(q, statsCollector);
+  }
+
+  @Override
+  public Source<ContextWrapper<EC>> getSource(int index) {
+    return (index != 0) ? null : this.sourceQueue;
+  }
+
+  @Override
+  public void setClosed(boolean closed) {
+    this.closed = closed;
+  }
+
+  @Override
+  public void addSingleThreaded(EC context) {
+    Assert.assertNotNull(context);
+    Assert.assertFalse(context instanceof MultiThreadedEventContext);
+    if (closed) {
+      throw new IllegalStateException("closed");
+    }
+    if (this.logger.isDebugEnabled()) {
+      this.logger.debug("Added:" + context + " to:" + this.stageName);
+    }
+
+    boolean interrupted = Thread.interrupted();
+    ContextWrapper<EC> wrapper = new HandledContext<EC>(context);
+    deliverToQueue("Single", wrapper);
+  }
+
+  @Override
+  public void addMultiThreaded(EC context) {
+    Assert.assertNotNull(context);
+    Assert.assertTrue(context instanceof MultiThreadedEventContext);
+    if (closed) {
+      throw new IllegalStateException("closed");
+    }
+    if (this.logger.isDebugEnabled()) {
+      this.logger.debug("Added:" + context + " to:" + this.stageName);
+    }
+
+    // NOTE:  We don't currently consult the predicate for multi-threaded events (the only implementation always returns true, in any case).
+    MultiThreadedEventContext cxt = (MultiThreadedEventContext) context;
+    ContextWrapper<EC> wrapper = (cxt.flush()) ? new FlushingHandledContext(context) : new HandledContext<EC>(context);
+    deliverToQueue("Multi", wrapper);
+  }
+
+  @Override
+  public void addSpecialized(SpecializedEventContext specialized) {
+    if (closed) {
+      throw new IllegalStateException("closed");
+    }
+    ContextWrapper<EC> wrapper = new DirectExecuteContext<EC>(specialized);
+    deliverToQueue("Specialized", wrapper);
+  }
+
+  private void deliverToQueue(String type, ContextWrapper<EC> wrapper) {
+    boolean interrupted = Thread.interrupted();
+    try {
+      for (; ; ) {
+        try {
+          this.sourceQueue.put(wrapper);
+          break;
+        } catch (InterruptedException e) {
+          this.logger.debug("StageQueue Add: [" + type + "] " + e);
+          interrupted = true;
+        }
+      }
+    } finally {
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  // Used for testing
+  @Override
+  public int size() {
+    return sourceQueue.size();
+  }
+
+  @Override
+  public String toString() {
+    return "StageQueue(" + this.stageName + ")";
+  }
+
+  @Override
+  public void clear() {
+    int clearCount = sourceQueue.clear();
+    this.logger.info("Cleared " + clearCount);
+  }
+
+  /*********************************************************************************************************************
+   * Monitorable Interface
+   * @param enable
+   */
+
+  @Override
+  public void enableStatsCollection(boolean enable) {
+    StageQueueStatsCollector collector = null;
+
+    String name = this.stageName + "[" + sourceQueue.getSourceName() + "]";
+    if (collector == null || !collector.getName().equals(name)) {
+      collector = (enable) ? new StageQueueStatsCollectorImpl(name) : new NullStageQueueStatsCollector(name);
+    }
+    sourceQueue.setStatsCollector(collector);
+  }
+
+  @Override
+  public Stats getStats(long frequency) {
+    return this.sourceQueue.getStatsCollector();
+  }
+
+  @Override
+  public Stats getStatsAndReset(long frequency) {
+    return getStats(frequency);
+  }
+
+  @Override
+  public boolean isStatsCollectionEnabled() {
+    // Since all source queues have the same collector, the first reference is used.
+    return this.sourceQueue.getStatsCollector() instanceof StageQueueStatsCollectorImpl;
+  }
+
+  @Override
+  public void resetStats() {
+    // Since all source queues have the same collector, the first reference is used.
+    this.sourceQueue.getStatsCollector().reset();
+  }
+
+  private final class SourceQueueImpl<W> implements SourceQueue<W> {
+
+    private final BlockingQueue<W> queue;
+    private volatile StageQueueStatsCollector statsCollector;
+
+    public SourceQueueImpl(BlockingQueue<W> queue, StageQueueStatsCollector statsCollector) {
+      this.queue = queue;
+      this.statsCollector = statsCollector;
+    }
+
+    @Override
+    public String toString() {
+      return "SourceQueueImpl{Singleton size=" + queue.size() + '}';
+    }
+
+    @Override
+    public StageQueueStatsCollector getStatsCollector() {
+      return this.statsCollector;
+    }
+
+    @Override
+    public void setStatsCollector(StageQueueStatsCollector collector) {
+      this.statsCollector = collector;
+    }
+
+    // XXX: poor man's clear.
+    @Override
+    public int clear() {
+      int cleared = 0;
+      try {
+        while (poll(0) != null) {
+          cleared++;
+        }
+        return cleared;
+      } catch (InterruptedException e) {
+        throw new TCRuntimeException(e);
+      }
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return this.queue.isEmpty();
+    }
+
+    @Override
+    public W poll(long timeout) throws InterruptedException {
+      W rv = this.queue.poll(timeout, TimeUnit.MILLISECONDS);
+      return rv;
+    }
+
+    @Override
+    public void put(W context) throws InterruptedException {
+      this.queue.put(context);
+      this.statsCollector.contextAdded();
+    }
+
+    @Override
+    public int size() {
+      return this.queue.size();
+    }
+
+    @Override
+    public String getSourceName() {
+      return "Singleton";
+    }
+
+  }
+
+  private class FlushingHandledContext<T extends EC> implements ContextWrapper<EC> {
+    private final EC context;
+    private int executionCount = 0;
+
+    public FlushingHandledContext(EC context) {
+      this.context = context;
+    }
+
+    @Override
+    public void runWithHandler(EventHandler<EC> handler) throws EventHandlerException {
+      handler.handleEvent(this.context);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (context.getClass().isInstance(obj)) {
+        return context.equals(obj);
+      }
+      return super.equals(obj);
+    }
+  }
+}

--- a/common/src/main/java/com/tc/async/impl/StageImpl.java
+++ b/common/src/main/java/com/tc/async/impl/StageImpl.java
@@ -41,7 +41,7 @@ public class StageImpl<EC> implements Stage<EC> {
                                                 // stage
   private final String         name;
   private final EventHandler<EC> handler;
-  private final StageQueueImpl<EC> stageQueue;
+  private final StageQueue<EC> stageQueue;
   private final WorkerThread<EC>[] threads;
   private final ThreadGroup    group;
   private final TCLogger       logger;
@@ -69,7 +69,7 @@ public class StageImpl<EC> implements Stage<EC> {
     this.name = name;
     this.handler = handler;
     this.threads = new WorkerThread[queueCount];
-    this.stageQueue = new StageQueueImpl<EC>(queueCount, queueFactory, loggerProvider, name, queueSize);
+    this.stageQueue = StageQueue.FACTORY.factory(queueCount, queueFactory, loggerProvider, name, queueSize);
     this.group = group;
     this.sleepMs = TCPropertiesImpl.getProperties().getInt("seda." + name + ".sleepMs", 0);
     if (this.sleepMs > 0) {

--- a/common/src/main/java/com/tc/async/impl/StageQueue.java
+++ b/common/src/main/java/com/tc/async/impl/StageQueue.java
@@ -1,0 +1,83 @@
+package com.tc.async.impl;
+
+import com.tc.async.api.Sink;
+import com.tc.async.api.Source;
+import com.tc.async.api.SpecializedEventContext;
+import com.tc.logging.TCLoggerProvider;
+import com.tc.stats.Stats;
+import com.tc.util.concurrent.QueueFactory;
+
+/**
+ * Created by cschanck on 5/23/2017.
+ */
+public interface StageQueue<EC> extends Sink<EC> {
+
+  StageQueueFactory FACTORY = new StageQueueFactory();
+
+  Source<ContextWrapper<EC>> getSource(int index);
+
+  @Override
+  void setClosed(boolean closed);
+
+  @Override
+  void addSingleThreaded(EC context);
+
+  @Override
+  void addMultiThreaded(EC context);
+
+  @Override
+  void addSpecialized(SpecializedEventContext specialized);
+
+  // Used for testing
+  @Override
+  int size();
+
+  @Override
+  String toString();
+
+  @Override
+  void clear();
+
+  /*********************************************************************************************************************
+   * Monitorable Interface
+   * @param enable
+   */
+
+  @Override
+  void enableStatsCollection(boolean enable);
+
+  @Override
+  Stats getStats(long frequency);
+
+  @Override
+  Stats getStatsAndReset(long frequency);
+
+  @Override
+  boolean isStatsCollectionEnabled();
+
+  @Override
+  void resetStats();
+
+  class StageQueueFactory {
+    /**
+     * The StageQueue factory.
+     *
+     * @param queueCount : Number of queues working on this stage
+     * @param queueFactory : Factory used to create the queues
+     * @param loggerProvider : logger
+     * @param stageName : The stage name
+     * @param queueSize : Max queue Size allowed
+     */
+    public static <C> StageQueue<C> factory(int queueCount,
+                                            QueueFactory<ContextWrapper<C>> queueFactory,
+                                            TCLoggerProvider loggerProvider,
+                                            String stageName,
+                                            int queueSize) {
+      if (queueCount == 1) {
+        return new SingletonStageQueueImpl<C>(queueFactory, loggerProvider, stageName, queueSize);
+      } else {
+        return new MultiStageQueueImpl<C>(queueCount, queueFactory, loggerProvider, stageName, queueSize);
+      }
+    }
+  }
+}

--- a/common/src/main/java/com/tc/util/UpdatableFixedHeap.java
+++ b/common/src/main/java/com/tc/util/UpdatableFixedHeap.java
@@ -1,0 +1,366 @@
+package com.tc.util;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * This is an implementation of a minheap data structure, which is prepropulated
+ * at construction with the objects it holds. For each of these objects, a
+ * wrapper object is created (and should after construction, be associated with
+ * the payload object). After construction, the wrapper object may be used to inform
+ * the heap that the underlying object has changed it's heap ordering value, in
+ * either a toward-the-front or toward-the-end manner.
+ *
+ * The delta is then procesed ina thread safe manner, to rebalance the heap.
+ *
+ * In this way, the payload object with the smallest heap ordering value is available
+ * by calling the top() method.
+ *
+ * @author cschanck
+ **/
+public class UpdatableFixedHeap<E extends UpdatableFixedHeap.Ordered> {
+
+  private final AtomicIntegerArray locks;
+  private final int arrayLength;
+  private final boolean rigid;
+  private AtomicReferenceArray<UpdatableWrapper<E>> arr;
+  private volatile int size = 0;
+  private ReentrantLock lock = new ReentrantLock(true);
+
+  public UpdatableFixedHeap(boolean rigid, E[] elements) {
+    this.rigid = rigid;
+    arr = new AtomicReferenceArray<UpdatableWrapper<E>>(elements.length + 1);
+    this.locks = new AtomicIntegerArray(arr.length());
+    this.arrayLength = arr.length();
+    for (E e : elements) {
+      add(e);
+    }
+    reheap();
+  }
+
+  private boolean orderLock(int index1, int index2) {
+    if (rigid) {
+      return orderLockRigid(index1, index2);
+    }
+    return orderLockTry(index1, index2);
+  }
+
+  private boolean orderLock(int index1, int index2, int index3) {
+    if (rigid) {
+      return orderLockRigid(index1, index2, index3);
+    }
+    return orderLockTry(index1, index2, index3);
+  }
+
+  private boolean orderLockTry(int index1, int index2) {
+    if (index1 < arrayLength) {
+      if (!locks.compareAndSet(index1, 0, 1)) {
+        return false;
+      }
+    }
+    if (index2 < arrayLength) {
+      if (!locks.compareAndSet(index2, 0, 1)) {
+        if (index1 < arrayLength) {
+          locks.compareAndSet(index1, 1, 0);
+        }
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean orderLockRigid(int index1, int index2) {
+    if (index1 < arrayLength) {
+      while (!locks.compareAndSet(index1, 0, 1)) {
+        ;
+      }
+    }
+    if (index2 < arrayLength) {
+      while (!locks.compareAndSet(index2, 0, 1)) {
+        ;
+      }
+    }
+    return true;
+  }
+
+  private boolean orderLockTry(int index1, int index2, int index3) {
+    if (index1 < arrayLength) {
+      if (!locks.compareAndSet(index1, 0, 1)) {
+        return false;
+      }
+    }
+    if (index2 < arrayLength) {
+      if (!locks.compareAndSet(index2, 0, 1)) {
+        if (index1 < arrayLength) {
+          locks.compareAndSet(index1, 1, 0);
+        }
+        return false;
+      }
+    }
+    if (index3 < arrayLength) {
+      if (!locks.compareAndSet(index3, 0, 1)) {
+        if (index1 < arrayLength) {
+          locks.compareAndSet(index1, 1, 0);
+        }
+        if (index2 < arrayLength) {
+          locks.compareAndSet(index2, 1, 0);
+        }
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean orderLockRigid(int index1, int index2, int index3) {
+    if (index1 < arrayLength) {
+      while (!locks.compareAndSet(index1, 0, 1)) {
+        ;
+      }
+    }
+    if (index2 < arrayLength) {
+      while (!locks.compareAndSet(index2, 0, 1)) {
+        ;
+      }
+    }
+    if (index3 < arrayLength) {
+      while (!locks.compareAndSet(index3, 0, 1)) {
+        ;
+      }
+    }
+    return true;
+  }
+
+  private void orderUnlock(int index1, int index2) {
+    if (index1 < arrayLength) {
+      locks.compareAndSet(index1, 1, 0);
+    }
+    if (index2 < arrayLength) {
+      locks.compareAndSet(index2, 1, 0);
+    }
+  }
+
+  private void orderUnlock(int index1, int index2, int index3) {
+    if (index1 < arrayLength) {
+      locks.compareAndSet(index1, 1, 0);
+    }
+    if (index2 < arrayLength) {
+      locks.compareAndSet(index2, 1, 0);
+    }
+    if (index3 < arrayLength) {
+      locks.compareAndSet(index3, 1, 0);
+    }
+  }
+
+  public int getSize() {
+    return size;
+  }
+
+  private UpdatableWrapper<E> add(E e) {
+    UpdatableWrapper<E> wrapper = new UpdatableWrapper<E>(e, ++size);
+    arr.set(size, wrapper);
+    siftUp(size);
+    return wrapper;
+  }
+
+  private void reheap() {
+    for (int i = size; i > 0; i--) {
+      siftUp(i);
+    }
+  }
+
+  public void possiblyCloserToFront(UpdatableWrapper<E> w) {
+    siftUp(w.index);
+  }
+
+  public void possiblyCloserToEnd(UpdatableWrapper<E> w) {
+    siftDown(w.index);
+  }
+
+  private boolean siftDown(int index) {
+    int smallest = index;
+    boolean workDone = false;
+    while (true) {
+      int next = siftDownOne(index);
+      if (next > 0) {
+        index = next;
+        workDone = true;
+      } else {
+        break;
+      }
+    }
+    return workDone;
+  }
+
+  private int siftDownOne(int index) {
+    int ret = -1;
+    boolean workDone = false;
+
+    int smallest = index;
+    int left = index * 2;
+    int right = index * 2 + 1;
+
+    if (left <= size) {
+      if (arr.get(left).getHeapOrderingAmount() < arr.get(smallest).getHeapOrderingAmount()) {
+        smallest = left;
+      } else if (right <= size) {
+        if (arr.get(right).getHeapOrderingAmount() < arr.get(smallest).getHeapOrderingAmount()) {
+          smallest = right;
+        }
+      }
+    } else if (right <= size) {
+      if (arr.get(right).getHeapOrderingAmount() < arr.get(smallest).getHeapOrderingAmount()) {
+        smallest = right;
+      }
+    }
+    if (smallest != index) {
+      int lock1 = index;
+      int lock2 = smallest;
+      if (orderLock(lock1, lock2)) {
+        try {
+          if (arr.get(index).getHeapOrderingAmount() > arr.get(smallest).getHeapOrderingAmount()) {
+            swap(index, smallest);
+            ret = smallest;
+          }
+        } finally {
+          orderUnlock(lock1, lock2);
+        }
+      }
+    }
+    return ret;
+  }
+
+  private void siftUp(int index) {
+    int parent = index / 2;
+    while (parent > 0) {
+      if (siftUpOne(parent, index)) {
+        index = parent;
+        parent = index / 2;
+      } else {
+        break;
+      }
+    }
+  }
+
+  private boolean siftUpOne(int parent, int index) {
+    if (parent > 0) {
+      int lock1 = parent;
+      int lock2 = index;
+      if (orderLock(lock1, lock2)) {
+        try {
+          if (arr.get(parent).getHeapOrderingAmount() > arr.get(index).getHeapOrderingAmount()) {
+            swap(parent, index);
+            return true;
+          }
+        } finally {
+          orderUnlock(lock1, lock2);
+        }
+      }
+    }
+    return false;
+  }
+
+  private void swap(int parent, int index) {
+    UpdatableWrapper swap = arr.get(parent);
+    arr.set(parent, arr.get(index));
+    arr.set(index, swap);
+    arr.get(parent).index(parent);
+    arr.get(index).index(index);
+  }
+
+  public String toString() {
+    StringWriter sw = new StringWriter();
+    PrintWriter pw = new PrintWriter(sw);
+    _print(1, "", pw);
+    pw.flush();
+    return sw.toString();
+  }
+
+  void verify() {
+    _verify(1);
+  }
+
+  private void _verify(int i) {
+    if (i > size) {
+      return;
+    }
+    if (arr.get(i).index != i) {
+      throw new AssertionError("At index: " + i);
+    }
+    int n1 = 2 * i;
+    if (n1 <= size) {
+      if (arr.get(i).getHeapOrderingAmount() > arr.get(n1).getHeapOrderingAmount()) {
+        throw new AssertionError("At index: " + i);
+      }
+      _verify(n1);
+    }
+    int n2 = n1 + 1;
+    if (n2 <= size) {
+      if (arr.get(i).getHeapOrderingAmount() > arr.get(n2).getHeapOrderingAmount()) {
+        throw new AssertionError("At index: " + i);
+      }
+      _verify(n2);
+    }
+  }
+
+  private void _print(int index, String indention, PrintWriter pw) {
+    if (index > size) {
+      return;
+    }
+    pw.println(indention + arr.get(index));
+    int n1 = 2 * index;
+    int n2 = n1 + 1;
+    _print(n1, indention + "  ", pw);
+    _print(n2, indention + "  ", pw);
+  }
+
+  public UpdatableWrapper top() {
+    // empty
+    if (size == 0) {
+      return null;
+    }
+    return arr.get(1);
+  }
+
+  public UpdatableWrapper<E> wrapperFor(int index) {
+    return arr.get(index + 1);
+  }
+
+  public static interface Ordered {
+    int getHeapOrderingAmount();
+  }
+
+  public static class UpdatableWrapper<EE extends Ordered> {
+    private final EE payload;
+    private volatile int index;
+
+    UpdatableWrapper(EE payload, int index) {
+      this.payload = payload;
+      this.index = index;
+    }
+
+    public int getHeapOrderingAmount() {
+      return payload.getHeapOrderingAmount();
+    }
+
+    public EE getPayload() {
+      return payload;
+    }
+
+    public int getIndex() {
+      return index;
+    }
+
+    public UpdatableWrapper index(int index) {
+      this.index = index;
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      return "Wrapper{" + "payload=" + payload + ", index=" + index + '}';
+    }
+  }
+}

--- a/common/src/test/java/com/tc/async/impl/MultiStageQueueImplTest.java
+++ b/common/src/test/java/com/tc/async/impl/MultiStageQueueImplTest.java
@@ -1,0 +1,360 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.async.impl;
+
+import com.tc.async.api.MultiThreadedEventContext;
+import com.tc.logging.DefaultLoggerProvider;
+import com.tc.logging.TCLoggerProvider;
+import com.tc.util.Assert;
+import com.tc.util.concurrent.QueueFactory;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Random;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * @author mscott
+ */
+public class MultiStageQueueImplTest {
+
+
+  public MultiStageQueueImplTest() {
+  }
+
+  @BeforeClass
+  public static void setUpClass() {
+  }
+
+  @AfterClass
+  public static void tearDownClass() {
+  }
+
+  @Before
+  public void setUp() {
+  }
+
+  @After
+  public void tearDown() {
+  }
+
+  /**
+   * Test of getSource method, of class StageQueueImpl.
+   */
+  @Test
+  public void testBasicMultiContext() {
+    System.out.println("multi context");
+    int index = 0;
+    int size = 4;
+    TCLoggerProvider logger = new DefaultLoggerProvider();
+    final List<BlockingQueue<Object>> cxts = new ArrayList<BlockingQueue<Object>>();
+
+    QueueFactory<ContextWrapper<Object>> context = mock(QueueFactory.class);
+    when(context.createInstance(Matchers.anyInt())).thenAnswer(new Answer<BlockingQueue<Object>>() {
+
+      @Override
+      public BlockingQueue<Object> answer(InvocationOnMock invocation) throws Throwable {
+        BlockingQueue<Object> queue = new ArrayBlockingQueue<Object>((Integer) invocation.getArguments()[0]);
+        cxts.add(queue);
+        return queue;
+      }
+
+    });
+    StageQueue<Object> instance = new MultiStageQueueImpl(size, context, logger, "mock", 16);
+    for (int x = 0; x < cxts.size(); x++) {
+      assertNotNull(instance.getSource(index));
+    }
+    assertNull(instance.getSource(cxts.size()));
+    assertEquals(cxts.size(), size);
+
+    MultiThreadedEventContext context1 = mock(MultiThreadedEventContext.class);
+    when(context1.getSchedulingKey()).thenReturn(null);
+    System.out.println("test add");
+    instance.addMultiThreaded(context1);
+    boolean found = false;
+    for (Queue<Object> q : cxts) {
+      if (q.poll() != null) {
+        found = true;
+      }
+    }
+    assertTrue(found);
+    System.out.println("test even distribution with no key");
+    for (int x = 0; x < size * 2; x++) {
+      instance.addMultiThreaded(context1);
+    }
+    for (Queue<Object> q : cxts) {
+      assertThat(q.size(), org.hamcrest.Matchers.lessThanOrEqualTo(2));
+      q.clear();
+    }
+
+    System.out.println("test specific queue");
+    when(context1.getSchedulingKey()).thenReturn(1);
+    instance.addMultiThreaded(context1);
+    //  int should hash to int
+    for (int x = 0; x < cxts.size(); x++) {
+      if (x != 1) {
+        assertTrue(cxts.get(x).isEmpty());
+      } else {
+        assertEquals(cxts.get(x).poll(), context1);
+      }
+    }
+
+    int rand = (int) (Math.random() * Integer.MAX_VALUE);
+    when(context1.getSchedulingKey()).thenReturn(rand);
+    instance.addMultiThreaded(context1);
+    //  tests specific implementation.  test expectation
+    assertEquals(cxts.get(rand % cxts.size()).poll(), context1);
+  }
+
+  @Test
+  public void testShortestRollover() throws Exception {
+    TCLoggerProvider logger = new DefaultLoggerProvider();
+    final List<BlockingQueue<Object>> cxts = new ArrayList<BlockingQueue<Object>>();
+
+    QueueFactory<ContextWrapper<Object>> context = mock(QueueFactory.class);
+    when(context.createInstance(Matchers.anyInt())).thenAnswer(new Answer<BlockingQueue<Object>>() {
+
+      @Override
+      public BlockingQueue<Object> answer(InvocationOnMock invocation) throws Throwable {
+        BlockingQueue<Object> queue = new ArrayBlockingQueue<Object>((Integer) invocation.getArguments()[0]);
+        cxts.add(queue);
+        return queue;
+      }
+
+    });
+    System.setProperty(MultiStageQueueImpl.FINDSTRATEGY_PROPNAME, MultiStageQueueImpl.ShortestFindStrategy.BRUTE.name());
+    StageQueue impl = new MultiStageQueueImpl(6, context, logger, "mock", 16);
+    MultiThreadedEventContext cxt = mock(MultiThreadedEventContext.class);
+    when(cxt.getSchedulingKey()).thenReturn(null);
+    // fcheck starts at zero and should stay at zero because first queue is always empty
+    for (int x = 0; x < 6; x++) {
+      Assert.assertTrue(impl.getSource(0).isEmpty());
+      impl.addMultiThreaded(cxt);
+      Assert.assertNotNull(impl.getSource(0).poll(0));
+    }
+    //  now try and fill one each on the the queues
+    for (int x = 0; x < 6; x++) {
+      Assert.assertTrue(impl.getSource(x).isEmpty());
+      impl.addMultiThreaded(cxt);
+      Assert.assertFalse(cxts.get(x).isEmpty());
+    }
+    //  now clear the last three and re-fill them
+    for (int x = 3; x < 6; x++) {
+      Assert.assertFalse(impl.getSource(x).isEmpty());
+      Assert.assertNotNull(impl.getSource(x).poll(0));
+      Assert.assertTrue(cxts.get(x).isEmpty());
+      impl.addMultiThreaded(cxt);
+      Assert.assertFalse(cxts.get(x).isEmpty());
+    }
+    //  now clear all again
+    for (int x = 0; x < 6; x++) {
+      Assert.assertFalse(impl.getSource(x).isEmpty());
+      Assert.assertNotNull(impl.getSource(x).poll(0));
+      Assert.assertTrue(cxts.get(x).isEmpty());
+    }
+    // now add one more and make sure it is at the last queue since that was the
+    // last to be cleared
+    impl.addMultiThreaded(cxt);
+    Assert.assertFalse(cxts.get(5).isEmpty());
+  }
+
+  @Test
+  @Ignore
+  public void testThroughput8() throws InterruptedException {
+    syntheticThroughput(5 * 60, 8, Integer.MAX_VALUE);
+  }
+
+  public void syntheticThroughput(int secondsToRun, final int qCount, int qSize) throws InterruptedException {
+    TCLoggerProvider logger = new DefaultLoggerProvider();
+    QueueFactory<ContextWrapper<MultiThreadedEventContext>> qFactory = new
+      QueueFactory<ContextWrapper<MultiThreadedEventContext>>();
+    final StageQueue<MultiThreadedEventContext> impl = new MultiStageQueueImpl<MultiThreadedEventContext>(qCount,
+                                                                                  qFactory,
+                                                                                  logger,
+                                                                                  "perf",
+                                                                                  qSize);
+
+    AtomicBoolean die = new AtomicBoolean(false);
+    final ArrayList<DelayingThread> suppliers = new ArrayList<DelayingThread>(4);
+    final MultiThreadedEventContext incoming = new MultiThreadedEventContext() {
+      @Override
+      public Object getSchedulingKey() {
+        return null;
+      }
+
+      @Override
+      public boolean flush() {
+        return false;
+      }
+    };
+    impl.enableStatsCollection(true);
+    final long[] incomingCount = new long[1];
+    final Random r = new Random(0);
+    DelayingThread supplier = DelayingThread.createDelayViaSleepThread(die, "Supplier", new Runnable() {
+      @Override
+      public void run() {
+        incomingCount[0]++;
+        impl.addMultiThreaded(incoming);
+      }
+    }, 1, TimeUnit.MILLISECONDS);
+    supplier.start();
+
+    final long[] consumerCount = new long[qCount];
+    ArrayList<Thread> consumers=new ArrayList<Thread>();
+    for(int i=0;i<qCount;i++) {
+      final int finalI = i;
+      final Random r2=new Random(i);
+      DelayingThread consumer = DelayingThread.createDelayViaSleepThread(die, "Consumer", new Runnable() {
+        @Override
+        public void run() {
+          try {
+            Object got = impl.getSource(finalI).poll(0);
+            if (got != null) {
+              //System.out.println("Consumer: " + finalI + " " + got);
+              consumerCount[finalI]++;
+            }
+            Thread.sleep(r2.nextInt(60));
+          } catch (InterruptedException e) {
+          }
+        }
+      }, 0, TimeUnit.MILLISECONDS);
+      consumers.add(consumer);
+    }
+    for(Thread t:consumers) {
+      t.start();
+    }
+    DelayingThread.createDelayViaSleepThread(die, "size", new Runnable() {
+                                               @Override
+                                               public void run() {
+                                                 System.out.println(impl.getStats(1000).getDetails());
+                                               }
+                                             }, 10, TimeUnit.SECONDS).start();
+
+    Thread.sleep(secondsToRun * 1000);
+    die.set(true);
+    impl.setClosed(true);
+    impl.clear();
+
+    System.out.println(consumerCount[0] +" events, "+(consumerCount[0] /secondsToRun)+"/sec");
+
+
+
+  }
+
+  static class DelayingThread extends Thread {
+    private final AtomicBoolean die;
+    private final Runnable task;
+    private final boolean working;
+    private volatile long delayNS;
+    private volatile long delayMS;
+    private double seed = Double.MAX_VALUE;
+
+    private DelayingThread(boolean working, AtomicBoolean die, String name, Runnable task, long delay, TimeUnit unit) {
+      super(name);
+      this.die = die;
+      this.task = task;
+
+      setDelay(delay, unit);
+      this.working = working;
+    }
+
+    public static DelayingThread createDelayViaSleepThread(AtomicBoolean die,
+                                                           String name,
+                                                           Runnable task,
+                                                           long delay,
+                                                           TimeUnit unit) {
+      return new DelayingThread(false, die, name, task, delay, unit);
+    }
+
+    public static DelayingThread createDelayViaWorkThread(AtomicBoolean die,
+                                                          String name,
+                                                          Runnable task,
+                                                          long delay,
+                                                          TimeUnit unit) {
+      return new DelayingThread(true, die, name, task, delay, unit);
+    }
+
+    public void setDelay(long delay, TimeUnit unit) {
+      this.delayNS = TimeUnit.NANOSECONDS.convert(delay, unit);
+      this.delayMS = TimeUnit.MILLISECONDS.convert(delay, unit);
+    }
+
+    public void incrementDelay(long delay, TimeUnit unit) {
+      this.delayNS = delayNS + TimeUnit.NANOSECONDS.convert(delay, unit);
+      this.delayMS = delayMS + TimeUnit.MILLISECONDS.convert(delay, unit);
+    }
+
+    @Override
+    public void run() {
+      while (!die.get()) {
+        if(delayMS>0) {
+          if (working) {
+            delayWorking();
+          } else {
+            delaySleeping();
+          }
+        }
+        try {
+          task.run();
+        } catch (Throwable t) {
+        }
+      }
+    }
+
+    private void delayWorking() {
+      long until = System.nanoTime() + delayNS;
+      do {
+        seed = Math.sqrt(seed);
+        if (seed < 10.0d) {
+          seed = Double.MAX_VALUE;
+        }
+      } while (System.nanoTime() < until);
+    }
+
+    private void delaySleeping() {
+      try {
+        Thread.sleep(delayMS);
+      } catch (InterruptedException e) {
+      }
+    }
+  }
+
+}

--- a/common/src/test/java/com/tc/async/impl/SingletonStageQueueImplTest.java
+++ b/common/src/test/java/com/tc/async/impl/SingletonStageQueueImplTest.java
@@ -23,45 +23,54 @@ import com.tc.logging.DefaultLoggerProvider;
 import com.tc.logging.TCLoggerProvider;
 import com.tc.util.Assert;
 import com.tc.util.concurrent.QueueFactory;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Queue;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Test;
-import static org.junit.Assert.*;
 import org.junit.Ignore;
+import org.junit.Test;
 import org.mockito.Matchers;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Random;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 /**
- *
  * @author mscott
  */
-public class StageQueueImplTest {
-  
-  public StageQueueImplTest() {
+public class SingletonStageQueueImplTest {
+
+
+  public SingletonStageQueueImplTest() {
   }
-  
+
   @BeforeClass
   public static void setUpClass() {
   }
-  
+
   @AfterClass
   public static void tearDownClass() {
   }
-  
+
   @Before
   public void setUp() {
   }
-  
+
   @After
   public void tearDown() {
   }
@@ -70,31 +79,29 @@ public class StageQueueImplTest {
    * Test of getSource method, of class StageQueueImpl.
    */
   @Test
-  public void testBasicMultiContext() {
-    System.out.println("multi context");
+  public void testBasicQueuing() {
     int index = 0;
-    int size = 4;
     TCLoggerProvider logger = new DefaultLoggerProvider();
     final List<BlockingQueue<Object>> cxts = new ArrayList<BlockingQueue<Object>>();
-    
+
     QueueFactory<ContextWrapper<Object>> context = mock(QueueFactory.class);
     when(context.createInstance(Matchers.anyInt())).thenAnswer(new Answer<BlockingQueue<Object>>() {
 
       @Override
       public BlockingQueue<Object> answer(InvocationOnMock invocation) throws Throwable {
-        BlockingQueue<Object> queue = new ArrayBlockingQueue<Object>((Integer)invocation.getArguments()[0]);
+        BlockingQueue<Object> queue = new ArrayBlockingQueue<Object>((Integer) invocation.getArguments()[0]);
         cxts.add(queue);
         return queue;
       }
-    
+
     });
-    StageQueueImpl<Object> instance = new StageQueueImpl<Object>(size, context, logger, "mock", 16);
-    for (int x=0;x<cxts.size();x++) {
+    StageQueue<Object> instance = new SingletonStageQueueImpl(context, logger, "mock", 16);
+    assertEquals(cxts.size(), 1);
+    for (int x = 0; x < cxts.size(); x++) {
       assertNotNull(instance.getSource(index));
     }
     assertNull(instance.getSource(cxts.size()));
-    assertEquals(cxts.size(), size);
-    
+
     MultiThreadedEventContext context1 = mock(MultiThreadedEventContext.class);
     when(context1.getSchedulingKey()).thenReturn(null);
     System.out.println("test add");
@@ -107,81 +114,31 @@ public class StageQueueImplTest {
     }
     assertTrue(found);
     System.out.println("test even distribution with no key");
-    for (int x=0;x<size*2;x++) {
+    for (int x = 0; x < 2; x++) {
       instance.addMultiThreaded(context1);
     }
     for (Queue<Object> q : cxts) {
       assertThat(q.size(), org.hamcrest.Matchers.lessThanOrEqualTo(2));
       q.clear();
     }
-    
+
     System.out.println("test specific queue");
     when(context1.getSchedulingKey()).thenReturn(1);
     instance.addMultiThreaded(context1);
-//  int should hash to int
-    for (int x=0;x<cxts.size();x++) {
-      if (x != 1) {
+    //  everything should hash to 0
+    for (int x = 0; x < cxts.size(); x++) {
+      if (x != 0) {
         assertTrue(cxts.get(x).isEmpty());
       } else {
         assertEquals(cxts.get(x).poll(), context1);
       }
     }
-    
-    int rand = (int)(Math.random() * Integer.MAX_VALUE);
+
+    int rand = (int) (Math.random() * Integer.MAX_VALUE);
     when(context1.getSchedulingKey()).thenReturn(rand);
     instance.addMultiThreaded(context1);
-//  tests specific implementation.  test expectation
+    //  tests specific implementation.  test expectation
     assertEquals(cxts.get(rand % cxts.size()).poll(), context1);
   }
-  
-  @Test
-  public void testShortestRollover() throws Exception {
-    TCLoggerProvider logger = new DefaultLoggerProvider();
-    final List<BlockingQueue<Object>> cxts = new ArrayList<BlockingQueue<Object>>();
-    
-    QueueFactory<ContextWrapper<Object>> context = mock(QueueFactory.class);
-    when(context.createInstance(Matchers.anyInt())).thenAnswer(new Answer<BlockingQueue<Object>>() {
 
-      @Override
-      public BlockingQueue<Object> answer(InvocationOnMock invocation) throws Throwable {
-        BlockingQueue<Object> queue = new ArrayBlockingQueue<Object>((Integer)invocation.getArguments()[0]);
-        cxts.add(queue);
-        return queue;
-      }
-    
-    });
-    StageQueueImpl impl = new StageQueueImpl(6, context, logger, "mock", 16);
-    MultiThreadedEventContext cxt = mock(MultiThreadedEventContext.class);
-    when(cxt.getSchedulingKey()).thenReturn(null);
- // fcheck starts at zero and should stay at zero because first queue is always empty
-    for (int x=0;x<6;x++) {
-      Assert.assertTrue(impl.getSource(0).isEmpty());
-      impl.addMultiThreaded(cxt);
-      Assert.assertNotNull(impl.getSource(0).poll(0));
-    }
-//  now try and fill one each on the the queues
-    for (int x=0;x<6;x++) {
-      Assert.assertTrue(impl.getSource(x).isEmpty());
-      impl.addMultiThreaded(cxt);
-      Assert.assertFalse(cxts.get(x).isEmpty());
-    }
-//  now clear the last three and re-fill them
-    for (int x=3;x<6;x++) {
-      Assert.assertFalse(impl.getSource(x).isEmpty());
-      Assert.assertNotNull(impl.getSource(x).poll(0));
-      Assert.assertTrue(cxts.get(x).isEmpty());
-      impl.addMultiThreaded(cxt);
-      Assert.assertFalse(cxts.get(x).isEmpty());
-    }
-//  now clear all again
-    for (int x=0;x<6;x++) {
-      Assert.assertFalse(impl.getSource(x).isEmpty());
-      Assert.assertNotNull(impl.getSource(x).poll(0));
-      Assert.assertTrue(cxts.get(x).isEmpty());
-    }
-// now add one more and make sure it is at the last queue since that was the 
-// last to be cleared
-    impl.addMultiThreaded(cxt);
-    Assert.assertFalse(cxts.get(5).isEmpty());
-  }
 }

--- a/common/src/test/java/com/tc/async/impl/StageImplTest.java
+++ b/common/src/test/java/com/tc/async/impl/StageImplTest.java
@@ -25,6 +25,16 @@ import com.tc.async.api.MultiThreadedEventContext;
 import com.tc.logging.DefaultLoggerProvider;
 import com.tc.logging.TCLoggerProvider;
 import com.tc.util.concurrent.QueueFactory;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -32,21 +42,13 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.mockito.Matchers;
+
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyInt;
-import org.mockito.Mockito;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 /**
  *
@@ -146,9 +148,12 @@ public class StageImplTest {
     when(cxt.flush()).thenReturn(Boolean.TRUE);
     
     instance.getSink().addMultiThreaded(cxt);
-    verify(cxt).getSchedulingKey();
+    if (size > 1) {
+      // if size is one, this will not be called.
+      verify(cxt).getSchedulingKey();
+    }
     verify(cxt).flush();
-    
+
     barrier.await();
     for (BlockingQueue q : cxts) {
       verify(q).put(Matchers.any(MultiThreadedEventContext.class));

--- a/common/src/test/java/com/tc/net/protocol/transport/ConnectionHealthCheckReverseCallbackTest.java
+++ b/common/src/test/java/com/tc/net/protocol/transport/ConnectionHealthCheckReverseCallbackTest.java
@@ -131,7 +131,12 @@ public class ConnectionHealthCheckReverseCallbackTest extends TCTestCase {
     
     clientComms.addClassMapping(TCMessageType.PING_MESSAGE, PingMessage.class);
     channel = clientComms.createClientChannel(new NullSessionManager(), -1, 30000, true);
-    channel.open(new ConnectionInfo(host,proxyPort));
+    try {
+      channel.open(new ConnectionInfo(host, proxyPort));
+    } catch (Throwable t) {
+      t.printStackTrace();
+      throw new RuntimeException(t);
+    }
   }
 
   public void testReverseCallback() throws Exception {

--- a/common/src/test/java/com/tc/util/UpdatableFixedHeapTest.java
+++ b/common/src/test/java/com/tc/util/UpdatableFixedHeapTest.java
@@ -1,0 +1,164 @@
+package com.tc.util;
+
+import com.tc.util.UpdatableFixedHeap.UpdatableWrapper;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Created by cschanck on 5/1/2017.
+ */
+public class UpdatableFixedHeapTest {
+
+
+  @Test
+  public void testPopulate() throws Exception {
+    Random rand = new Random(0);
+
+    int MANY = 20;
+
+    MutableCounter[] arr = new MutableCounter[MANY];
+
+    for (int i = 0; i < MANY; i++) {
+      arr[i] = new MutableCounter(rand.nextInt(500));
+    }
+
+    UpdatableFixedHeap<MutableCounter> heap = new UpdatableFixedHeap<MutableCounter>(true, arr);
+
+    heap.verify();
+  }
+
+  @Test
+  public void testUpdate1Threads() throws Exception {
+    Random rand = new Random(0);
+
+    int MANY = 20;
+
+    MutableCounter[] arr = new MutableCounter[MANY];
+
+    for (int i = 0; i < MANY; i++) {
+      arr[i] = new MutableCounter(rand.nextInt(500));
+    }
+
+    UpdatableFixedHeap<MutableCounter> heap = new UpdatableFixedHeap<MutableCounter>(true, arr);
+
+    Random r = new Random(0);
+    for (int iter = 0; iter < 500; iter++) {
+      System.out.println(iter);
+      boolean bigger = r.nextBoolean();
+      int index = r.nextInt(heap.getSize());
+      UpdatableWrapper<MutableCounter> probe = heap.wrapperFor(index);
+      MutableCounter p = probe.getPayload();
+      if (bigger) {
+        p.increment();
+        heap.possiblyCloserToFront(probe);
+      } else {
+        p.decrement();
+        heap.possiblyCloserToEnd(probe);
+      }
+      heap.verify();
+    }
+    System.out.println(heap);
+    heap.verify();
+  }
+
+  @Test
+  public void test4Threads() throws Exception {
+    nThreads(4, 20);
+  }
+
+  private void nThreads(int nThreads, int many) throws Exception {
+    Random rand = new Random(0);
+
+    MutableCounter[] arr = new MutableCounter[many];
+
+    for (int i = 0; i < many; i++) {
+      arr[i] = new MutableCounter(rand.nextInt(many));
+    }
+
+    final UpdatableFixedHeap<MutableCounter> heap = new UpdatableFixedHeap<MutableCounter>(true, arr);
+    System.out.println("Before: " + heap);
+
+    final AtomicBoolean die = new AtomicBoolean(false);
+    ArrayList<Thread> threads = new ArrayList<Thread>();
+    for (int i = 0; i < nThreads; i++) {
+      final int finalI = i;
+      Thread t = new Thread() {
+        @Override
+        public void run() {
+          Random r = new Random(finalI);
+          for (; !die.get(); ) {
+            boolean bigger = r.nextBoolean();
+            int index = r.nextInt(heap.getSize());
+            try {
+              Thread.sleep(r.nextInt(50));
+            } catch (InterruptedException e) {
+
+            }
+            UpdatableWrapper<MutableCounter> probe = heap.wrapperFor(index);
+            MutableCounter p = probe.getPayload();
+            if (bigger) {
+              p.increment(3);
+              heap.possiblyCloserToFront(probe);
+            } else {
+              p.decrement(3);
+              heap.possiblyCloserToEnd(probe);
+            }
+          }
+        }
+      };
+      threads.add(t);
+    }
+    Thread.sleep(3 * 1000);
+    die.set(true);
+    for (Thread t : threads) {
+      t.join();
+    }
+    System.out.println("After: " + heap);
+    heap.verify();
+  }
+
+  static class MutableCounter implements UpdatableFixedHeap.Ordered {
+    private int val = 0;
+
+    public MutableCounter(int val) {
+      this.val = val;
+    }
+
+    public int getValue() {
+      return val;
+    }
+
+    public MutableCounter increment() {
+      val++;
+      return this;
+    }
+
+    public MutableCounter decrement() {
+      val--;
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      return "MutatableCounter{" + "val=" + val + '}';
+    }
+
+    public MutableCounter decrement(int i) {
+      val = val - i;
+      return this;
+    }
+
+    public MutableCounter increment(int i) {
+      val = val + i;
+      return this;
+    }
+
+    @Override
+    public int getHeapOrderingAmount() {
+      return val;
+    }
+  }
+}


### PR DESCRIPTION
Updated for rework...

For StageQueueImpl, an interface StageQueue was extracted; a factory
is now used to create StageQueue's. This allowed me to split
StageQueueImpl into 2 different implementations. SingletonStageQueueImpl
is used when only 1 queue is desired (allowing for much more efficiency)
in this case, while MultiStageQueueImpl is used for queue counts >1.

In MultiStageQueueImpl, I created an enum for two different shortest path
impls. BRUTE is the classic brute force approach, while PARTITION
simply partitions the queues into sets of 4 (or 2 if the number of
queue is <8, or 1 if <2), and then on each findShortestQueue(),
we choose the next partition, and brute force the shortest queue
within that partition. Since the partitions are so small, the short
brute force search is fast, and the clock-cache like behavior
of round robin selection of partition should be pretty good at finding
the shortest queue most of the time. Synthetic testing showed this to
be extremely efficient.

Another minheap approach was tried, but the overhead on put()/poll()
was too great to be useful.

A system property, "tc.stagequeueimpl.findstrategy", is available which
cane be set to one of BRUTE or PARTITION to choose the findstrategy
while we test in real world conditions. By default, PARTITION is used.