### PR TITLE
Adapt to CommonServerEntity and ServiceProvider API changes

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -35,7 +35,6 @@ import org.terracotta.entity.MessageCodecException;
 import org.terracotta.entity.PassiveServerEntity;
 import org.terracotta.entity.PassiveSynchronizationChannel;
 import org.terracotta.entity.EntityServerService;
-import org.terracotta.entity.StateDumpable;
 import org.terracotta.entity.StateDumper;
 import org.terracotta.entity.SyncMessageCodec;
 
@@ -370,21 +369,11 @@ public class ManagedEntityImpl implements ManagedEntity {
   @Override
   public void dumpStateTo(StateDumper stateDumper) {
     if(activeServerEntity != null) {
-      // Entities can optionally implement StateDumpable, so we do a instanceof check before calling dump state method
-      if(activeServerEntity instanceof StateDumpable) {
-        ((StateDumpable) activeServerEntity).dumpStateTo(stateDumper);
-      } else {
-        stateDumper.dumpState(this.getID().toString(), activeServerEntity.toString());
-      }
+      activeServerEntity.dumpStateTo(stateDumper);
     }
 
     if(passiveServerEntity != null) {
-      // Entities can optionally implement StateDumpable, so we do a instanceof check before calling dump state method
-      if(passiveServerEntity instanceof StateDumpable) {
-        ((StateDumpable) passiveServerEntity).dumpStateTo(stateDumper);
-      } else {
-        stateDumper.dumpState(this.getID().toString(), passiveServerEntity.toString());
-      }
+      passiveServerEntity.dumpStateTo(stateDumper);
     }
   }
 

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/ClientStatePersistor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/ClientStatePersistor.java
@@ -20,6 +20,8 @@ package com.tc.objectserver.persistence;
 
 import com.tc.net.ClientID;
 import com.tc.objectserver.api.ClientNotFoundException;
+import com.tc.text.PrettyPrintable;
+import com.tc.text.PrettyPrinter;
 import com.tc.util.Assert;
 import com.tc.util.sequence.MutableSequence;
 
@@ -30,7 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.terracotta.persistence.IPlatformPersistence;
 
 
-public class ClientStatePersistor {
+public class ClientStatePersistor implements PrettyPrintable {
   private static final String CLIENTS_MAP_FILE_NAME =  "clients_map.map";
   private static final String NEXT_CLIENT_ID_FILE_NAME =  "next_client_id.dat";
   
@@ -79,6 +81,19 @@ public class ClientStatePersistor {
       throw new ClientNotFoundException();
     }
     safeStoreClients();
+  }
+
+  @Override
+  public PrettyPrinter prettyPrint(PrettyPrinter out) {
+    out.indent().println(this.getClass().getName());
+    if(clients != null) {
+      out.indent().indent().println("Connected clients: ");
+      for (ClientID clientID : clients.keySet()) {
+        out.indent().indent().indent().println(clientID);
+      }
+      out.indent().indent().println("Next client id: " + clientIDSequence.current());
+    }
+    return out;
   }
 
   private void safeStoreClients() {

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/ClusterStatePersistor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/ClusterStatePersistor.java
@@ -19,6 +19,8 @@
 package com.tc.objectserver.persistence;
 
 import com.tc.net.StripeID;
+import com.tc.text.PrettyPrintable;
+import com.tc.text.PrettyPrinter;
 import com.tc.util.State;
 import com.tc.util.version.Version;
 import java.io.IOException;
@@ -26,7 +28,7 @@ import java.util.HashMap;
 import org.terracotta.persistence.IPlatformPersistence;
 
 
-public class ClusterStatePersistor {
+public class ClusterStatePersistor implements PrettyPrintable {
   private static final String MAP_FILE_NAME = "ClusterStatePersistor.map";
   private static final String DB_CLEAN_KEY = "dbclean";
   private static final String L2_STATE_KEY = "l2state";
@@ -104,6 +106,17 @@ public class ClusterStatePersistor {
   public void clear() {
     map.clear();
     initialState = null;
+  }
+
+  @Override
+  public PrettyPrinter prettyPrint(PrettyPrinter out) {
+    out.indent().println(this.getClass().getName());
+    out.indent().indent().println("StripeID = " + getStripeID());
+    out.indent().indent().println("Version = " + getVersion());
+    out.indent().indent().println("Initial State = " + getInitialState());
+    out.indent().indent().println("Current State = " + getCurrentL2State());
+    out.indent().indent().println("isDBClean = " + isDBClean());
+    return out;
   }
 
   // This isn't called from different threads but we can easily synchronize around the putAndStore.

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/EntityPersistor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/EntityPersistor.java
@@ -26,6 +26,8 @@ import com.tc.object.EntityID;
 import com.tc.objectserver.persistence.EntityData.JournalEntry;
 import com.tc.objectserver.persistence.EntityData.Key;
 import com.tc.objectserver.persistence.EntityData.Value;
+import com.tc.text.PrettyPrintable;
+import com.tc.text.PrettyPrinter;
 import com.tc.util.Assert;
 import com.tc.util.State;
 import java.io.IOException;
@@ -36,6 +38,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 
@@ -46,7 +49,7 @@ import org.terracotta.persistence.IPlatformPersistence;
 /**
  * Stores the information relating to the entities currently alive on the platform into persistent storage.
  */
-public class EntityPersistor {
+public class EntityPersistor implements PrettyPrintable {
   private static final TCLogger LOGGER = TCLogging.getLogger(EntityPersistor.class);
   
   private static final String ENTITIES_ALIVE_FILE_NAME = "entities_alive.map";
@@ -253,6 +256,33 @@ public class EntityPersistor {
   
   public synchronized void removeTrackingForClient(ClientID sourceNodeID) {
     this.entityLifeJournal.remove(sourceNodeID);
+  }
+
+  @Override
+  public PrettyPrinter prettyPrint(PrettyPrinter out) {
+    out.indent().println(this.getClass().getName());
+    if(entities != null) {
+      out.indent().indent().println("Existing entities: ");
+      for (Key key : entities.keySet()) {
+        out.indent().indent().indent().println(key.className + ":" + key.entityName);
+      }
+    }
+
+    if(entityLifeJournal != null) {
+      out.indent().indent().println("Client Journals: ");
+      for (Map.Entry<ClientID, List<EntityData.JournalEntry>> entry : entityLifeJournal.entrySet()) {
+        out.indent().indent().indent().println("Journal operations for client " + entry.getKey());
+        for (JournalEntry journalEntry : entry.getValue()) {
+          out.indent().indent().indent().indent().println(journalEntry);
+        }
+
+      }
+    }
+
+    if(counters != null) {
+      out.indent().indent().println("Next consumer ID = " + this.counters.get(COUNTERS_CONSUMER_ID));
+    }
+    return out;
   }
 
 

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/Persistor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/Persistor.java
@@ -81,11 +81,14 @@ public class Persistor implements PrettyPrintable {
 
   @Override
   public PrettyPrinter prettyPrint(PrettyPrinter out) {
-    out.print(getClass().getName()).flush();
+    out.print("Persistor State: " + getClass().getName()).flush();
     if (!started) {
       out.indent().print("PersistorImpl not started.").flush();
     } else {
-      out.println(persistentStorage);
+      if(clusterStatePersistor != null) clusterStatePersistor.prettyPrint(out);
+      if(entityPersistor != null) entityPersistor.prettyPrint(out);
+      if(clientStatePersistor != null) clientStatePersistor.prettyPrint(out);
+      if(transactionOrderPersistor != null) transactionOrderPersistor.prettyPrint(out);
     }
     return out;
   }

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/TransactionOrderPersistor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/TransactionOrderPersistor.java
@@ -23,6 +23,8 @@ import org.terracotta.persistence.IPlatformPersistence;
 import com.tc.net.ClientID;
 import com.tc.net.protocol.tcm.ChannelID;
 import com.tc.object.tx.TransactionID;
+import com.tc.text.PrettyPrintable;
+import com.tc.text.PrettyPrinter;
 import com.tc.util.Assert;
 
 import java.io.IOException;
@@ -42,7 +44,7 @@ import java.util.concurrent.Future;
  * This is persisted because reconnect on restart needs to ensure that the transactions being replayed are done so in
  * the same order as their original order.
  */
-public class TransactionOrderPersistor {
+public class TransactionOrderPersistor implements PrettyPrintable {
   private final IPlatformPersistence storageManager;
   private Long receivedTransactionCount = new Long(0L);
     
@@ -128,6 +130,14 @@ public class TransactionOrderPersistor {
       }
       return isEqual;
     }
+
+    @Override
+    public String toString() {
+      return "{clientID=" + clientID +
+             ", localTransactionID=" + localTransactionID +
+             ", globalTransactionID=" + globalTransactionID +
+             '}';
+    }
   }
   
   private List<ClientTransaction> buildGlobalListIfNessessary() {
@@ -195,5 +205,34 @@ public class TransactionOrderPersistor {
    */
   public long getReceivedTransactionCount() {
     return this.receivedTransactionCount;
+  }
+
+  @Override
+  public PrettyPrinter prettyPrint(PrettyPrinter out) {
+    out.indent().println(this.getClass().getName());
+    out.indent().indent().println("Received transaction count = " + getReceivedTransactionCount());
+    if(globalList != null) {
+      out.indent().indent().println("Existing Global List: ");
+      for (ClientTransaction clientTransaction : globalList) {
+        out.indent().indent().indent().print(clientTransaction);
+      }
+    }
+
+    if(clientNodeIDs != null && storageManager != null) {
+      for (Long clientNodeID : clientNodeIDs) {
+        List<IPlatformPersistence.SequenceTuple> transactions = null;
+        try {
+          transactions = this.storageManager.loadSequence(clientNodeID);
+        } catch (IOException e) {
+          Assert.fail(e.getLocalizedMessage());
+        }
+        out.indent().indent().println("Persisted transaction order for client " + clientNodeID);
+        for (IPlatformPersistence.SequenceTuple transaction : transactions) {
+          out.indent().indent().indent()
+              .println("Global seq Id = " + transaction.localSequenceID + ", local seq id = " + transaction.localSequenceID);
+        }
+      }
+    }
+    return out;
   }
 }

--- a/dso-l2/src/main/java/com/tc/services/CommunicatorService.java
+++ b/dso-l2/src/main/java/com/tc/services/CommunicatorService.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentMap;
 import org.terracotta.entity.ClientCommunicator;
 import org.terracotta.entity.ServiceConfiguration;
 import org.terracotta.entity.ServiceProviderCleanupException;
+import org.terracotta.entity.StateDumper;
 
 
 public class CommunicatorService implements ImplementationProvidedServiceProvider, DSOChannelManagerEventListener {
@@ -99,5 +100,9 @@ public class CommunicatorService implements ImplementationProvidedServiceProvide
   public void setChannelManager(DSOChannelManager dsoChannelManager) {
     dsoChannelManager.addEventListener(this);
     this.wasInitialized = true;
+  }
+
+  @Override
+  public void dumpStateTo(final StateDumper stateDumper) {
   }
 }

--- a/dso-l2/src/main/java/com/tc/services/EntityMessengerProvider.java
+++ b/dso-l2/src/main/java/com/tc/services/EntityMessengerProvider.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import org.terracotta.entity.IEntityMessenger;
 import org.terracotta.entity.ServiceConfiguration;
 import org.terracotta.entity.ServiceProviderCleanupException;
+import org.terracotta.entity.StateDumper;
 
 import com.tc.async.api.Sink;
 import com.tc.entity.VoltronEntityMessage;
@@ -78,5 +79,10 @@ public class EntityMessengerProvider implements ImplementationProvidedServicePro
   public void setMessageSink(Sink<VoltronEntityMessage> messageSink) {
     Assert.assertNotNull(messageSink);
     this.messageSink = messageSink;
+  }
+
+  @Override
+  public void dumpStateTo(final StateDumper stateDumper) {
+    //TODO: implement this
   }
 }

--- a/dso-l2/src/main/java/com/tc/services/ImplementationProvidedServiceProvider.java
+++ b/dso-l2/src/main/java/com/tc/services/ImplementationProvidedServiceProvider.java
@@ -24,6 +24,7 @@ import org.terracotta.entity.ServiceConfiguration;
 
 import com.tc.objectserver.api.ManagedEntity;
 import org.terracotta.entity.ServiceProviderCleanupException;
+import org.terracotta.entity.StateDumpable;
 
 
 /**
@@ -37,7 +38,7 @@ import org.terracotta.entity.ServiceProviderCleanupException;
  * This has no explicit initialization routine as it is expected that the implementation will be initialized with rich
  * context, inline, prior to being registered with the platform's provider registry.
  */
-public interface ImplementationProvidedServiceProvider {
+public interface ImplementationProvidedServiceProvider extends StateDumpable {
   /**
    * Get an instance of service from the provider.
    *

--- a/dso-l2/src/main/java/com/tc/services/LocalMonitoringProducer.java
+++ b/dso-l2/src/main/java/com/tc/services/LocalMonitoringProducer.java
@@ -11,6 +11,7 @@ import org.terracotta.entity.ServiceConfiguration;
 import org.terracotta.entity.ServiceException;
 import org.terracotta.entity.ServiceProvider;
 import org.terracotta.entity.ServiceProviderCleanupException;
+import org.terracotta.entity.StateDumper;
 import org.terracotta.monitoring.IMonitoringProducer;
 import org.terracotta.monitoring.IStripeMonitoring;
 import org.terracotta.monitoring.PlatformServer;
@@ -329,6 +330,11 @@ public class LocalMonitoringProducer implements ImplementationProvidedServicePro
     System.arraycopy(parents, 0, newParents, 0, parents.length);
     newParents[parents.length] = nodeName;
     walkCacheChildren(newParents, node.children, walker);
+  }
+
+  @Override
+  public void dumpStateTo(final StateDumper stateDumper) {
+    //TODO: implement this
   }
 
 

--- a/dso-l2/src/main/java/com/tc/services/PlatformServiceProvider.java
+++ b/dso-l2/src/main/java/com/tc/services/PlatformServiceProvider.java
@@ -4,6 +4,7 @@ import com.tc.management.beans.TCDumper;
 import com.tc.objectserver.api.ManagedEntity;
 import org.terracotta.entity.ServiceConfiguration;
 import org.terracotta.entity.ServiceProviderCleanupException;
+import org.terracotta.entity.StateDumper;
 import org.terracotta.monitoring.PlatformService;
 
 import java.util.Collection;
@@ -37,5 +38,10 @@ public class PlatformServiceProvider implements ImplementationProvidedServicePro
     @Override
     public void serverDidBecomeActive() {
       // The platform service works the same way whether active or passive - ignore.
+    }
+
+    @Override
+    public void dumpStateTo(final StateDumper stateDumper) {
+        //nothing to do
     }
 }

--- a/dso-l2/src/main/java/com/tc/services/TerracottaServiceProviderRegistryImpl.java
+++ b/dso-l2/src/main/java/com/tc/services/TerracottaServiceProviderRegistryImpl.java
@@ -144,19 +144,11 @@ public class TerracottaServiceProviderRegistryImpl implements TerracottaServiceP
   @Override
   public void dumpStateTo(StateDumper stateDumper) {
     for (ServiceProvider serviceProvider : serviceProviders) {
-      // ServiceProviders can optionally implement StateDumpable, so we do a instanceof check before calling dump state
-      // method
-      if(serviceProvider instanceof StateDumpable) {
-        ((StateDumpable) serviceProvider).dumpStateTo(stateDumper.subStateDumper(serviceProvider.getClass().getName()));
-      }
+      serviceProvider.dumpStateTo(stateDumper.subStateDumper(serviceProvider.getClass().getName()));
     }
 
     for (ImplementationProvidedServiceProvider implementationProvidedServiceProvider : implementationProvidedServiceProviders) {
-      // ServiceProviders can optionally implement StateDumpable, so we do a instanceof check before calling dump state
-      // method
-      if(implementationProvidedServiceProvider instanceof StateDumpable) {
-        ((StateDumpable) implementationProvidedServiceProvider).dumpStateTo(stateDumper.subStateDumper(implementationProvidedServiceProvider.getClass().getName()));
-      }
+      implementationProvidedServiceProvider.dumpStateTo(stateDumper.subStateDumper(implementationProvidedServiceProvider.getClass().getName()));
     }
   }
 

--- a/dso-l2/src/test/java/com/tc/objectserver/testentity/TestEntityServer.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/testentity/TestEntityServer.java
@@ -23,6 +23,7 @@ import org.terracotta.entity.EntityMessage;
 import org.terracotta.entity.EntityResponse;
 import org.terracotta.entity.ActiveServerEntity;
 import org.terracotta.entity.PassiveSynchronizationChannel;
+import org.terracotta.entity.StateDumper;
 
 
 public class TestEntityServer implements ActiveServerEntity<EntityMessage, EntityResponse> {
@@ -61,5 +62,10 @@ public class TestEntityServer implements ActiveServerEntity<EntityMessage, Entit
   public void synchronizeKeyToPassive(PassiveSynchronizationChannel<EntityMessage> syncChannel, int concurrencyKey) {
     // TODO:  Add synchronization support.
     throw new AssertionError("Synchronization not supported for this entity");
+  }
+
+  @Override
+  public void dumpStateTo(final StateDumper stateDumper) {
+    //nothing to dump
   }
 }

--- a/dso-l2/src/test/java/com/tc/server/TestServiceProvider.java
+++ b/dso-l2/src/test/java/com/tc/server/TestServiceProvider.java
@@ -26,6 +26,7 @@ import org.terracotta.entity.ServiceConfiguration;
 import org.terracotta.entity.ServiceProvider;
 import org.terracotta.entity.ServiceProviderConfiguration;
 import org.terracotta.entity.ServiceProviderCleanupException;
+import org.terracotta.entity.StateDumper;
 
 
 public class TestServiceProvider implements ServiceProvider {
@@ -47,5 +48,10 @@ public class TestServiceProvider implements ServiceProvider {
   @Override
   public void prepareForSynchronization() throws ServiceProviderCleanupException {
     // nothing to do
+  }
+
+  @Override
+  public void dumpStateTo(final StateDumper stateDumper) {
+    //nothing to dump
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <tc-shader.version>1.2</tc-shader.version>
     <skip.deploy>false</skip.deploy>
 
-    <terracotta-apis.version>1.3.0-pre5</terracotta-apis.version>
+    <terracotta-apis.version>1.3.0-pre6</terracotta-apis.version>
     <terracotta-configuration.version>10.3.0-pre5</terracotta-configuration.version>
     <galvan.version>1.3.0-pre3</galvan.version>
   </properties>


### PR DESCRIPTION
    * Add ClientStatePersistor, EntityPersistor, TransactionOrderPersistor and ClusterStatePersistor state to cluster state

excerpt from a cluster state dump:

--> com.tc.objectserver.persistence.ClusterStatePersistor
--> --> StripeID = StripeID[b6640d6b502a4b36918a773fe10761c1]
--> --> Version = 5.3.0.0.0
--> --> Initial State = null
--> --> Current State = State[ ACTIVE-COORDINATOR ]
--> --> isDBClean = true
--> com.tc.objectserver.persistence.EntityPersistor
--> --> Existing entities: 
--> --> --> org.terracotta.entity.testsupport.TestSupport:TestSupport
--> --> Client Journals: 
--> --> Next consumer ID = 2
--> com.tc.objectserver.persistence.ClientStatePersistor
--> --> Connected clients: 
--> --> --> ClientID[0]
--> --> Next client id: 1
--> com.tc.objectserver.persistence.TransactionOrderPersistor
--> --> Received transaction count = 0