### PR TITLE
Fix #509: propagate EntityUserException to client

### DIFF
--- a/connection-impl/src/main/java/com/terracotta/connection/entity/TerracottaEntityRef.java
+++ b/connection-impl/src/main/java/com/terracotta/connection/entity/TerracottaEntityRef.java
@@ -25,6 +25,7 @@ import org.terracotta.entity.EntityClientEndpoint;
 import org.terracotta.entity.EntityClientService;
 import org.terracotta.entity.EntityMessage;
 import org.terracotta.entity.EntityResponse;
+import org.terracotta.entity.EntityUserException;
 import org.terracotta.exception.EntityAlreadyExistsException;
 import org.terracotta.exception.EntityConfigurationException;
 import org.terracotta.exception.EntityException;
@@ -117,7 +118,11 @@ public class TerracottaEntityRef<T extends Entity, C, U> implements EntityRef<T,
     } catch (EntityException e) {
       // Note that we must externally only present the specific exception types we were expecting.  Thus, we need to check
       // that this is one of those supported types, asserting that there was an unexpected wire inconsistency, otherwise.
-      e = ExceptionUtils.addLocalStackTraceToEntityException(e);
+      try {
+        e = ExceptionUtils.addLocalStackTraceToEntityException(e);
+      } catch (EntityUserException e1) {
+        //not expected
+      }
       if (e instanceof EntityNotProvidedException) {
         throw (EntityNotProvidedException)e;
       } else if (e instanceof EntityAlreadyExistsException) {
@@ -142,7 +147,11 @@ public class TerracottaEntityRef<T extends Entity, C, U> implements EntityRef<T,
     } catch (EntityException e) {
       // Note that we must externally only present the specific exception types we were expecting.  Thus, we need to check
       // that this is one of those supported types, asserting that there was an unexpected wire inconsistency, otherwise.
-      e = ExceptionUtils.addLocalStackTraceToEntityException(e);
+      try {
+        e = ExceptionUtils.addLocalStackTraceToEntityException(e);
+      } catch (EntityUserException e1) {
+        //not expected
+      }
       if (e instanceof EntityNotFoundException) {
         throw (EntityNotFoundException)e;
       } else if (e instanceof EntityNotProvidedException) {
@@ -166,7 +175,11 @@ public class TerracottaEntityRef<T extends Entity, C, U> implements EntityRef<T,
       // Note that we must externally only present the specific exception types we were expecting.  Thus, we need to check
       // that this is one of those supported types, asserting that there was an unexpected wire inconsistency, otherwise.
       // NOTE: PermanentEntityException is thrown by this method.
-      e = ExceptionUtils.addLocalStackTraceToEntityException(e);
+      try {
+        e = ExceptionUtils.addLocalStackTraceToEntityException(e);
+      } catch (EntityUserException e1) {
+        //not expected
+      }
       if (e instanceof EntityNotProvidedException) {
         throw (EntityNotProvidedException)e;
       } else if (e instanceof EntityNotFoundException) {

--- a/dso-l1/src/main/java/com/tc/object/ClientEntityManagerImpl.java
+++ b/dso-l1/src/main/java/com/tc/object/ClientEntityManagerImpl.java
@@ -27,6 +27,7 @@ import com.tc.async.api.Stage;
 import com.tc.async.api.StageManager;
 import com.tc.util.Throwables;
 import org.terracotta.entity.EntityClientEndpoint;
+import org.terracotta.entity.EntityUserException;
 import org.terracotta.entity.InvokeFuture;
 import org.terracotta.entity.MessageCodec;
 import org.terracotta.entity.EntityMessage;
@@ -75,7 +76,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.terracotta.exception.EntityNotFoundException;
-import org.terracotta.exception.EntityUserException;
+import org.terracotta.exception.EntityServerUncaughtException;
 
 
 public class ClientEntityManagerImpl implements ClientEntityManager {
@@ -524,12 +525,14 @@ public class ClientEntityManagerImpl implements ClientEntityManager {
         try {
           TimeUnit.SECONDS.sleep(2);
         } catch (InterruptedException in) {
-          throw new EntityUserException(eid.getClassName(), eid.getEntityName(), in);
+          throw new VoltronWrapperException(new EntityServerUncaughtException(eid.getClassName(), eid.getEntityName(), "", in));
         }
         logger.info("Operation delayed:" + msg.getVoltronType() + ", busy wait");
         msg = createMessageWithDescriptor(msg.getEntityDescriptor(), msg.doesRequireReplication(), msg.getExtendedData(), msg.getVoltronType(), requestedAcks);
       } catch (InterruptedException ie) {
-        throw new EntityUserException(eid.getClassName(), eid.getEntityName(), ie);
+        throw new VoltronWrapperException(new EntityServerUncaughtException(eid.getClassName(), eid.getEntityName(), "", ie));
+      } catch (EntityUserException e) {
+        //not expected
       }
     }
   }

--- a/dso-l1/src/main/java/com/tc/object/EntityClientEndpointImpl.java
+++ b/dso-l1/src/main/java/com/tc/object/EntityClientEndpointImpl.java
@@ -21,6 +21,7 @@ package com.tc.object;
 
 import org.terracotta.entity.EndpointDelegate;
 import org.terracotta.entity.EntityClientEndpoint;
+import org.terracotta.entity.EntityUserException;
 import org.terracotta.entity.InvocationBuilder;
 import org.terracotta.entity.InvokeFuture;
 import org.terracotta.entity.MessageCodec;
@@ -179,7 +180,7 @@ public class EntityClientEndpointImpl<M extends EntityMessage, R extends EntityR
         }
 
         @Override
-        public R get() throws InterruptedException, EntityException {
+        public R get() throws InterruptedException, EntityUserException, EntityException {
           try {
             return codec.decodeResponse(invokeFuture.get());
           } catch (MessageCodecException e) {
@@ -188,7 +189,7 @@ public class EntityClientEndpointImpl<M extends EntityMessage, R extends EntityR
         }
 
         @Override
-        public R getWithTimeout(long timeout, TimeUnit unit) throws InterruptedException, EntityException, TimeoutException {
+        public R getWithTimeout(long timeout, TimeUnit unit) throws InterruptedException, EntityException, EntityUserException, TimeoutException {
           try {
             return codec.decodeResponse(invokeFuture.getWithTimeout(timeout, unit));
           } catch (MessageCodecException e) {

--- a/dso-l1/src/main/java/com/tc/object/InFlightMessage.java
+++ b/dso-l1/src/main/java/com/tc/object/InFlightMessage.java
@@ -18,6 +18,7 @@
  */
 package com.tc.object;
 
+import org.terracotta.entity.EntityUserException;
 import org.terracotta.entity.InvokeFuture;
 import org.terracotta.exception.EntityException;
 
@@ -131,7 +132,7 @@ public class InFlightMessage implements InvokeFuture<byte[]> {
   }
 
   @Override
-  public synchronized byte[] get() throws InterruptedException, EntityException {
+  public synchronized byte[] get() throws InterruptedException, EntityUserException, EntityException {
     Thread callingThread = Thread.currentThread();
     boolean didAdd = this.waitingThreads.add(callingThread);
     // We can't have already been waiting.
@@ -155,7 +156,7 @@ public class InFlightMessage implements InvokeFuture<byte[]> {
   }
 
   @Override
-  public synchronized byte[] getWithTimeout(long timeout, TimeUnit unit) throws InterruptedException, EntityException, TimeoutException {
+  public synchronized byte[] getWithTimeout(long timeout, TimeUnit unit) throws InterruptedException, EntityException, EntityUserException, TimeoutException {
     Thread callingThread = Thread.currentThread();
     boolean didAdd = this.waitingThreads.add(callingThread);
     // We can't have already been waiting.

--- a/dso-l1/src/test/java/com/tc/object/InFlightMessageTest.java
+++ b/dso-l1/src/test/java/com/tc/object/InFlightMessageTest.java
@@ -18,6 +18,7 @@
  */
 package com.tc.object;
 
+import org.terracotta.entity.EntityUserException;
 import org.terracotta.exception.EntityException;
 
 import com.tc.entity.NetworkVoltronEntityMessage;
@@ -80,6 +81,9 @@ public class InFlightMessageTest extends TestCase {
       } catch (EntityException e) {
         // This was NOT expected in this test.
         fail();
+      } catch (EntityUserException e) {
+        // This was NOT expected in this test.
+        fail();
       }
     }
   }
@@ -97,7 +101,7 @@ public class InFlightMessageTest extends TestCase {
     }
 
     @Override
-    public synchronized byte[] get() throws InterruptedException, EntityException {
+    public synchronized byte[] get() throws InterruptedException, EntityUserException, EntityException {
       // Notify anyone waiting so that they know we now have the monitor and are going to block in get().
       this.didEnter = true;
       notifyAll();

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
@@ -27,6 +27,8 @@ import com.tc.entity.ResendVoltronEntityMessage;
 import com.tc.entity.VoltronEntityAppliedResponse;
 import com.tc.entity.VoltronEntityMessage;
 import com.tc.entity.VoltronEntityMultiResponse;
+import com.tc.exception.VoltronEntityUserExceptionWrapper;
+import com.tc.exception.VoltronWrapperException;
 import com.tc.logging.TCLogger;
 import com.tc.logging.TCLogging;
 import com.tc.net.ClientID;
@@ -67,10 +69,11 @@ import java.util.function.Consumer;
 import java.util.concurrent.Future;
 import java.util.function.Predicate;
 import org.terracotta.entity.EntityMessage;
+import org.terracotta.entity.EntityUserException;
 import org.terracotta.entity.MessageCodecException;
 import org.terracotta.exception.EntityException;
 import org.terracotta.exception.EntityNotFoundException;
-import org.terracotta.exception.EntityUserException;
+import org.terracotta.exception.EntityServerUncaughtException;
 
 
 public class ProcessTransactionHandler implements ReconnectListener {
@@ -347,7 +350,7 @@ public class ProcessTransactionHandler implements ReconnectListener {
               retireMessagesForEntity(locked, message);
             });
           } catch (MessageCodecException codec) {
-            serverEntityRequest.failure(new EntityUserException(locked.getID().getClassName(), locked.getID().getEntityName(), codec));
+            serverEntityRequest.failure(new VoltronEntityUserExceptionWrapper(new EntityUserException("Caught MessageCodecException while decoding message", codec)));
             serverEntityRequest.retired();
           }
         } else if (ServerEntityAction.RECONFIGURE_ENTITY == action) {

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -29,6 +29,7 @@ import com.tc.services.SingleThreadedTimer;
 
 import org.terracotta.entity.PlatformConfiguration;
 import org.terracotta.entity.ServiceConfiguration;
+import org.terracotta.entity.ServiceException;
 import org.terracotta.entity.ServiceRegistry;
 import org.terracotta.monitoring.IMonitoringProducer;
 import org.terracotta.monitoring.PlatformServer;
@@ -654,12 +655,17 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
         .createCounter(sampledCumulativeCounterConfig);
 
     // Note that the monitoring service interface can be null if there is no monitoring support loaded into the server.
-    IMonitoringProducer serviceInterface = platformServiceRegistry.getService(new ServiceConfiguration<IMonitoringProducer>(){
-      @Override
-      public Class<IMonitoringProducer> getServiceType() {
-        return IMonitoringProducer.class;
-      }});
-    
+    IMonitoringProducer serviceInterface = null;
+    try {
+      serviceInterface = platformServiceRegistry.getService(new ServiceConfiguration<IMonitoringProducer>(){
+        @Override
+        public Class<IMonitoringProducer> getServiceType() {
+          return IMonitoringProducer.class;
+        }});
+    } catch (ServiceException e) {
+      Assert.fail("Multiple IMonitoringProducer implementations found!");
+    }
+
     long reconnectTimeout = l2DSOConfig.clientReconnectWindow();
     logger.debug("Client Reconnect Window: " + reconnectTimeout + " seconds");
     reconnectTimeout *= 1000;

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/PluggableSecurityManager.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/PluggableSecurityManager.java
@@ -21,10 +21,13 @@ package com.tc.objectserver.impl;
 import com.tc.net.core.BufferManagerFactory;
 import com.tc.net.core.ClearTextBufferManagerFactory;
 import com.tc.net.core.security.TCSecurityManager;
+import com.tc.util.Assert;
+
 import java.net.URI;
 import java.security.Principal;
 import javax.net.ssl.SSLContext;
 import org.terracotta.entity.BasicServiceConfiguration;
+import org.terracotta.entity.ServiceException;
 import org.terracotta.entity.ServiceRegistry;
 
 /**
@@ -35,7 +38,12 @@ public class PluggableSecurityManager implements TCSecurityManager {
   private final BufferManagerFactory buffers;
 
   public PluggableSecurityManager(ServiceRegistry registry) {
-    BufferManagerFactory factory = registry.getService(new BasicServiceConfiguration<>(BufferManagerFactory.class));
+    BufferManagerFactory factory = null;
+    try {
+      factory = registry.getService(new BasicServiceConfiguration<>(BufferManagerFactory.class));
+    } catch (ServiceException e) {
+      Assert.fail("Multiple BufferManagerFactory implementations found!");
+    }
     if (factory == null) {
       factory = new ClearTextBufferManagerFactory();
     }

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/StandardServerBuilder.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/StandardServerBuilder.java
@@ -19,6 +19,7 @@
 package com.tc.objectserver.impl;
 
 import org.terracotta.entity.BasicServiceConfiguration;
+import org.terracotta.entity.ServiceException;
 import org.terracotta.entity.ServiceRegistry;
 
 import com.tc.async.api.ConfigurationContext;
@@ -122,7 +123,12 @@ public class StandardServerBuilder implements ServerBuilder {
 
   @Override
   public Persistor createPersistor(ServiceRegistry serviceRegistry) {
-    IPlatformPersistence platformPersistence = serviceRegistry.getService(new BasicServiceConfiguration<IPlatformPersistence>(IPlatformPersistence.class));
+    IPlatformPersistence platformPersistence = null;
+    try {
+      platformPersistence = serviceRegistry.getService(new BasicServiceConfiguration<IPlatformPersistence>(IPlatformPersistence.class));
+    } catch (ServiceException e) {
+      Assert.fail("Multiple IPlatformPersistence implementations found!");
+    }
     // We can't fail to look this up as the implementation will install an in-memory implementation if an on-disk on
     //  wasn't provided
     Assert.assertNotNull(platformPersistence);

--- a/dso-l2/src/main/java/com/tc/services/BestEffortsMonitoring.java
+++ b/dso-l2/src/main/java/com/tc/services/BestEffortsMonitoring.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.terracotta.entity.BasicServiceConfiguration;
+import org.terracotta.entity.ServiceException;
 import org.terracotta.monitoring.IStripeMonitoring;
 import org.terracotta.monitoring.PlatformServer;
 
@@ -39,7 +40,12 @@ public class BestEffortsMonitoring {
     
     // Walk each consumerID, looking up their registries, and flushing all entries to the implementation.
     for (Map.Entry<Long, Map<String, Serializable>> perConsumerEntry : this.bestEffortsCache.entrySet()) {
-      IStripeMonitoring collector = globalRegistry.subRegistry(perConsumerEntry.getKey()).getService(new BasicServiceConfiguration<IStripeMonitoring>(IStripeMonitoring.class));
+      IStripeMonitoring collector = null;
+      try {
+        collector = globalRegistry.subRegistry(perConsumerEntry.getKey()).getService(new BasicServiceConfiguration<IStripeMonitoring>(IStripeMonitoring.class));
+      } catch (ServiceException e) {
+        Assert.fail("Multiple IStripeMonitoring implementations found!");
+      }
       // NOTE:  We assert that there _is_ a registry for IStripeMonitoring if we received this call.
       Assert.assertNotNull(collector);
       for (Map.Entry<String, Serializable> entry : perConsumerEntry.getValue().entrySet()) {

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
@@ -31,7 +31,7 @@ import org.terracotta.entity.EntityServerService;
 import org.terracotta.entity.ServiceRegistry;
 import org.terracotta.entity.SyncMessageCodec;
 import org.terracotta.exception.EntityAlreadyExistsException;
-import org.terracotta.exception.EntityUserException;
+import org.terracotta.entity.EntityUserException;
 
 import com.tc.object.ClientInstanceID;
 import com.tc.object.EntityID;
@@ -83,6 +83,7 @@ import org.terracotta.entity.ConfigurationException;
 import org.terracotta.entity.EntityResponse;
 import org.terracotta.entity.ExecutionStrategy;
 import org.terracotta.entity.MessageCodec;
+import org.terracotta.exception.EntityServerUncaughtException;
 
 import com.tc.objectserver.api.ManagedEntity;
 import com.tc.objectserver.api.ManagementKeyCallback;
@@ -680,7 +681,7 @@ public class ManagedEntityImplTest {
   @Test (expected = EntityUserException.class)
   public void testCodecException() throws Exception {
 // this test is no longer relevant, decode is done in the hydrate stage or process/replicated transaction handler
-    throw new EntityUserException(entityID.getClassName(), entityID.getEntityName(), new MessageCodecException("fake", new IOException()));
+    throw new EntityUserException("fake", new MessageCodecException("fake", new IOException()));
   }
 
   @Test

--- a/dso-l2/src/test/java/com/tc/services/BestEffortsMonitoringTest.java
+++ b/dso-l2/src/test/java/com/tc/services/BestEffortsMonitoringTest.java
@@ -232,7 +232,7 @@ public class BestEffortsMonitoringTest {
 
 
   @SuppressWarnings("unchecked")
-  private TerracottaServiceProviderRegistry mockRegistry(IStripeMonitoring consumer1, IStripeMonitoring consumer2) {
+  private TerracottaServiceProviderRegistry mockRegistry(IStripeMonitoring consumer1, IStripeMonitoring consumer2) throws Exception {
     TerracottaServiceProviderRegistry globalRegistry = mock(TerracottaServiceProviderRegistry.class);
     if (null != consumer1) {
       InternalServiceRegistry registry1 = mock(InternalServiceRegistry.class);

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <tc-shader.version>1.2</tc-shader.version>
     <skip.deploy>false</skip.deploy>
 
-    <terracotta-apis.version>1.3.0-pre3</terracotta-apis.version>
+    <terracotta-apis.version>1.3.0-pre4</terracotta-apis.version>
     <terracotta-configuration.version>10.3.0-pre4</terracotta-configuration.version>
     <galvan.version>1.3.0-pre3</galvan.version>
   </properties>

--- a/tc-messaging/src/main/java/com/tc/entity/VoltronEntityAppliedResponseImpl.java
+++ b/tc-messaging/src/main/java/com/tc/entity/VoltronEntityAppliedResponseImpl.java
@@ -20,6 +20,7 @@
 package com.tc.entity;
 
 import com.tc.bytes.TCByteBuffer;
+import com.tc.exception.VoltronWrapperException;
 import com.tc.io.TCByteBufferOutputStream;
 import com.tc.net.protocol.tcm.MessageChannel;
 import com.tc.net.protocol.tcm.MessageMonitor;
@@ -37,7 +38,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import org.terracotta.exception.EntityException;
-import org.terracotta.exception.EntityUserException;
+import org.terracotta.exception.EntityServerUncaughtException;
 
 
 public class VoltronEntityAppliedResponseImpl extends DSOMessageBase implements VoltronEntityAppliedResponse {
@@ -148,7 +149,7 @@ public class VoltronEntityAppliedResponseImpl extends DSOMessageBase implements 
       } catch (ClassNotFoundException e) {
         // We may want to make this into an assertion but we do have a mechanism to pass it up to the next level so wrap
         // it in a user exception.
-        this.failureException = new EntityUserException(null, null, e);
+        this.failureException = new VoltronWrapperException(new EntityServerUncaughtException(null, null, "caught exception during invoke ", e));
       } finally {
         objectInput.close();
       }

--- a/tc-messaging/src/main/java/com/tc/exception/VoltronEntityUserExceptionWrapper.java
+++ b/tc-messaging/src/main/java/com/tc/exception/VoltronEntityUserExceptionWrapper.java
@@ -1,0 +1,11 @@
+package com.tc.exception;
+
+import org.terracotta.entity.EntityUserException;
+import org.terracotta.exception.EntityException;
+
+public class VoltronEntityUserExceptionWrapper extends EntityException {
+
+  public VoltronEntityUserExceptionWrapper(EntityUserException cause) {
+    super(null, null, cause.getMessage(), cause);
+  }
+}


### PR DESCRIPTION
   *  EntityUserException(s) thrown by ActiveServerEntity.invoke() will be logged and sent to the client and PassiveServerEntity.invoke() will be just logged. 
   * EntityUserException(s) don't crash the server but other exceptions crash and they will be not sent to the client. 