### PR TITLE
Adapt tc config default port changes

### DIFF
--- a/dso-l1/src/main/java/com/tc/object/config/ConnectionInfoConfig.java
+++ b/dso-l1/src/main/java/com/tc/object/config/ConnectionInfoConfig.java
@@ -57,14 +57,14 @@ public class ConnectionInfoConfig {
       for (int i = 0; i < count; i++) {
         String[] serverDesc = serverDescs[i].split(":");
         String host = serverDesc.length > 0 ? serverDesc[0] : "localhost";
-        int tsaPort = 9510;
+        int tsaPort = 9410;
 
         if (serverDesc.length == 2) {
           try {
             tsaPort = Integer.parseInt(serverDesc[1]);
           } catch (NumberFormatException nfe) {
             consoleLogger.warn("Cannot parse port for tc.server element '" + serverDescs[i]
-                               + "'; Using default of 9510.");
+                               + "'; Using default of 9410.");
           }
         }
 

--- a/dso-l2/src/test/java/com/tc/config/PortBindAddressTest.java
+++ b/dso-l2/src/test/java/com/tc/config/PortBindAddressTest.java
@@ -23,6 +23,7 @@ import com.tc.config.schema.setup.StandardConfigurationSetupManagerFactory;
 import com.tc.test.TCTestCase;
 import com.tc.util.Assert;
 import org.apache.commons.io.IOUtils;
+import org.terracotta.config.TCConfigDefaults;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -75,8 +76,8 @@ public class PortBindAddressTest extends TCTestCase {
       configSetupMgr = factory.createL2TVSConfigurationSetupManager("server4", getClass().getClassLoader());
       Assert.assertEquals("1.2.3.4", configSetupMgr.dsoL2Config().tsaPort().getBind());
       Assert.assertEquals("1.2.3.4", configSetupMgr.dsoL2Config().tsaGroupPort().getBind());
-      Assert.assertEquals(9510, configSetupMgr.dsoL2Config().tsaPort().getValue());
-      Assert.assertEquals(9530, configSetupMgr.dsoL2Config().tsaGroupPort().getValue());
+      Assert.assertEquals(TCConfigDefaults.TSA_PORT, configSetupMgr.dsoL2Config().tsaPort().getValue());
+      Assert.assertEquals(TCConfigDefaults.GROUP_PORT, configSetupMgr.dsoL2Config().tsaGroupPort().getValue());
     } catch (Exception e) {
       throw new AssertionError(e);
     }

--- a/dso-l2/src/test/java/com/tc/config/schema/ConfigDefaultPortTest.java
+++ b/dso-l2/src/test/java/com/tc/config/schema/ConfigDefaultPortTest.java
@@ -24,6 +24,7 @@ import com.tc.object.config.schema.L2ConfigObject;
 import com.tc.test.TCTestCase;
 import com.tc.util.Assert;
 import org.apache.commons.io.IOUtils;
+import org.terracotta.config.TCConfigDefaults;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -82,8 +83,8 @@ public class ConfigDefaultPortTest extends TCTestCase {
 
       // case 4: all ports are default
       configSetupMgr = factory.createL2TVSConfigurationSetupManager("server4", getClass().getClassLoader());
-      Assert.assertEquals(9510, configSetupMgr.dsoL2Config().tsaPort().getValue());
-      Assert.assertEquals(9530, configSetupMgr.dsoL2Config().tsaGroupPort().getValue());
+      Assert.assertEquals(TCConfigDefaults.TSA_PORT, configSetupMgr.dsoL2Config().tsaPort().getValue());
+      Assert.assertEquals(TCConfigDefaults.GROUP_PORT, configSetupMgr.dsoL2Config().tsaGroupPort().getValue());
 
       // case 5: ports range overflow
       configSetupMgr = factory.createL2TVSConfigurationSetupManager("server5", getClass().getClassLoader());

--- a/dso-l2/src/test/java/com/tc/config/schema/setup/BaseConfigurationSetupManagerTest.java
+++ b/dso-l2/src/test/java/com/tc/config/schema/setup/BaseConfigurationSetupManagerTest.java
@@ -40,6 +40,8 @@ import com.tc.object.config.schema.L2ConfigObject;
 import com.tc.test.TCTestCase;
 import com.tc.text.StringUtils;
 import com.tc.util.Assert;
+
+import org.terracotta.config.TCConfigDefaults;
 import org.terracotta.config.TcConfiguration;
 
 import java.io.File;
@@ -74,14 +76,9 @@ public class BaseConfigurationSetupManagerTest extends TCTestCase {
     Assert.assertEquals("0.0.0.0", server.getBind());
     Assert.assertEquals(InetAddress.getLocalHost().getHostAddress() + ":" + server.getTsaPort().getValue(), server.getName());
 
-    Assert.assertEquals(9510, server.getTsaPort().getValue());
+    Assert.assertEquals(TCConfigDefaults.TSA_PORT, server.getTsaPort().getValue());
     Assert.assertEquals(server.getBind(), server.getTsaPort().getBind());
-
-    int tempGroupPort = 9510 + L2ConfigObject.DEFAULT_GROUPPORT_OFFSET_FROM_TSAPORT;
-    int defaultGroupPort = ((tempGroupPort <= L2ConfigObject.MAX_PORTNUMBER) ? (tempGroupPort)
-        : (tempGroupPort % L2ConfigObject.MAX_PORTNUMBER) + L2ConfigObject.MIN_PORTNUMBER);
-
-    Assert.assertEquals(defaultGroupPort, server.getTsaGroupPort().getValue());
+    Assert.assertEquals(TCConfigDefaults.GROUP_PORT, server.getTsaGroupPort().getValue());
     Assert.assertEquals(server.getBind(), server.getTsaGroupPort().getBind());
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <skip.deploy>false</skip.deploy>
 
     <terracotta-apis.version>1.3.0-pre6</terracotta-apis.version>
-    <terracotta-configuration.version>10.3.0-pre5</terracotta-configuration.version>
+    <terracotta-configuration.version>10.3.0-pre6</terracotta-configuration.version>
     <galvan.version>1.3.0-pre3</galvan.version>
   </properties>
 


### PR DESCRIPTION
Should follow https://github.com/Terracotta-OSS/terracotta-configuration/pull/58 merge 

Note that 

- there are still some tests which references 9510 port (or other default port numbers) but they are explicitly configured in the test xml or code. 
- ConnectionInfoConfig still uses hardcoded tsa port as dso-l1 doesn't depend on terracotta-configuration, would like discuss internally before adding that dependency
- ConnectionInfoConfig's code that references hardcoded tsa port looks like a dead code but we need this dependency change for Terracotta-OSS/terracotta-core#549