### PR TITLE
APIs Issue 227: Message Tracking support

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ClientDescriptorImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ClientDescriptorImpl.java
@@ -19,10 +19,9 @@
 package com.tc.objectserver.entity;
 
 import com.tc.net.ClientID;
-import org.terracotta.entity.ClientDescriptor;
-
 import com.tc.object.ClientInstanceID;
 import com.tc.util.Assert;
+import org.terracotta.entity.ClientDescriptor;
 
 /**
  * An opaque token representing a specific entity instance on a specific client node.
@@ -33,6 +32,7 @@ import com.tc.util.Assert;
  * client-side entity lives.
  */
 public class ClientDescriptorImpl implements ClientDescriptor {
+  public static ClientDescriptorImpl NULL_ID = new ClientDescriptorImpl(ClientID.NULL_ID, ClientInstanceID.NULL_ID);
   // The specific node where the referenced instance lives.
   private final ClientID nodeID;
   private final ClientInstanceID clientInstance;

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -22,22 +22,11 @@ import com.tc.exception.EntityBusyException;
 import com.tc.exception.EntityReferencedException;
 import com.tc.exception.TCServerRestartException;
 import com.tc.exception.TCShutdownServerException;
-import com.tc.exception.VoltronWrapperException;
 import com.tc.exception.VoltronEntityUserExceptionWrapper;
+import com.tc.exception.VoltronWrapperException;
 import com.tc.l2.msg.SyncReplicationActivity;
 import com.tc.logging.TCLogger;
 import com.tc.logging.TCLogging;
-
-import org.terracotta.entity.ActiveServerEntity;
-import org.terracotta.entity.CommonServerEntity;
-import org.terracotta.entity.EntityMessage;
-import org.terracotta.entity.MessageCodecException;
-import org.terracotta.entity.PassiveServerEntity;
-import org.terracotta.entity.PassiveSynchronizationChannel;
-import org.terracotta.entity.EntityServerService;
-import org.terracotta.entity.StateDumper;
-import org.terracotta.entity.SyncMessageCodec;
-
 import com.tc.net.ClientID;
 import com.tc.net.NodeID;
 import com.tc.object.ClientInstanceID;
@@ -46,6 +35,7 @@ import com.tc.object.EntityID;
 import com.tc.object.FetchID;
 import com.tc.object.tx.TransactionID;
 import com.tc.objectserver.api.ManagedEntity;
+import com.tc.objectserver.api.ManagementKeyCallback;
 import com.tc.objectserver.api.ServerEntityAction;
 import com.tc.objectserver.api.ServerEntityRequest;
 import com.tc.objectserver.core.api.ITopologyEventCollector;
@@ -55,30 +45,39 @@ import com.tc.properties.TCPropertiesConsts;
 import com.tc.properties.TCPropertiesImpl;
 import com.tc.services.InternalServiceRegistry;
 import com.tc.util.Assert;
+import com.tc.util.concurrent.SetOnceFlag;
+import org.terracotta.entity.ActiveServerEntity;
+import org.terracotta.entity.CommonServerEntity;
+import org.terracotta.entity.ConcurrencyStrategy;
+import org.terracotta.entity.ConfigurationException;
+import org.terracotta.entity.EntityMessage;
+import org.terracotta.entity.EntityResponse;
+import org.terracotta.entity.EntityServerService;
+import org.terracotta.entity.EntityUserException;
+import org.terracotta.entity.ExecutionStrategy;
+import org.terracotta.entity.MessageCodec;
+import org.terracotta.entity.MessageCodecException;
+import org.terracotta.entity.PassiveServerEntity;
+import org.terracotta.entity.PassiveSynchronizationChannel;
+import org.terracotta.entity.StateDumper;
+import org.terracotta.entity.SyncMessageCodec;
+import org.terracotta.exception.EntityAlreadyExistsException;
+import org.terracotta.exception.EntityConfigurationException;
+import org.terracotta.exception.EntityException;
+import org.terracotta.exception.EntityNotFoundException;
+import org.terracotta.exception.EntityServerUncaughtException;
+import org.terracotta.exception.PermanentEntityException;
+
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import org.terracotta.entity.ConcurrencyStrategy;
-import org.terracotta.entity.EntityResponse;
-import org.terracotta.entity.MessageCodec;
-import org.terracotta.exception.EntityAlreadyExistsException;
-import org.terracotta.exception.EntityException;
-import org.terracotta.exception.EntityNotFoundException;
-import org.terracotta.entity.EntityUserException;
 import java.util.function.Consumer;
-import java.util.concurrent.TimeUnit;
-import org.terracotta.entity.ConfigurationException;
-import org.terracotta.entity.ExecutionStrategy;
-import org.terracotta.exception.EntityConfigurationException;
-import org.terracotta.exception.EntityServerUncaughtException;
-import org.terracotta.exception.PermanentEntityException;
-import com.tc.objectserver.api.ManagementKeyCallback;
-import com.tc.util.concurrent.SetOnceFlag;
 
 
 public class ManagedEntityImpl implements ManagedEntity {
@@ -486,7 +485,7 @@ public class ManagedEntityImpl implements ManagedEntity {
             receiveSyncEntityKeyEnd(response, concurrencyKey);
             break;
           case RECEIVE_SYNC_PAYLOAD:
-            receiveSyncEntityPayload(response, message);
+            receiveSyncEntityPayload(request, response, message);
             break;
           case LOCAL_FLUSH:
           case LOCAL_FLUSH_AND_SYNC:
@@ -550,11 +549,20 @@ public class ManagedEntityImpl implements ManagedEntity {
     Assert.assertFalse(this.isInActiveState);
   }
 
-  private void receiveSyncEntityPayload(ResultCapture response, MessagePayload message) {
+  private void receiveSyncEntityPayload(ServerEntityRequest request, ResultCapture response, MessagePayload message) {
     // This only makes sense if we have a passive instance.
     Assert.assertNotNull(this.passiveServerEntity);
     try {
-      this.passiveServerEntity.invoke(message.decodeRawMessage(raw->syncCodec.decode(message.getConcurrency(), raw)));
+      ClientDescriptorImpl cdescr = new ClientDescriptorImpl(request.getNodeID(),
+                                                             request.getClientInstance());
+      long eldestId = request.getOldestTransactionOnClient().toLong();
+      long currentId = request.getTransaction().toLong();
+
+      this.passiveServerEntity.invokePassive(cdescr,
+                                             currentId,
+                                             eldestId,
+                                             message.decodeRawMessage(raw -> syncCodec.decode(message.getConcurrency(),
+                                                                                        raw)));
     } catch (EntityUserException e) {
       logger.error("Caught EntityUserException during sync invoke", e);
       throw new RuntimeException("Caught EntityUserException during sync invoke", e);
@@ -723,6 +731,10 @@ public class ManagedEntityImpl implements ManagedEntity {
   
   private void performAction(ServerEntityRequest wrappedRequest, ResultCapture response, MessagePayload message) {
     Assert.assertNotNull(message);
+    ClientDescriptorImpl clientDescriptor = new ClientDescriptorImpl(wrappedRequest.getNodeID(),
+                                                                     wrappedRequest.getClientInstance());
+    long currentId = wrappedRequest.getTransaction().toLong();
+    long oldestId = wrappedRequest.getOldestTransactionOnClient().toLong();
     EntityMessage em = message.decodeRawMessage(raw->this.codec.decodeMessage(raw));
     if (this.isInActiveState) {
       if (null == this.activeServerEntity) {
@@ -733,7 +745,7 @@ public class ManagedEntityImpl implements ManagedEntity {
           this.retirementManager.registerWithMessage(em, concurrencyKey);
           ExecutionStrategy.Location loc = this.executionStrategy.getExecutionLocation(em);
           if (loc.runOnActive()) {
-            EntityResponse resp = this.activeServerEntity.invoke(new ClientDescriptorImpl(wrappedRequest.getNodeID(), wrappedRequest.getClientInstance()), em);
+            EntityResponse resp = this.activeServerEntity.invokeActive(clientDescriptor, currentId, oldestId, em);
             byte[] er = runWithHelper(()->codec.encodeResponse(resp));
             response.complete(er);
           } else {
@@ -750,7 +762,7 @@ public class ManagedEntityImpl implements ManagedEntity {
         throw new IllegalStateException("Actions on a non-existent entity.");
       } else {
         try {
-          this.passiveServerEntity.invoke(em);
+          this.passiveServerEntity.invokePassive(clientDescriptor, currentId, oldestId, em);
         } catch (EntityUserException e) {
           //on passives, just log the exception - don't crash server
           logger.error("Caught EntityUserException during invoke", e);
@@ -819,18 +831,20 @@ public class ManagedEntityImpl implements ManagedEntity {
         clientReferenceCount -= 1;
         Assert.assertTrue(clientReferenceCount >= 0);
       }
-      if (this.isInActiveState) {
-        // The RELEASE can only come directly from a client so we can down-cast.
-        ClientID clientID = (ClientID) request.getNodeID();
 
-        ClientDescriptorImpl clientInstance = new ClientDescriptorImpl(clientID, request.getClientInstance());
+      ClientID clientID = (ClientID) request.getNodeID();
+      ClientDescriptorImpl clientInstance = new ClientDescriptorImpl(clientID, request.getClientInstance());
+
+      if (this.isInActiveState) {
 
         boolean removed = clientEntityStateManager.removeReference(clientInstance);
         Assert.assertTrue(removed);
-        
+
         this.activeServerEntity.disconnected(clientInstance);
         // Fire the event that the client released the entity.
         this.eventCollector.clientDidReleaseEntity(clientID, this.id, request.getClientInstance());
+      } else {
+        this.passiveServerEntity.notifyClientDisconnectedFromActive(clientInstance);
       }
       response.complete();
     }
@@ -998,7 +1012,7 @@ public class ManagedEntityImpl implements ManagedEntity {
 
     @Override
     public ClientInstanceID getClientInstance() {
-      return null;
+      return ClientInstanceID.NULL_ID;
     }
 
     @Override

--- a/dso-l2/src/main/java/com/tc/services/TerracottaServiceProviderRegistryImpl.java
+++ b/dso-l2/src/main/java/com/tc/services/TerracottaServiceProviderRegistryImpl.java
@@ -173,4 +173,5 @@ public class TerracottaServiceProviderRegistryImpl implements TerracottaServiceP
     out.println(dump);
     return out;
   }
+
 }

--- a/dso-l2/src/test/java/com/tc/objectserver/testentity/TestEntityServer.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/testentity/TestEntityServer.java
@@ -22,6 +22,7 @@ import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.entity.EntityMessage;
 import org.terracotta.entity.EntityResponse;
 import org.terracotta.entity.ActiveServerEntity;
+import org.terracotta.entity.EntityUserException;
 import org.terracotta.entity.PassiveSynchronizationChannel;
 import org.terracotta.entity.StateDumper;
 
@@ -40,9 +41,12 @@ public class TestEntityServer implements ActiveServerEntity<EntityMessage, Entit
   @Override
   public void disconnected(ClientDescriptor clientDescriptor) {
   }
-  
+
   @Override
-  public EntityResponse invoke(ClientDescriptor clientDescriptor, EntityMessage message) {
+  public EntityResponse invokeActive(ClientDescriptor clientDescriptor,
+                               long currentOrderedId,
+                               long eldestOrderedId,
+                               EntityMessage message) throws EntityUserException {
     return null;
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
     <tc-shader.version>1.2</tc-shader.version>
     <skip.deploy>false</skip.deploy>
 
-    <terracotta-apis.version>1.3.0-pre6</terracotta-apis.version>
-    <terracotta-configuration.version>10.3.0-pre6</terracotta-configuration.version>
+    <terracotta-apis.version>1.3-SNAPSHOT</terracotta-apis.version>
+    <terracotta-configuration.version>10.3-SNAPSHOT</terracotta-configuration.version>
     <galvan.version>1.3.0-pre3</galvan.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
     <tc-shader.version>1.2</tc-shader.version>
     <skip.deploy>false</skip.deploy>
 
-    <terracotta-apis.version>1.3-SNAPSHOT</terracotta-apis.version>
-    <terracotta-configuration.version>10.3-SNAPSHOT</terracotta-configuration.version>
+    <terracotta-apis.version>1.3.0-pre7</terracotta-apis.version>
+    <terracotta-configuration.version>10.3.0-pre7</terracotta-configuration.version>
     <galvan.version>1.3.0-pre3</galvan.version>
   </properties>
 


### PR DESCRIPTION
Implementation to allow an entity, passive or active, to track
messages. Both active and passive invoke methods now supply
ClientDescriptor and current/oldest transaction id's, as well as
message.

invoke() became invokeActive(0 and invokePassive(), to differentiate
between the active and passive code paths.