### PR TITLE
Fix #578 Update reference directory for server

### DIFF
--- a/common/src/main/java/com/tc/config/Directories.java
+++ b/common/src/main/java/com/tc/config/Directories.java
@@ -60,18 +60,15 @@ public class Directories {
   /**
    * Get installation root directory.
    * 
-   * @return Installation root directory or null if TC_INSTALL_ROOT_IGNORE_CHECKS_PROPERTY_NAME is set and
+   * @return Installation root directory or {@code user.dir} if TC_INSTALL_ROOT_IGNORE_CHECKS_PROPERTY_NAME is set and
    *         TC_INSTALL_ROOT_PROPERTY_NAME is not.
-   * @throws FileNotFoundException If {@link #TC_INSTALL_ROOT_PROPERTY_NAME} has not been set. If
-   *         {@link #TC_INSTALL_ROOT_IGNORE_CHECKS_PROPERTY_NAME} has not been set, this exception may be thrown if the
-   *         installation root directory has not been set, is not a directory
+   * @throws FileNotFoundException If {@link #TC_INSTALL_ROOT_IGNORE_CHECKS_PROPERTY_NAME} has not been set,
+   *         this exception may be thrown if the installation root directory is not a directory
    */
-  public static File getInstallationRoot() throws FileNotFoundException {
+  static File getInstallationRoot() throws FileNotFoundException {
     boolean ignoreCheck = Boolean.getBoolean(TC_INSTALL_ROOT_IGNORE_CHECKS_PROPERTY_NAME);
     if (ignoreCheck) {
-      // XXX hack to have enterprise system tests to find license key under <ee-branch>/code/base
-      String baseDir = System.getProperty("tc.base-dir");
-      return new File(baseDir != null ? baseDir : ".", "../../../code/base");
+      return new File(System.getProperty("user.dir"));
     } else {
       String path = System.getProperty(TC_INSTALL_ROOT_PROPERTY_NAME);
       if (StringUtils.isBlank(path)) {

--- a/common/src/main/java/com/tc/config/Directories.java
+++ b/common/src/main/java/com/tc/config/Directories.java
@@ -45,17 +45,17 @@ public class Directories {
   /**
    * Relative location for server lib directory under Terracotta installation directory
    */
-  public static final String SERVER_LIB_DIR                                  = "server/lib";
+  public static final String SERVER_LIB_DIR                                  = "lib";
 
   /**
    * Relative location for server plugin api directory under Terracotta installation directory
    */
-  public static final String SERVER_PLUGIN_API_DIR                           = "server/plugins/api";
+  public static final String SERVER_PLUGIN_API_DIR                           = "plugins/api";
 
   /**
    * Relative location for server plugin lib directory under Terracotta installation directory
    */
-  public static final String SERVER_PLUGIN_LIB_DIR                           = "server/plugins/lib";
+  public static final String SERVER_PLUGIN_LIB_DIR                           = "plugins/lib";
 
   /**
    * Get installation root directory.

--- a/terracotta-kit/src/assemble/server/bin/start-tc-server.bat
+++ b/terracotta-kit/src/assemble/server/bin/start-tc-server.bat
@@ -33,13 +33,13 @@ exit /b 0
 :start
 setlocal enabledelayedexpansion enableextensions
 
-set TC_INSTALL_DIR=%~d0%~p0..\..
-set TC_INSTALL_DIR="%TC_INSTALL_DIR:"=%"
-set PLUGIN_LIB_DIR=%TC_INSTALL_DIR%\server\plugins\lib
-set PLUGIN_API_DIR=%TC_INSTALL_DIR%\server\plugins\api
+set TC_SERVER_DIR=%~d0%~p0..\..
+set TC_SERVER_DIR="%TC_SERVER_DIR:"=%"
+set PLUGIN_LIB_DIR=%TC_SERVER_DIR%\plugins\lib
+set PLUGIN_API_DIR=%TC_SERVER_DIR%\plugins\api
 
-if exist %TC_INSTALL_DIR%\server\bin\setenv.bat (
-  call %TC_INSTALL_DIR%\server\bin\setenv.bat
+if exist %TC_SERVER_DIR%\bin\setenv.bat (
+  call %TC_SERVER_DIR%\bin\setenv.bat
 )
 
 if not defined JAVA_HOME (
@@ -76,24 +76,24 @@ set PLUGIN_CLASSPATH="%PLUGIN_CLASSPATH:"=%"
 
 REM   Adding SLF4j libraries to the classpath of the server to 
 REM   support services that may use SLF4j for logging
-if exist %TC_INSTALL_DIR%\server\lib (
-	for %%K in (%TC_INSTALL_DIR%\server\lib\slf4j*.jar) do (
+if exist %TC_SERVER_DIR%\lib (
+	for %%K in (%TC_SERVER_DIR%\lib\slf4j*.jar) do (
 		set PLUGIN_CLASSPATH=!PLUGIN_CLASSPATH!;"%%K"
 	)
 ) else (
-		echo %TC_INSTALL_DIR%\server\lib does not exist!
+		echo %TC_SERVER_DIR%\lib does not exist!
 	)
 	
 REM todo do i still need to enable nullglob?
 REM $ENV{NULLGLOB} = 0;
 
-set CLASSPATH=%TC_INSTALL_DIR%\server\lib\tc.jar;%PLUGIN_CLASSPATH%
+set CLASSPATH=%TC_SERVER_DIR%\lib\tc.jar;%PLUGIN_CLASSPATH%
 set OPTS=%SERVER_OPT% -Xms256m -Xmx2g -XX:+HeapDumpOnOutOfMemoryError
 set OPTS=%OPTS% -Dcom.sun.management.jmxremote
 rem rmi.dgc.server.gcInterval is set as year to avoid system gc in case authentication is enabled
 rem users may change it accordingly
 set OPTS=%OPTS% -Dsun.rmi.dgc.server.gcInterval=31536000000
-set OPTS=%OPTS% -Dtc.install-root=%TC_INSTALL_DIR%
+set OPTS=%OPTS% -Dtc.install-root=%TC_SERVER_DIR%
 set JAVA_OPTS=%OPTS% %JAVA_OPTS%
 
 

--- a/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
+++ b/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
@@ -30,9 +30,9 @@ esac
 
 
 THIS_DIR=`dirname $0`
-TC_INSTALL_DIR=`cd $THIS_DIR;pwd`/../..
-PLUGIN_LIB_DIR="$TC_INSTALL_DIR/server/plugins/lib"
-PLUGIN_API_DIR="$TC_INSTALL_DIR/server/plugins/api"
+TC_SERVER_DIR=`cd $THIS_DIR;pwd`/..
+PLUGIN_LIB_DIR="$TC_SERVER_DIR/plugins/lib"
+PLUGIN_API_DIR="$TC_SERVER_DIR/plugins/api"
 
 if test \! -d "${JAVA_HOME}"; then
   echo "$0: the JAVA_HOME environment variable is not defined correctly"
@@ -65,7 +65,7 @@ function setPluginClasspath {
             done
 #  Adding SLF4j libraries to the classpath of the server to 
 #  support services that may use SLF4j for logging
-            for jarFile in "${TC_INSTALL_DIR}"/server/lib/slf4j*.jar
+            for jarFile in "${TC_SERVER_DIR}"/lib/slf4j*.jar
             do
                 PLUGIN_CLASSPATH=${PLUGIN_CLASSPATH}:${jarFile}
             done
@@ -87,10 +87,10 @@ do
 # the max heap is <= 2G, hence we set the heap size to a bit more than 2GB
 ${JAVA_COMMAND} -Xms256m -Xmx2049m -XX:+HeapDumpOnOutOfMemoryError \
    -Dcom.sun.management.jmxremote \
-   -Dtc.install-root="${TC_INSTALL_DIR}" \
+   -Dtc.install-root="${TC_SERVER_DIR}" \
    -Dsun.rmi.dgc.server.gcInterval=31536000000\
    ${JAVA_OPTS} \
-   -cp "${TC_INSTALL_DIR}/server/lib/tc.jar:${PLUGIN_CLASSPATH}" \
+   -cp "${TC_SERVER_DIR}/lib/tc.jar:${PLUGIN_CLASSPATH}" \
    com.tc.server.TCServerMain "$@"
  exitValue=$?
  start=false;


### PR DESCRIPTION
Move it to the server folder instead of the kit root. This allows
moving out server from a kit and use that as the set of files to copy
on different hosts.