### PR TITLE
Connection refactor

### DIFF
--- a/common/src/main/java/com/tc/net/ReconnectionRejectedException.java
+++ b/common/src/main/java/com/tc/net/ReconnectionRejectedException.java
@@ -23,4 +23,8 @@ public class ReconnectionRejectedException extends Exception {
   public ReconnectionRejectedException(String msg) {
     super(msg);
   }
+
+  public ReconnectionRejectedException(Throwable cause) {
+    super(cause);
+  }
 }

--- a/common/src/main/java/com/tc/net/protocol/ProductNotSupportedException.java
+++ b/common/src/main/java/com/tc/net/protocol/ProductNotSupportedException.java
@@ -16,22 +16,16 @@
  *  Terracotta, Inc., a Software AG company
  *
  */
-package com.tc.net.protocol.transport;
+package com.tc.net.protocol;
 
-public interface SynAckMessage extends TransportHandshakeMessage {
+import com.tc.net.TCSocketAddress;
 
-  public String getErrorContext();
+/**
+ * Thrown by Stack providers when a connecting product is not supported by the server
+ */
+public class ProductNotSupportedException extends Exception {
 
-  public TransportHandshakeError getErrorType();
-
-  public boolean hasErrorContext();
-
-  @Override
-  public boolean isMaxConnectionsExceeded();
-
-  int getCallbackPort();
-
-  @Override
-  public int getMaxConnections();
-
+  public ProductNotSupportedException(String reason) {
+    super(reason);
+  }
 }

--- a/common/src/main/java/com/tc/net/protocol/tcm/CommunicationsManager.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/CommunicationsManager.java
@@ -19,12 +19,11 @@
 package com.tc.net.protocol.tcm;
 
 import com.tc.net.TCSocketAddress;
-import com.tc.net.core.ConnectionInfo;
 import com.tc.net.core.TCConnectionManager;
 import com.tc.net.protocol.transport.ConnectionIDFactory;
 import com.tc.object.session.SessionProvider;
 import com.tc.operatorevent.NodeNameProvider;
-import java.util.Collection;
+import com.tc.util.ProductID;
 
 /**
  * CommsMgr provides Listener and Channel endpoints for exchanging <code>TCMessage</code> type messages
@@ -48,15 +47,11 @@ public interface CommunicationsManager {
   /**
    * Creates a client message channel to the given host/port.
    * 
-   * @param maxReconnectTries The number of times the channel will attempt to reestablish communications with the server
-   *        if the connection is lost. If n==0, the channel will not attempt to reestablish communications. If n>0, the
-   *        channel will attempt to reestablish communications n times. If n<0 the channel will always try to
-   *        reestablish communications.
    * @param timeout The maximum time (in milliseconds) to wait for the underlying connection to be established before
    *        giving up.
    */
 
-  public ClientMessageChannel createClientChannel(SessionProvider provider, int maxReconnectTries, int timeout, boolean followRedirects);
+  public ClientMessageChannel createClientChannel(ProductID product, SessionProvider provider, int timeout);
     
   public NetworkListener createListener(TCSocketAddress addr, boolean transportDisconnectRemovesChannel, 
                                         ConnectionIDFactory connectionIdFactory);

--- a/common/src/main/java/com/tc/net/protocol/tcm/CommunicationsManagerImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/CommunicationsManagerImpl.java
@@ -100,7 +100,6 @@ public class CommunicationsManagerImpl implements CommunicationsManager {
   private final HealthCheckerConfig                                            healthCheckerConfig;
   private final ConnectionPolicy                                               connectionPolicy;
   private final ReconnectionRejectedHandler                                    reconnectionRejectedHandler;
-  protected final ProductID                                                    productId;
   protected final ConcurrentHashMap<TCMessageType, Class<? extends TCMessage>> messageTypeClassMapping   = new ConcurrentHashMap<TCMessageType, Class<? extends TCMessage>>();
   protected final ConcurrentHashMap<TCMessageType, GeneratedMessageFactory>    messageTypeFactoryMapping = new ConcurrentHashMap<TCMessageType, GeneratedMessageFactory>();
 
@@ -157,7 +156,7 @@ public class CommunicationsManagerImpl implements CommunicationsManager {
                                    TCSecurityManager securityManager) {
     this(commsMgrName, monitor, messageRouter, stackHarnessFactory, null, connectionPolicy, workerCommCount, config,
          transportHandshakeErrorHandler, messageTypeClassMapping, ReconnectionRejectedHandlerL2.SINGLETON,
-         securityManager, null);
+         securityManager);
     this.serverID = serverID;
   }
 
@@ -171,7 +170,7 @@ public class CommunicationsManagerImpl implements CommunicationsManager {
                                    TCSecurityManager securityManager) {
     this(commsMgrName, monitor, messageRouter, stackHarnessFactory, connMgr, connectionPolicy, workerCommCount,
          healthCheckerConf, transportHandshakeErrorHandler, messageTypeClassMapping,
-         ReconnectionRejectedHandlerL1.SINGLETON, securityManager, null);
+         ReconnectionRejectedHandlerL1.SINGLETON, securityManager);
   }
 
   /**
@@ -188,11 +187,10 @@ public class CommunicationsManagerImpl implements CommunicationsManager {
                                    TransportHandshakeErrorHandler transportHandshakeErrorHandler,
                                    Map<TCMessageType, Class<? extends TCMessage>> messageTypeClassMapping,
                                    ReconnectionRejectedHandler reconnectionRejectedHandler,
-                                   TCSecurityManager securityManager, ProductID productId) {
+                                   TCSecurityManager securityManager) {
     this.commsMgrName = commsMgrName;
     this.monitor = monitor;
     this.messageRouter = messageRouter;
-    this.productId = productId;
     this.transportMessageFactory = new TransportMessageFactoryImpl();
     this.connectionPolicy = connectionPolicy;
     this.stackHarnessFactory = stackHarnessFactory;
@@ -257,12 +255,12 @@ public class CommunicationsManagerImpl implements CommunicationsManager {
   }
 
   @Override
-  public ClientMessageChannel createClientChannel(SessionProvider sessions, int maxReconnectTries, int timeout, boolean followRedirects) {
-    return createClientChannel(sessions, maxReconnectTries, timeout, followRedirects, null, null);
+  public ClientMessageChannel createClientChannel(ProductID productId, SessionProvider sessions, int timeout) {
+    return createClientChannel(productId, sessions, timeout, null, null);
   }
   
-  public ClientMessageChannel createClientChannel(SessionProvider sessions, int maxReconnectTries,
-                                                  int timeout, boolean followRedirects, 
+  public ClientMessageChannel createClientChannel(ProductID productId, SessionProvider sessions, 
+                                                  int timeout, 
                                                   MessageTransportFactory transportFactory,
                                                   TCMessageFactory messageFactory) {
 
@@ -286,8 +284,8 @@ public class CommunicationsManagerImpl implements CommunicationsManager {
     if (transportFactory == null) transportFactory = new MessageTransportFactoryImpl(transportMessageFactory,
                                                                                      connectionHealthChecker,
                                                                                      connectionManager,
-                                                                                     maxReconnectTries, timeout,
-                                                                                     callbackPort, followRedirects, handshakeErrHandler,
+                                                                                     timeout,
+                                                                                     callbackPort, handshakeErrHandler,
                                                                                      reconnectionRejectedHandler,
                                                                                      securityManager);
     NetworkStackHarness stackHarness = this.stackHarnessFactory.createClientHarness(transportFactory, rv,

--- a/common/src/main/java/com/tc/net/protocol/tcm/MessageTransportFactoryImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/MessageTransportFactoryImpl.java
@@ -40,10 +40,8 @@ public class MessageTransportFactoryImpl implements MessageTransportFactory {
   private final TransportHandshakeMessageFactory transportMessageFactory;
   private final ConnectionHealthChecker          connectionHealthChecker;
   private final TCConnectionManager              connectionMgr;
-  private final int                              maxReconnectTries;
   private final int                              timeout;
   private final int                              callbackport;
-  private final boolean                          followRedirects;
   private final TransportHandshakeErrorHandler   defaultHandshakeErrorHandler;
   private final ReconnectionRejectedHandler      reconnectionRejectedHandler;
   private final TCSecurityManager                securityManager;
@@ -51,18 +49,15 @@ public class MessageTransportFactoryImpl implements MessageTransportFactory {
   public MessageTransportFactoryImpl(TransportHandshakeMessageFactory transportMessageFactory,
                                      ConnectionHealthChecker connectionHealthChecker,
                                      TCConnectionManager connectionManager,
-                                     int maxReconnectTries,
-                                     int timeout, int callbackPort, boolean follow,
+                                     int timeout, int callbackPort, 
                                      TransportHandshakeErrorHandler defaultHandshakeErrorHandler,
                                      ReconnectionRejectedHandler reconnectionRejectedBehaviour,
                                      TCSecurityManager securityManager) {
     this.transportMessageFactory = transportMessageFactory;
     this.connectionHealthChecker = connectionHealthChecker;
     this.connectionMgr = connectionManager;
-    this.maxReconnectTries = maxReconnectTries;
     this.timeout = timeout;
     this.callbackport = callbackPort;
-    this.followRedirects = follow;
     this.defaultHandshakeErrorHandler = defaultHandshakeErrorHandler;
     this.reconnectionRejectedHandler = reconnectionRejectedBehaviour;
     this.securityManager = securityManager;
@@ -70,8 +65,7 @@ public class MessageTransportFactoryImpl implements MessageTransportFactory {
   
   @Override
   public ClientConnectionEstablisher createClientConnectionEstablisher() {
-    ClientConnectionEstablisher clientConnectionEstablisher = new ClientConnectionEstablisher(maxReconnectTries,
-                                                                                              reconnectionRejectedHandler);
+    ClientConnectionEstablisher clientConnectionEstablisher = new ClientConnectionEstablisher(reconnectionRejectedHandler);
     return clientConnectionEstablisher;
   }
 
@@ -79,7 +73,7 @@ public class MessageTransportFactoryImpl implements MessageTransportFactory {
   public ClientMessageTransport createNewTransport() {
     ClientMessageTransport cmt = createClientMessageTransport(
                                                               defaultHandshakeErrorHandler, transportMessageFactory,
-                                                              new WireProtocolAdaptorFactoryImpl(), callbackport, this.followRedirects);
+                                                              new WireProtocolAdaptorFactoryImpl(), callbackport);
     cmt.addTransportListener(connectionHealthChecker);
     return cmt;
   }
@@ -87,9 +81,9 @@ public class MessageTransportFactoryImpl implements MessageTransportFactory {
   protected ClientMessageTransport createClientMessageTransport(TransportHandshakeErrorHandler handshakeErrorHandler,
                                                                 TransportHandshakeMessageFactory messageFactory,
                                                                 WireProtocolAdaptorFactory wireProtocolAdaptorFactory,
-                                                                int callbackPortNum, boolean followRedirects) {
+                                                                int callbackPortNum) {
     return new ClientMessageTransport(this.connectionMgr, handshakeErrorHandler, transportMessageFactory,
-                                      wireProtocolAdaptorFactory, callbackPortNum, this.timeout, followRedirects, reconnectionRejectedHandler, securityManager);
+                                      wireProtocolAdaptorFactory, callbackPortNum, this.timeout, reconnectionRejectedHandler, securityManager);
   }
 
   @Override

--- a/common/src/main/java/com/tc/net/protocol/transport/ClientMessageTransport.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ClientMessageTransport.java
@@ -18,7 +18,6 @@
  */
 package com.tc.net.protocol.transport;
 
-import com.tc.exception.TCInternalError;
 import com.tc.exception.TCRuntimeException;
 import com.tc.logging.ConnectionIdLogger;
 import com.tc.logging.TCLogging;
@@ -179,30 +178,31 @@ public class ClientMessageTransport extends MessageTransportBase {
   private void handleHandshakeError(HandshakeResult result) throws TransportHandshakeException, MaxConnectionsExceededException,
       CommStackMismatchException, ReconnectionRejectedException {
     if (result.hasErrorContext()) {
-      switch (result.getErrorType()) {
-        case TransportHandshakeError.ERROR_NONE:
+      switch (result.getError()) {
+        case ERROR_NO_ACTIVE:
           if (this.followRedirects) {
             throw new NoActiveException();
           }
           break;
-        case TransportHandshakeError.ERROR_MAX_CONNECTION_EXCEED:
+        case ERROR_MAX_CONNECTION_EXCEED:
           cleanConnectionWithoutNotifyListeners();
           throw new MaxConnectionsExceededException(getMaxConnectionsExceededMessage(result.maxConnections()));
-        case TransportHandshakeError.ERROR_STACK_MISMATCH:
+        case ERROR_STACK_MISMATCH:
           cleanConnectionWithoutNotifyListeners();
           throw new CommStackMismatchException("Disconnected due to comm stack mismatch");
-        case TransportHandshakeError.ERROR_RECONNECTION_REJECTED:
+        case ERROR_RECONNECTION_REJECTED:
           cleanConnectionWithoutNotifyListeners();
           fireTransportReconnectionRejectedEvent();
           throw new ReconnectionRejectedException(
                                                   "Reconnection rejected by L2 due to stack not found. Client will be unable to join the cluster again unless rejoin is enabled.");
-        case TransportHandshakeError.ERROR_REDIRECT_CONNECTION:
+        case ERROR_REDIRECT_CONNECTION:
           if (this.followRedirects) {
             throw new TransportRedirect(result.synAck.getErrorContext());
           }
           break;
+        case ERROR_PRODUCT_NOT_SUPPORTED:
         default:
-          throw new TransportHandshakeException("Disconnected due to transport handshake error");
+          throw new TransportHandshakeException("Disconnected due to transport handshake error: " + result.getError());
       }
     }
   }
@@ -477,7 +477,7 @@ public class ClientMessageTransport extends MessageTransportBase {
       return synAck.getConnectionId().isValid();
     }
 
-    public short getErrorType() {
+    public TransportHandshakeError getError() {
       if (this.synAck.isMaxConnectionsExceeded()) {
         return TransportHandshakeError.ERROR_MAX_CONNECTION_EXCEED;
       } else {

--- a/common/src/main/java/com/tc/net/protocol/transport/DefaultConnectionIdFactory.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/DefaultConnectionIdFactory.java
@@ -21,6 +21,7 @@ package com.tc.net.protocol.transport;
 import com.tc.net.ClientID;
 import com.tc.net.StripeID;
 import com.tc.net.protocol.tcm.ChannelID;
+import com.tc.util.ProductID;
 import com.tc.util.UUID;
 
 
@@ -33,18 +34,18 @@ public class DefaultConnectionIdFactory implements ConnectionIDFactory {
   @Override
   public ConnectionID populateConnectionID(ConnectionID connectionID) {
     if (new ChannelID(connectionID.getChannelID()).isNull()) {
-      return nextConnectionId(connectionID.getJvmID());
+      return nextConnectionId(connectionID.getJvmID(), connectionID.getProductId());
     } else {
-      return makeConnectionId(connectionID.getJvmID(), connectionID.getChannelID());
+      return makeConnectionId(connectionID.getJvmID(), connectionID.getChannelID(), connectionID.getProductId());
     }
   }
 
-  private synchronized ConnectionID nextConnectionId(String clientJvmID) {
-    return new ConnectionID(clientJvmID, sequence++, serverID);
+  private synchronized ConnectionID nextConnectionId(String clientJvmID, ProductID product) {
+    return new ConnectionID(clientJvmID, sequence++, serverID, null, null, product);
   }
 
-  private ConnectionID makeConnectionId(String clientJvmID, long channelID) {
-    return new ConnectionID(clientJvmID, channelID, serverID);
+  private ConnectionID makeConnectionId(String clientJvmID, long channelID, ProductID product) {
+    return new ConnectionID(clientJvmID, channelID, serverID, null, null, product);
   }
 
   @Override

--- a/common/src/main/java/com/tc/net/protocol/transport/NetworkStackProvider.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/NetworkStackProvider.java
@@ -19,6 +19,7 @@
 package com.tc.net.protocol.transport;
 
 import com.tc.net.core.TCConnection;
+import com.tc.net.protocol.ProductNotSupportedException;
 import com.tc.net.protocol.RejectReconnectionException;
 
 /**
@@ -30,6 +31,6 @@ public interface NetworkStackProvider {
    * Takes a new connection and a connectionId. Returns the MessageTransport associated with that id.
    */
   public MessageTransport attachNewConnection(ConnectionID connectionId, TCConnection connection)
-      throws RejectReconnectionException;
+      throws RejectReconnectionException, ProductNotSupportedException;
 
 }

--- a/common/src/main/java/com/tc/net/protocol/transport/NullConnectionIDFactoryImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/NullConnectionIDFactoryImpl.java
@@ -39,7 +39,7 @@ public class NullConnectionIDFactoryImpl implements ConnectionIDFactory {
   @Override
   public ConnectionID populateConnectionID(ConnectionID connectionID) {
 // only assign invalid IDs as these connections are not real
-    ConnectionID connection = new ConnectionID(connectionID.getJvmID(), cid.decrementAndGet());
+    ConnectionID connection = new ConnectionID(connectionID.getJvmID(), cid.decrementAndGet(), null, null, connectionID.getProductId());
     Assert.assertTrue(!connection.isValid());
     return connection;
   }

--- a/common/src/main/java/com/tc/net/protocol/transport/ServerStackProvider.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ServerStackProvider.java
@@ -36,6 +36,7 @@ import com.tc.net.protocol.tcm.ServerMessageChannelFactory;
 import com.tc.net.protocol.tcm.msgs.CommsMessageFactory;
 import com.tc.operatorevent.NodeNameProvider;
 import com.tc.util.Assert;
+import com.tc.util.ProductID;
 import java.io.IOException;
 
 import java.security.Principal;
@@ -114,7 +115,7 @@ public class ServerStackProvider implements NetworkStackProvider, MessageTranspo
 
   @Override
   public MessageTransport attachNewConnection(ConnectionID connectionId, TCConnection connection)
-      throws RejectReconnectionException {
+      throws RejectReconnectionException, ProductNotSupportedException {
     Assert.assertNotNull(connection);
 
     final NetworkStackHarness harness;
@@ -122,6 +123,10 @@ public class ServerStackProvider implements NetworkStackProvider, MessageTranspo
     ConnectionID ourConnectionId;
     if (this.activeProvider != null || connectionId.isNewConnection()) {
       ourConnectionId = connectionIdFactory.populateConnectionID(connectionId);
+      
+      if (ourConnectionId == ConnectionID.NULL_ID) {
+        throw new ProductNotSupportedException(connectionId.getProductId() + " not supported");
+      }
 
       rv = messageTransportFactory.createNewTransport(ourConnectionId, connection, createHandshakeErrorHandler(),
           handshakeMessageFactory, transportListeners);

--- a/common/src/main/java/com/tc/net/protocol/transport/ServerStackProvider.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ServerStackProvider.java
@@ -27,6 +27,7 @@ import com.tc.net.protocol.IllegalReconnectException;
 import com.tc.net.protocol.NetworkLayer;
 import com.tc.net.protocol.NetworkStackHarness;
 import com.tc.net.protocol.NetworkStackHarnessFactory;
+import com.tc.net.protocol.ProductNotSupportedException;
 import com.tc.net.protocol.ProtocolAdaptorFactory;
 import com.tc.net.protocol.RejectReconnectionException;
 import com.tc.net.protocol.TCProtocolAdaptor;
@@ -278,12 +279,24 @@ public class ServerStackProvider implements NetworkStackProvider, MessageTranspo
                                                                       ((SynMessage) message).getSource(),
                                                                       createHandshakeErrorHandler(),
                                                                       handshakeMessageFactory, transportListeners);
-          sendSynAck(((SynMessage) message).getConnectionId(),
-                     new TransportHandshakeErrorContext(errorMessage,
-                                                        TransportHandshakeError.ERROR_RECONNECTION_REJECTED),
-                     ((SynMessage) message).getSource(), false);
+          TransportHandshakeErrorContext cxt = new TransportHandshakeErrorContext(errorMessage,
+                                                        TransportHandshakeError.ERROR_RECONNECTION_REJECTED);
+          sendSynAck(((SynMessage) message).getConnectionId(), cxt, ((SynMessage) message).getSource(), false);
 
           handleHandshakeError(new TransportHandshakeErrorContext(errorMessage, e));
+        } catch (ProductNotSupportedException product) {
+          // send connection rejected SycAck back to L1
+          // since stack no found, create a temp transport for sending sycAck message back
+          this.transport = messageTransportFactory.createNewTransport(((SynMessage) message).getConnectionId(),
+                                                                      ((SynMessage) message).getSource(),
+                                                                      createHandshakeErrorHandler(),
+                                                                      handshakeMessageFactory, transportListeners);
+          TransportHandshakeErrorContext cxt = new TransportHandshakeErrorContext(product.getMessage(),
+                                                        TransportHandshakeError.ERROR_PRODUCT_NOT_SUPPORTED);
+          sendSynAck(((SynMessage) message).getConnectionId(), cxt,
+                     ((SynMessage) message).getSource(), false);
+
+          handleHandshakeError(cxt);
         }
       }
       return isSynced;
@@ -294,7 +307,7 @@ public class ServerStackProvider implements NetworkStackProvider, MessageTranspo
       this.handshakeErrorHandler.handleHandshakeError(ctxt);
     }
 
-    private void handleSyn(SynMessage syn) throws RejectReconnectionException {
+    private void handleSyn(SynMessage syn) throws RejectReconnectionException, ProductNotSupportedException {
       ConnectionID connectionId = syn.getConnectionId();
       boolean isMaxConnectionReached = false;
 
@@ -327,11 +340,12 @@ public class ServerStackProvider implements NetworkStackProvider, MessageTranspo
           // Update the connection ID with the new channel id and server id from server
           connectionId = new ConnectionID(sentConnectionId.getJvmID(), transportConnectionId.getChannelID(),
               transportConnectionId.getServerID(), sentConnectionId.getUsername(), sentConnectionId.getPassword(),
-              sentConnectionId.getProductId());
+              transportConnectionId.getProductId());
           // populate the jvmid on the server copy of the connection id if it's null
           if (transportConnectionId.isJvmIDNull()) {
             transport.initConnectionID(new ConnectionID(sentConnectionId.getJvmID(), connectionId.getChannelID(),
-                connectionId.getServerID()));
+              connectionId.getServerID(), sentConnectionId.getUsername(), sentConnectionId.getPassword(),
+              transportConnectionId.getProductId()));
           }
           isMaxConnectionReached = !connectionPolicy.connectClient(connectionId);
         }
@@ -402,15 +416,15 @@ public class ServerStackProvider implements NetworkStackProvider, MessageTranspo
       boolean isError = (errorContext != null);
       int maxConnections = connectionPolicy.getMaxConnections();
       if (isError) {
-        synAck = handshakeMessageFactory.createSynAck(connectionId, errorContext, source, isMaxConnectionsReached,
+        synAck = handshakeMessageFactory.createSynAck(connectionId, errorContext.getErrorType(), errorContext.getMessage(), source, isMaxConnectionsReached,
                                                       maxConnections);
       } else if (activeProvider != null) {
         String active = activeProvider.getNodeName();
         if (active != null) {
-          synAck = handshakeMessageFactory.createSynAck(connectionId, new TransportRedirect(active), 
+          synAck = handshakeMessageFactory.createSynAck(connectionId, TransportHandshakeError.ERROR_REDIRECT_CONNECTION, active,
                 source, isMaxConnectionsReached, maxConnections);
         } else {
-          synAck = handshakeMessageFactory.createSynAck(connectionId, new TransportHandshakeErrorContext("no active", errorContext.ERROR_NONE), 
+          synAck = handshakeMessageFactory.createSynAck(connectionId, TransportHandshakeError.ERROR_NO_ACTIVE, "no active", 
                 source, isMaxConnectionsReached, maxConnections);
         }
       } else {

--- a/common/src/main/java/com/tc/net/protocol/transport/TransportHandshakeErrorContext.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/TransportHandshakeErrorContext.java
@@ -18,34 +18,37 @@
  */
 package com.tc.net.protocol.transport;
 
-public class TransportHandshakeErrorContext implements TransportHandshakeError {
+public class TransportHandshakeErrorContext {
   private String    message;
-  private short     errorType;
+  private TransportHandshakeError     errorType;
   private Throwable throwable;
 
   public TransportHandshakeErrorContext(String message) {
     this.message = message;
-    this.errorType = ERROR_GENERIC;
+    this.errorType = TransportHandshakeError.ERROR_GENERIC;
   }
 
   public TransportHandshakeErrorContext(String message, Throwable throwable) {
     this(message);
-    this.errorType = ERROR_GENERIC;
+    this.errorType = TransportHandshakeError.ERROR_GENERIC;
     this.throwable = throwable;
   }
 
-  public TransportHandshakeErrorContext(String message, short errorType) {
+  public TransportHandshakeErrorContext(String message, TransportHandshakeError errorType) {
     this(message);
     this.errorType = errorType;
   }
 
-  @Override
+  public TransportHandshakeErrorContext(String message, short errorType) {
+    this(message);
+    this.errorType = TransportHandshakeError.values()[errorType];
+  }
+  
   public String getMessage() {
     return message;
   }
-
-  @Override
-  public short getErrorType() {
+  
+  public TransportHandshakeError getErrorType() {
     return errorType;
   }
 

--- a/common/src/main/java/com/tc/net/protocol/transport/TransportHandshakeErrorHandlerForL1.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/TransportHandshakeErrorHandlerForL1.java
@@ -37,6 +37,8 @@ public class TransportHandshakeErrorHandlerForL1 implements TransportHandshakeEr
       //  don't log these, not real errors
     } else if (e.getErrorType() == TransportHandshakeError.ERROR_REDIRECT_CONNECTION) {
       //  don't log these, not real errors
+    } else if (e.getErrorType() == TransportHandshakeError.ERROR_NO_ACTIVE) {
+      //  don't log these, not real errors
     } else {
       consoleLogger.error(e);
     }
@@ -49,11 +51,12 @@ public class TransportHandshakeErrorHandlerForL1 implements TransportHandshakeEr
      */
 
     switch (e.getErrorType()) {
-      case TransportHandshakeError.ERROR_STACK_MISMATCH:
-      case TransportHandshakeError.ERROR_MAX_CONNECTION_EXCEED:
-      case TransportHandshakeError.ERROR_RECONNECTION_REJECTED:
-      case TransportHandshakeError.ERROR_REDIRECT_CONNECTION:
-      case TransportHandshakeError.ERROR_NONE:
+      case ERROR_STACK_MISMATCH:
+      case ERROR_MAX_CONNECTION_EXCEED:
+      case ERROR_RECONNECTION_REJECTED:
+      case ERROR_REDIRECT_CONNECTION:
+      case ERROR_NO_ACTIVE:
+      case ERROR_NONE:
         // no sleep;
         break;
       default:
@@ -61,8 +64,9 @@ public class TransportHandshakeErrorHandlerForL1 implements TransportHandshakeEr
     }
 
     switch (e.getErrorType()) {
-      case TransportHandshakeError.ERROR_STACK_MISMATCH:
-      case TransportHandshakeError.ERROR_MAX_CONNECTION_EXCEED:
+      case ERROR_STACK_MISMATCH:
+      case ERROR_MAX_CONNECTION_EXCEED:
+      case ERROR_PRODUCT_NOT_SUPPORTED:
         consoleLogger.error("Crashing the client due to handshake errors.");
         break;
       default:

--- a/common/src/main/java/com/tc/net/protocol/transport/TransportRedirect.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/TransportRedirect.java
@@ -18,9 +18,9 @@
  */
 package com.tc.net.protocol.transport;
 
-public class TransportRedirect extends TransportHandshakeException implements TransportHandshakeError {
+public class TransportRedirect extends TransportHandshakeException {
   private final String    hostname;
-  private final short     errorType;
+  private final TransportHandshakeError     errorType;
   private final int port;
 
   public TransportRedirect(String activeHost) {
@@ -28,11 +28,10 @@ public class TransportRedirect extends TransportHandshakeException implements Tr
     int index = activeHost.indexOf(':');
     hostname = activeHost.substring(0, index);
     port = Integer.parseInt(activeHost.substring(index + 1));          
-    this.errorType = ERROR_REDIRECT_CONNECTION;
+    this.errorType = TransportHandshakeError.ERROR_REDIRECT_CONNECTION;
   }
 
-  @Override
-  public short getErrorType() {
+  public TransportHandshakeError getErrorType() {
     return errorType;
   }
 

--- a/common/src/test/java/com/tc/net/core/NoReconnectThreadTest.java
+++ b/common/src/test/java/com/tc/net/core/NoReconnectThreadTest.java
@@ -53,6 +53,7 @@ import com.tc.util.PortChooser;
 import com.tc.util.concurrent.ThreadUtil;
 import com.tc.util.runtime.ThreadDumpUtil;
 import com.tc.properties.TCPropertiesConsts;
+import com.tc.util.ProductID;
 
 import java.net.InetAddress;
 import java.util.Collections;
@@ -95,9 +96,8 @@ public class NoReconnectThreadTest extends TCTestCase implements ChannelEventLis
                                                                       getNetworkStackHarnessFactory(ooo),
                                                                       new NullConnectionPolicy());
     ClientMessageChannel clientMsgCh = clientComms
-        .createClientChannel(new NullSessionManager(),
-                             0,
-                             1000, true);
+        .createClientChannel(ProductID.SERVER, new NullSessionManager(),
+                             1000);
     return clientMsgCh;
   }
 

--- a/common/src/test/java/com/tc/net/core/OOOReconnectTimeoutTest.java
+++ b/common/src/test/java/com/tc/net/core/OOOReconnectTimeoutTest.java
@@ -50,6 +50,7 @@ import com.tc.util.PortChooser;
 import com.tc.util.concurrent.ThreadUtil;
 import com.tc.util.runtime.ThreadDumpUtil;
 import com.tc.properties.TCPropertiesConsts;
+import com.tc.util.ProductID;
 
 import java.net.InetAddress;
 import java.util.Collections;
@@ -74,9 +75,8 @@ public class OOOReconnectTimeoutTest extends TCTestCase {
                                                                       new NullConnectionPolicy());
 
     ClientMessageChannel clientMsgCh = clientComms
-        .createClientChannel(new NullSessionManager(),
-                             -1,
-                             1000, true);
+        .createClientChannel(ProductID.STRIPE, new NullSessionManager(),
+                             1000);
     return clientMsgCh;
   }
 

--- a/common/src/test/java/com/tc/net/core/TCWorkerCommManagerTest.java
+++ b/common/src/test/java/com/tc/net/core/TCWorkerCommManagerTest.java
@@ -61,6 +61,7 @@ import com.tc.util.CallableWaiter;
 import com.tc.util.PortChooser;
 import com.tc.util.concurrent.ThreadUtil;
 import com.tc.properties.TCPropertiesConsts;
+import com.tc.util.ProductID;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -77,16 +78,13 @@ public class TCWorkerCommManagerTest extends TCTestCase {
 
   }
   
-  private synchronized ClientMessageTransport createClient(String clientName, int serverPort) {
+  private synchronized ClientMessageTransport createClient(String clientName) {
     CommunicationsManager commsMgr = new CommunicationsManagerImpl(clientName + "CommsMgr", new NullMessageMonitor(),
                                                                    new TransportNetworkStackHarnessFactory(),
                                                                    new NullConnectionPolicy());
 
-    final ConnectionInfo connInfo = new ConnectionInfo(TCSocketAddress.LOOPBACK_IP, serverPort);
-    ClientConnectionEstablisher cce = new ClientConnectionEstablisher(0, ReconnectionRejectedHandlerL1.SINGLETON);
-
     ClientMessageTransport cmt = new ClientMessageTransport(commsMgr.getConnectionManager(), createHandshakeErrorHandler(), new TransportMessageFactoryImpl(),
-                                      new WireProtocolAdaptorFactoryImpl(), TransportHandshakeMessage.NO_CALLBACK_PORT, 1000, true);
+                                      new WireProtocolAdaptorFactoryImpl(), TransportHandshakeMessage.NO_CALLBACK_PORT, 1000);
     transports.add(cmt);
     return cmt;
   }
@@ -121,10 +119,10 @@ public class TCWorkerCommManagerTest extends TCTestCase {
     listener.start(Collections.<ClientID>emptySet());
     int port = listener.getBindPort();
 
-    ClientMessageTransport client1 = createClient("client1", port);
-    ClientMessageTransport client2 = createClient("client2", port);
-    ClientMessageTransport client3 = createClient("client3", port);
-    ClientMessageTransport client4 = createClient("client4", port);
+    ClientMessageTransport client1 = createClient("client1");
+    ClientMessageTransport client2 = createClient("client2");
+    ClientMessageTransport client3 = createClient("client3");
+    ClientMessageTransport client4 = createClient("client4");
     ConnectionInfo info = new ConnectionInfo("localhost", port);
 
     client1.open(info);
@@ -296,9 +294,8 @@ public class TCWorkerCommManagerTest extends TCTestCase {
                                                                       new NullConnectionPolicy());
 
     ClientMessageChannel clientMsgCh = clientComms
-        .createClientChannel(new NullSessionManager(),
-                             -1,
-                             1000, true);
+        .createClientChannel(ProductID.STRIPE, new NullSessionManager(),
+                             1000);
     return clientMsgCh;
   }
 

--- a/common/src/test/java/com/tc/net/protocol/tcm/LazyHandshakeTest.java
+++ b/common/src/test/java/com/tc/net/protocol/tcm/LazyHandshakeTest.java
@@ -35,6 +35,7 @@ import com.tc.object.session.NullSessionManager;
 import com.tc.test.TCTestCase;
 import com.tc.util.Assert;
 import com.tc.util.PortChooser;
+import com.tc.util.ProductID;
 import com.tc.util.TCTimeoutException;
 import com.tc.util.concurrent.ThreadUtil;
 
@@ -103,8 +104,8 @@ public class LazyHandshakeTest extends TCTestCase {
 
   private ClientMessageChannel createClientMessageChannel() {
     return clientComms
-        .createClientChannel(new NullSessionManager(), 0,
-                             (int) PROXY_SYNACK_DELAY, true);
+        .createClientChannel(ProductID.STRIPE, new NullSessionManager(),
+                             (int) PROXY_SYNACK_DELAY);
   }
 
   @Override

--- a/common/src/test/java/com/tc/net/protocol/transport/ConnectionHealthCheckReverseCallbackTest.java
+++ b/common/src/test/java/com/tc/net/protocol/transport/ConnectionHealthCheckReverseCallbackTest.java
@@ -46,6 +46,7 @@ import com.tc.net.proxy.TCPProxy;
 import com.tc.object.session.NullSessionManager;
 import com.tc.test.TCTestCase;
 import com.tc.util.PortChooser;
+import com.tc.util.ProductID;
 import com.tc.util.concurrent.ThreadUtil;
 
 import java.io.IOException;
@@ -130,7 +131,7 @@ public class ConnectionHealthCheckReverseCallbackTest extends TCTestCase {
     listener.start(Collections.<ClientID>emptySet());
     
     clientComms.addClassMapping(TCMessageType.PING_MESSAGE, PingMessage.class);
-    channel = clientComms.createClientChannel(new NullSessionManager(), -1, 30000, true);
+    channel = clientComms.createClientChannel(ProductID.STRIPE, new NullSessionManager(),30000);
     try {
       channel.open(new ConnectionInfo(host, proxyPort));
     } catch (Throwable t) {

--- a/common/src/test/java/com/tc/net/protocol/transport/ConnectionHealthCheckerReconnectTest.java
+++ b/common/src/test/java/com/tc/net/protocol/transport/ConnectionHealthCheckerReconnectTest.java
@@ -45,6 +45,7 @@ import com.tc.object.session.NullSessionManager;
 import com.tc.properties.L1ReconnectConfigImpl;
 import com.tc.test.TCTestCase;
 import com.tc.util.PortChooser;
+import com.tc.util.ProductID;
 import com.tc.util.SequenceGenerator;
 import com.tc.util.concurrent.ThreadUtil;
 
@@ -175,8 +176,8 @@ public class ConnectionHealthCheckerReconnectTest extends TCTestCase {
     });
     
     ClientMessageChannel clientMsgCh = commsMgr
-        .createClientChannel(new NullSessionManager(), 0,
-                             1000, true);
+        .createClientChannel(ProductID.SERVER, new NullSessionManager(),
+                             1000);
 
     return clientMsgCh;
   }

--- a/common/src/test/java/com/tc/net/protocol/transport/ConnectionPolicyTest.java
+++ b/common/src/test/java/com/tc/net/protocol/transport/ConnectionPolicyTest.java
@@ -112,9 +112,9 @@ public class ConnectionPolicyTest extends TestCase {
   public void testInternalClients() throws Exception {
     policy = new ConnectionPolicyImpl(1);
     assertTrue(policy.connectClient(new ConnectionID("foo", 1)));
-    assertTrue(policy.isConnectAllowed(new ConnectionID("bar", 2, null, null, ProductID.WAN)));
-    assertTrue(policy.connectClient(new ConnectionID("bar", 2, null, null, ProductID.WAN)));
-    policy.clientDisconnected(new ConnectionID("foo", 4, null, null, ProductID.TMS));
+    assertTrue(policy.isConnectAllowed(new ConnectionID("bar", 2, null, null, ProductID.DIAGNOSTIC)));
+    assertTrue(policy.connectClient(new ConnectionID("bar", 2, null, null, ProductID.DIAGNOSTIC)));
+    policy.clientDisconnected(new ConnectionID("foo", 4, null, null, ProductID.DIAGNOSTIC));
     assertFalse(policy.connectClient(new ConnectionID("baz", 3)));
     assertTrue(policy.connectClient(new ConnectionID("redirect", -2)));
   }

--- a/connection-loader/src/main/java/com/terracotta/connection/TerracottaInternalClientFactoryImpl.java
+++ b/connection-loader/src/main/java/com/terracotta/connection/TerracottaInternalClientFactoryImpl.java
@@ -25,14 +25,10 @@ import java.util.Properties;
 
 
 public class TerracottaInternalClientFactoryImpl implements TerracottaInternalClientFactory {
-  public static final String  SECRET_PROVIDER = "com.terracotta.express.SecretProvider";
 
   // public nullary constructor needed as entry point from SPI
   public TerracottaInternalClientFactoryImpl() {
-    testForWrongTcconfig();
 
-    System.setProperty("tc.active", "true");
-    System.setProperty("tc.dso.globalmode", "false");
   }
 
   @Override
@@ -43,20 +39,12 @@ public class TerracottaInternalClientFactoryImpl implements TerracottaInternalCl
       String expandedMemberUri = URLConfigUtil.translateSystemProperties(memberUri);
       stripeConnectionConfig.addStripeMemberUri(expandedMemberUri);
     }
-    return createClient(stripeConnectionConfig, config.getProductId(), config.getGenericProperties());
+    return createClient(stripeConnectionConfig, config.getGenericProperties());
   }
 
 
-  private TerracottaInternalClient createClient(TerracottaClientStripeConnectionConfig stripeConnectionConfig, String productId, Properties props) {
-    TerracottaInternalClient client = new TerracottaInternalClientImpl(stripeConnectionConfig, productId, props);
+  private TerracottaInternalClient createClient(TerracottaClientStripeConnectionConfig stripeConnectionConfig, Properties props) {
+    TerracottaInternalClient client = new TerracottaInternalClientImpl(stripeConnectionConfig, props);
     return client;
-  }
-
-  private static void testForWrongTcconfig() {
-    String tcConfigValue = System.getProperty("tc.config");
-    if (tcConfigValue != null) {
-      //
-      throw new RuntimeException("The Terracotta config file should not be set through -Dtc.config in this usage.");
-    }
   }
 }

--- a/connection-loader/src/main/java/com/terracotta/connection/TerracottaInternalClientImpl.java
+++ b/connection-loader/src/main/java/com/terracotta/connection/TerracottaInternalClientImpl.java
@@ -24,11 +24,11 @@ import com.tc.object.ClientEntityManager;
 import com.tc.object.DistributedObjectClient;
 import com.tc.object.DistributedObjectClientFactory;
 import com.tc.object.StandardClientBuilder;
-import com.tc.util.ProductID;
 import com.terracotta.connection.client.TerracottaClientStripeConnectionConfig;
 
 import java.util.Properties;
 import java.util.concurrent.TimeoutException;
+import org.terracotta.connection.ConnectionPropertyNames;
 
 
 public class TerracottaInternalClientImpl implements TerracottaInternalClient {
@@ -41,22 +41,21 @@ public class TerracottaInternalClientImpl implements TerracottaInternalClient {
   private volatile boolean            shutdown             = false;
   private volatile boolean            isInitialized        = false;
 
-  TerracottaInternalClientImpl(TerracottaClientStripeConnectionConfig stripeConnectionConfig, String productId, Properties props) {
+  TerracottaInternalClientImpl(TerracottaClientStripeConnectionConfig stripeConnectionConfig, Properties props) {
     try {
-      this.clientCreator = buildClientCreator(stripeConnectionConfig, productId, props);
+      this.clientCreator = buildClientCreator(stripeConnectionConfig, props);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
   }
   
-  private DistributedObjectClientFactory buildClientCreator(TerracottaClientStripeConnectionConfig stripeConnectionConfig, String productIdName, Properties props) {
-    ProductID productId = productIdName == null ? ProductID.USER : ProductID.valueOf(productIdName);
+  private DistributedObjectClientFactory buildClientCreator(TerracottaClientStripeConnectionConfig stripeConnectionConfig, Properties props) {
+    boolean noreconnect = Boolean.valueOf(props.getProperty(ConnectionPropertyNames.CONNECTION_DISABLE_RECONNECT, "false"));  // TODO: replace with ConnectionPropertyNames.CONNECTION_DISABLE_RECONNECT once API is released
     return new DistributedObjectClientFactory(stripeConnectionConfig.getStripeMemberUris(),
-         new StandardClientBuilder(), 
+         new StandardClientBuilder(noreconnect), 
          null,  // no security features
          new SecurityInfo(false, null),  // no security info
-         productId,
-         props, false);
+         props);
   }
 
   @Override

--- a/connection-loader/src/main/java/com/terracotta/connection/api/TerracottaConnectionService.java
+++ b/connection-loader/src/main/java/com/terracotta/connection/api/TerracottaConnectionService.java
@@ -34,6 +34,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Properties;
 import java.util.concurrent.TimeoutException;
+import org.terracotta.connection.ConnectionPropertyNames;
 
 
 /**

--- a/connection-loader/src/main/java/com/terracotta/connection/client/TerracottaClientConfigParams.java
+++ b/connection-loader/src/main/java/com/terracotta/connection/client/TerracottaClientConfigParams.java
@@ -26,9 +26,7 @@ import java.util.Vector;
 
 public class TerracottaClientConfigParams {
   private final List<String> stripeMembers;
-  private boolean     rejoin;
-  private boolean     nonStop;
-  private String      productId;
+  private boolean disableReconnect = false;
   private ClassLoader clasLoader;
   private final Properties properties = new Properties();
 
@@ -44,40 +42,14 @@ public class TerracottaClientConfigParams {
     this.stripeMembers.add(stripeMember);
     return this;
   }
-
-  public boolean isRejoin() {
-    return rejoin;
-  }
-
-  public void setRejoin(boolean rejoin) {
-    this.rejoin = rejoin;
-  }
-
-  public TerracottaClientConfigParams rejoin(boolean rejoinParam) {
-    this.rejoin = rejoinParam;
+  
+  public TerracottaClientConfigParams disableReconnect() {
+    disableReconnect = true;
     return this;
   }
 
-  public TerracottaClientConfigParams nonStopEnabled(boolean nonStopParam) {
-    this.nonStop = nonStopParam;
-    return this;
-  }
-
-  public boolean isNonStop() {
-    return nonStop;
-  }
-
-  public String getProductId() {
-    return productId;
-  }
-
-  public void setProductId(String productId) {
-    this.productId = productId;
-  }
-
-  public TerracottaClientConfigParams productId(String appName) {
-    setProductId(appName);
-    return this;
+  public boolean isDisableReconnect() {
+    return disableReconnect;
   }
 
   public ClassLoader getClassLoader() {

--- a/connection-loader/src/main/java/com/terracotta/diagnostic/DiagnosticClientBuilder.java
+++ b/connection-loader/src/main/java/com/terracotta/diagnostic/DiagnosticClientBuilder.java
@@ -32,6 +32,7 @@ import com.tc.net.protocol.tcm.TCMessage;
 import com.tc.net.protocol.tcm.TCMessageRouter;
 import com.tc.net.protocol.tcm.TCMessageType;
 import com.tc.net.protocol.transport.ConnectionPolicy;
+import com.tc.net.protocol.transport.DisabledHealthCheckerConfigImpl;
 import com.tc.net.protocol.transport.HealthCheckerConfig;
 import com.tc.net.protocol.transport.ReconnectionRejectedHandler;
 import com.tc.net.protocol.transport.TransportHandshakeErrorHandlerForL1;
@@ -53,7 +54,7 @@ public class DiagnosticClientBuilder implements ClientBuilder {
   public ClientMessageChannel createClientMessageChannel(CommunicationsManager commMgr,
                                                          SessionProvider sessionProvider, 
                                                          int socketConnectTimeout, TCClient client) {
-    return commMgr.createClientChannel(sessionProvider, 0 /* never try and reconnect */, socketConnectTimeout, false);
+    return commMgr.createClientChannel(ProductID.DIAGNOSTIC, sessionProvider, socketConnectTimeout);
   }
 
   @Override
@@ -63,10 +64,10 @@ public class DiagnosticClientBuilder implements ClientBuilder {
                                                            HealthCheckerConfig aConfig,
                                                            Map<TCMessageType, Class<? extends TCMessage>> messageTypeClassMapping,
                                                            ReconnectionRejectedHandler reconnectionRejectedHandler,
-                                                           TCSecurityManager securityManager, ProductID productId) {
+                                                           TCSecurityManager securityManager) {
     return new CommunicationsManagerImpl(CommunicationsManager.COMMSMGR_CLIENT, monitor, messageRouter, stackHarnessFactory, null,
-                                         connectionPolicy, 0, aConfig, new TransportHandshakeErrorHandlerForL1(), messageTypeClassMapping,
-                                         reconnectionRejectedHandler, securityManager, productId);
+                                         connectionPolicy, 0, new DisabledHealthCheckerConfigImpl() /* ignore health check settings */, new TransportHandshakeErrorHandlerForL1(), messageTypeClassMapping,
+                                         reconnectionRejectedHandler, securityManager);
   }
 
   @Override

--- a/connection-loader/src/main/java/com/terracotta/diagnostic/DiagnosticClientEntityManager.java
+++ b/connection-loader/src/main/java/com/terracotta/diagnostic/DiagnosticClientEntityManager.java
@@ -148,7 +148,6 @@ public class DiagnosticClientEntityManager implements ClientEntityManager {
     // Get the clientID for our channel.
     // Get the next transaction ID.
     TransactionID transactionID = new TransactionID(tid.incrementAndGet());
-    // Figure out the "trailing edge" of the current progress through the transaction stream.
 
     // Create the message and populate it.
     DiagnosticMessage message = (DiagnosticMessage) channel.createMessage(TCMessageType.DIAGNOSTIC_REQUEST);

--- a/connection-loader/src/main/java/com/terracotta/diagnostic/DiagnosticClientImpl.java
+++ b/connection-loader/src/main/java/com/terracotta/diagnostic/DiagnosticClientImpl.java
@@ -50,13 +50,11 @@ public class DiagnosticClientImpl implements TerracottaInternalClient {
   }
   
   private DistributedObjectClientFactory buildClientCreator(TerracottaClientStripeConnectionConfig stripeConnectionConfig, Properties props) {
-    ProductID productId = ProductID.DIAGNOSTIC;
     return new DistributedObjectClientFactory(stripeConnectionConfig.getStripeMemberUris(),
          new DiagnosticClientBuilder(),
          null,  // no security features
          new SecurityInfo(false, null),  // no security info
-         productId,
-         props, true);
+         props);
   }
 
   public synchronized void init() throws TimeoutException, InterruptedException, ConfigurationSetupException {

--- a/dso-l1/src/main/java/com/tc/client/ClientFactory.java
+++ b/dso-l1/src/main/java/com/tc/client/ClientFactory.java
@@ -35,9 +35,9 @@ public class ClientFactory {
                                                      PreparedComponentsFromL2Connection connectionComponents,
                                                      ClusterInternal cluster,
                                                      TCSecurityManager securityManager,
-                                                     String uuid, String name, ProductID productId, boolean diagnostic) {
+                                                     String uuid, String name) {
     return new DistributedObjectClient(config, builder, threadGroup, connectionComponents,
         cluster, null,
-        uuid, name, productId, diagnostic);
+        uuid, name);
   }
 }

--- a/dso-l1/src/main/java/com/tc/object/ClientBuilder.java
+++ b/dso-l1/src/main/java/com/tc/object/ClientBuilder.java
@@ -19,7 +19,6 @@
 package com.tc.object;
 
 import com.tc.async.api.StageManager;
-import com.tc.util.ProductID;
 import com.tc.logging.TCLogger;
 import com.tc.management.TCClient;
 import com.tc.net.core.security.TCSecurityManager;
@@ -56,7 +55,7 @@ public interface ClientBuilder {
                                                     HealthCheckerConfig hcConfig,
                                                     Map<TCMessageType, Class<? extends TCMessage>> messageTypeClassMapping,
                                                     ReconnectionRejectedHandler reconnectionRejectedBehaviour,
-                                                    TCSecurityManager securityManager, ProductID productId);
+                                                    TCSecurityManager securityManager);
 
   ClientHandshakeManager createClientHandshakeManager(TCLogger logger,
                                                       ClientHandshakeMessageFactory chmf,

--- a/dso-l1/src/main/java/com/tc/object/DistributedObjectClientFactory.java
+++ b/dso-l1/src/main/java/com/tc/object/DistributedObjectClientFactory.java
@@ -47,22 +47,16 @@ public class DistributedObjectClientFactory {
   private final ClientBuilder builder;
   private final TCSecurityManager securityManager;
   private final SecurityInfo      securityInfo;
-  private final ProductID         productId;
   private final Properties        properties;
-  private final boolean           diagnostic;
 
   public DistributedObjectClientFactory(List<String> stripeMemberUris, ClientBuilder builder, TCSecurityManager securityManager,
                                         SecurityInfo securityInfo, 
-                                        ProductID productId,
-                                        Properties properties,
-                                        boolean diagnostic) {
+                                        Properties properties) {
     this.stripeMemberUris = stripeMemberUris;
     this.builder = builder;
     this.securityManager = securityManager;
     this.securityInfo = securityInfo;
-    this.productId = productId;
     this.properties = properties;
-    this.diagnostic = diagnostic;
   }
 
   public DistributedObjectClient create() throws InterruptedException, ConfigurationSetupException {
@@ -99,10 +93,10 @@ public class DistributedObjectClientFactory {
     String uuid = this.properties.getProperty(ConnectionPropertyNames.CONNECTION_UUID, UUID.getUUID().toString());
     String name = this.properties.getProperty(ConnectionPropertyNames.CONNECTION_NAME, "");
     
+    
     DistributedObjectClient client = ClientFactory.createClient(configHelper, builder, group, connectionComponents, cluster, securityManager,
         uuid,
-        name,
-        productId,  this.diagnostic);
+        name);
 
     try {
       client.start();

--- a/dso-l1/src/main/java/com/tc/object/StandardClientBuilder.java
+++ b/dso-l1/src/main/java/com/tc/object/StandardClientBuilder.java
@@ -47,11 +47,18 @@ import java.util.Map;
 
 
 public class StandardClientBuilder implements ClientBuilder {
+  
+  private final boolean isReconnectEnabled;
+
+  public StandardClientBuilder(boolean noreconnect) {
+    this.isReconnectEnabled = !noreconnect;
+  }
+  
   @Override
   public ClientMessageChannel createClientMessageChannel(CommunicationsManager commMgr,
                                                          SessionProvider sessionProvider, 
                                                          int socketConnectTimeout, TCClient client) {
-    return commMgr.createClientChannel(sessionProvider, -1 /*  reconnect retry forever  */, socketConnectTimeout, true);
+    return commMgr.createClientChannel(isReconnectEnabled ? ProductID.STRIPE : ProductID.SERVER, sessionProvider, socketConnectTimeout);
   }
 
   @Override
@@ -61,10 +68,10 @@ public class StandardClientBuilder implements ClientBuilder {
                                                            HealthCheckerConfig aConfig,
                                                            Map<TCMessageType, Class<? extends TCMessage>> messageTypeClassMapping,
                                                            ReconnectionRejectedHandler reconnectionRejectedHandler,
-                                                           TCSecurityManager securityManager, ProductID productId) {
+                                                           TCSecurityManager securityManager) {
     return new CommunicationsManagerImpl(CommunicationsManager.COMMSMGR_CLIENT, monitor, messageRouter, stackHarnessFactory, null,
                                          connectionPolicy, 0, aConfig, new TransportHandshakeErrorHandlerForL1(), messageTypeClassMapping,
-                                         reconnectionRejectedHandler, securityManager, productId);
+                                         reconnectionRejectedHandler, securityManager);
   }
 
   @Override

--- a/dso-l1/src/test/java/com/tc/object/ClientEntityManagerTest.java
+++ b/dso-l1/src/test/java/com/tc/object/ClientEntityManagerTest.java
@@ -49,6 +49,7 @@ import com.tc.net.protocol.tcm.UnknownNameException;
 import com.tc.object.session.SessionID;
 import com.tc.object.tx.TransactionID;
 import com.tc.stats.Stats;
+import com.tc.util.ProductID;
 import com.tc.util.concurrent.ThreadUtil;
 
 import java.io.IOException;
@@ -85,6 +86,7 @@ public class ClientEntityManagerTest extends TestCase {
   @Override
   public void setUp() throws Exception {
     this.channel = mock(ClientMessageChannel.class);
+    when(this.channel.getProductId()).thenReturn(ProductID.STRIPE);
     this.stageMgr = mock(StageManager.class);
     when(this.stageMgr.createStage(any(String.class), any(Class.class), any(EventHandler.class), anyInt(), anyInt())).then(new Answer() {
       @Override

--- a/dso-l1/src/test/java/com/tc/object/DistributedObjectClientTest.java
+++ b/dso-l1/src/test/java/com/tc/object/DistributedObjectClientTest.java
@@ -36,11 +36,13 @@ import com.tc.object.config.PreparedComponentsFromL2Connection;
 import com.tc.object.session.SessionProvider;
 import com.tc.util.Assert;
 import com.tc.util.PortChooser;
+import com.tc.util.ProductID;
 import com.tcclient.cluster.ClusterInternal;
 import java.util.concurrent.TimeUnit;
 import junit.framework.TestCase;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
+import static org.mockito.Mockito.when;
 
 
 public class DistributedObjectClientTest extends TestCase {
@@ -157,7 +159,7 @@ public class DistributedObjectClientTest extends TestCase {
     Mockito.when(l2connection.createConnectionInfoConfigItem()).thenReturn(config);
     ClusterInternal cluster = new ClusterImpl();
     TCThreadGroup threadGroup = new TCThreadGroup(new TestThrowableHandler(TCLogging.getLogger(DistributedObjectClient.class)));
-    ClientBuilder builder = new StandardClientBuilder() {
+    ClientBuilder builder = new StandardClientBuilder(true) {
       @Override
       public ClientMessageChannel createClientMessageChannel(CommunicationsManager commMgr, SessionProvider sessionProvider, int socketConnectTimeout, TCClient client) {
         ClientMessageChannel channel = Mockito.mock(ClientMessageChannel.class);
@@ -166,11 +168,12 @@ public class DistributedObjectClientTest extends TestCase {
         } catch (Exception exp) {
           
         }
+        when(channel.getProductId()).thenReturn(ProductID.STRIPE);
         return channel;
       }
     };
     
-    DistributedObjectClient client = new DistributedObjectClient(new ClientConfigImpl(manager), builder, threadGroup, l2connection, cluster, null, null, null, null, false);
+    DistributedObjectClient client = new DistributedObjectClient(new ClientConfigImpl(manager), builder, threadGroup, l2connection, cluster, null, null, null);
     client.start();
     Assert.assertTrue(threadGroup.activeCount() > 0);
     long start = System.currentTimeMillis();

--- a/dso-l1/src/test/java/com/tc/object/handler/ClusterMembershipEventsHandlerTest.java
+++ b/dso-l1/src/test/java/com/tc/object/handler/ClusterMembershipEventsHandlerTest.java
@@ -50,25 +50,25 @@ public class ClusterMembershipEventsHandlerTest {
 
   @Test
   public void testInternalNodeJoined() throws Exception {
-    handler.handleEvent(joinedMsg(clientID, ProductID.TMS));
+    handler.handleEvent(joinedMsg(clientID, ProductID.DIAGNOSTIC));
     verify(clusterEventsGun, never()).fireNodeJoined(clientID);
   }
 
   @Test
   public void testInternalNodeLeft() throws Exception {
-    handler.handleEvent(leftMsg(clientID, ProductID.WAN));
+    handler.handleEvent(leftMsg(clientID, ProductID.DIAGNOSTIC));
     verify(clusterEventsGun, never()).fireNodeLeft(clientID);
   }
 
   @Test
   public void testUserNodeJoined() throws Exception {
-    handler.handleEvent(joinedMsg(clientID, ProductID.USER));
+    handler.handleEvent(joinedMsg(clientID, ProductID.STRIPE));
     verify(clusterEventsGun).fireNodeJoined(clientID);
   }
 
   @Test
   public void testUserNodeLeft() throws Exception {
-    handler.handleEvent(leftMsg(clientID, ProductID.USER));
+    handler.handleEvent(leftMsg(clientID, ProductID.STRIPE));
     verify(clusterEventsGun).fireNodeLeft(clientID);
   }
 

--- a/dso-l2/src/main/java/com/tc/l2/ha/ClusterStateImpl.java
+++ b/dso-l2/src/main/java/com/tc/l2/ha/ClusterStateImpl.java
@@ -129,7 +129,9 @@ public class ClusterStateImpl implements ClusterState {
       clientStatePersistor.getConnectionIDSequence().setNext(nextAvailChannelID);
     }
     connections.add(connID);
-    clientStatePersistor.saveClientState(connID.getClientID());
+    if (connID.getProductId().isReconnectEnabled()) {
+      clientStatePersistor.saveClientState(connID.getClientID());
+    }
   }
 
   @Override
@@ -139,7 +141,9 @@ public class ClusterStateImpl implements ClusterState {
       logger.warn("Connection ID not found, must be a failed reconnect : " + connectionID + " Current Connections count : " + connections.size());
     }
     try {
-      clientStatePersistor.deleteClientState(connectionID.getClientID());
+      if (connectionID.getProductId().isReconnectEnabled()) {
+        clientStatePersistor.deleteClientState(connectionID.getClientID());
+      }
     } catch (ClientNotFoundException notfound) {
       logger.warn("not found", notfound);
     }

--- a/dso-l2/src/main/java/com/tc/l2/ha/ClusterStateImpl.java
+++ b/dso-l2/src/main/java/com/tc/l2/ha/ClusterStateImpl.java
@@ -25,8 +25,7 @@ import com.tc.net.groups.StripeIDStateManager;
 import com.tc.net.protocol.transport.ConnectionID;
 import com.tc.net.protocol.transport.ConnectionIDFactory;
 import com.tc.objectserver.api.ClientNotFoundException;
-import com.tc.objectserver.persistence.ClientStatePersistor;
-import com.tc.objectserver.persistence.ClusterStatePersistor;
+import com.tc.objectserver.persistence.Persistor;
 import com.tc.util.State;
 import com.tc.util.UUID;
 
@@ -38,8 +37,7 @@ public class ClusterStateImpl implements ClusterState {
 
   private static final TCLogger                     logger                 = TCLogging.getLogger(ClusterState.class);
 
-  private final ClusterStatePersistor               clusterStatePersistor;
-  private final ClientStatePersistor                clientStatePersistor;
+  private final Persistor               persistor;
   private final ConnectionIDFactory                 connectionIdFactory;
   private final StripeIDStateManager                stripeIDStateManager;
 
@@ -48,13 +46,12 @@ public class ClusterStateImpl implements ClusterState {
   private State                                     currentState;
   private StripeID                                  stripeID;
 
-  public ClusterStateImpl(ClusterStatePersistor clusterStatePersistor, ClientStatePersistor clientStatePersistor, 
+  public ClusterStateImpl(Persistor persistor, 
                           ConnectionIDFactory connectionIdFactory, StripeIDStateManager stripeIDStateManager) {
-    this.clusterStatePersistor = clusterStatePersistor;
-    this.clientStatePersistor = clientStatePersistor;
+    this.persistor = persistor;
     this.connectionIdFactory = connectionIdFactory;
     this.stripeIDStateManager = stripeIDStateManager;
-    this.stripeID = clusterStatePersistor.getThisStripeID();
+    this.stripeID = persistor.getClusterStatePersistor().getThisStripeID();
     this.nextAvailChannelID = this.connectionIdFactory.getCurrentConnectionID();
   }
 
@@ -72,7 +69,7 @@ public class ClusterStateImpl implements ClusterState {
       return;
     }
     this.nextAvailChannelID = nextAvailableCID;
-    clientStatePersistor.getConnectionIDSequence().setNext(nextAvailChannelID);
+    persistor.getClientStatePersistor().getConnectionIDSequence().setNext(nextAvailChannelID);
   }
 
   @Override
@@ -109,7 +106,7 @@ public class ClusterStateImpl implements ClusterState {
   }
 
   private void syncStripeIDToDB() {
-    clusterStatePersistor.setThisStripeID(stripeID);
+    persistor.getClusterStatePersistor().setThisStripeID(stripeID);
   }
 
   @Override
@@ -119,18 +116,18 @@ public class ClusterStateImpl implements ClusterState {
   }
 
   private void syncCurrentStateToDB() {
-    clusterStatePersistor.setCurrentL2State(currentState);
+    persistor.getClusterStatePersistor().setCurrentL2State(currentState);
   }
 
   @Override
   public void addNewConnection(ConnectionID connID) {
     if (connID.getChannelID() >= nextAvailChannelID) {
       nextAvailChannelID = connID.getChannelID() + 1;
-      clientStatePersistor.getConnectionIDSequence().setNext(nextAvailChannelID);
+      persistor.getClientStatePersistor().getConnectionIDSequence().setNext(nextAvailChannelID);
     }
     connections.add(connID);
     if (connID.getProductId().isReconnectEnabled()) {
-      clientStatePersistor.saveClientState(connID.getClientID());
+      persistor.addClientState(connID.getClientID());
     }
   }
 
@@ -142,7 +139,7 @@ public class ClusterStateImpl implements ClusterState {
     }
     try {
       if (connectionID.getProductId().isReconnectEnabled()) {
-        clientStatePersistor.deleteClientState(connectionID.getClientID());
+        persistor.removeClientState(connectionID.getClientID());
       }
     } catch (ClientNotFoundException notfound) {
       logger.warn("not found", notfound);

--- a/dso-l2/src/main/java/com/tc/l2/ha/L2HACoordinator.java
+++ b/dso-l2/src/main/java/com/tc/l2/ha/L2HACoordinator.java
@@ -73,8 +73,7 @@ public class L2HACoordinator implements L2Coordinator {
   private void init(StageManager stageManager, Persistor persistor,
                     WeightGeneratorFactory weightGeneratorFactory,
                     StripeIDStateManager stripeIDStateManager, ChannelLifeCycleHandler clm) {
-    final ClusterState clusterState = new ClusterStateImpl(persistor.getClusterStatePersistor(),  persistor.getClientStatePersistor(), 
-                                                           this.server.getConnectionIdFactory(),
+    final ClusterState clusterState = new ClusterStateImpl(persistor, this.server.getConnectionIdFactory(),
                                                        stripeIDStateManager);
 
     final L2HAZapNodeRequestProcessor zapProcessor = new L2HAZapNodeRequestProcessor(this.consoleLogger,

--- a/dso-l2/src/main/java/com/tc/management/beans/TCServerInfo.java
+++ b/dso-l2/src/main/java/com/tc/management/beans/TCServerInfo.java
@@ -111,6 +111,16 @@ public class TCServerInfo extends AbstractTerracottaMBean implements TCServerInf
   }
 
   @Override
+  public boolean isReconnectWindow() {
+    return server.isReconnectWindow();
+  }
+
+  @Override
+  public int getReconnectWindowTimeout() {
+    return server.getReconnectWindowTimeout();
+  }
+
+  @Override
   public long getStartTime() {
     return server.getStartTime();
   }
@@ -188,6 +198,8 @@ public class TCServerInfo extends AbstractTerracottaMBean implements TCServerInf
   public String getBuildID() {
     return buildID;
   }
+  
+  
 
   @Override
   public boolean isPatched() {

--- a/dso-l2/src/main/java/com/tc/net/groups/TCGroupManagerImpl.java
+++ b/dso-l2/src/main/java/com/tc/net/groups/TCGroupManagerImpl.java
@@ -84,6 +84,7 @@ import com.tc.properties.TCPropertiesConsts;
 import com.tc.properties.TCPropertiesImpl;
 import com.tc.text.PrettyPrinter;
 import com.tc.util.Assert;
+import com.tc.util.ProductID;
 import com.tc.util.ProductInfo;
 import com.tc.util.TCTimeoutException;
 import com.tc.util.UUID;
@@ -608,7 +609,7 @@ public class TCGroupManagerImpl implements GroupManager<AbstractGroupMessage>, C
     communicationsManager.addClassMapping(TCMessageType.GROUP_WRAPPER_MESSAGE, TCGroupMessageWrapper.class);
     communicationsManager.addClassMapping(TCMessageType.GROUP_HANDSHAKE_MESSAGE, TCGroupHandshakeMessage.class);
 
-    ClientMessageChannel channel = communicationsManager.createClientChannel(sessionProvider, 0 /* no reconnect */, 10000 /*  timeout */, false /* no redirects */);
+    ClientMessageChannel channel = communicationsManager.createClientChannel(ProductID.SERVER, sessionProvider, 10000 /*  timeout */);
 
     channel.addListener(listener);
     channel.open(Collections.singleton(info), username, password);

--- a/dso-l2/src/main/java/com/tc/objectserver/core/impl/ServerManagementContext.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/core/impl/ServerManagementContext.java
@@ -24,24 +24,21 @@ import com.tc.object.net.ChannelStats;
 import com.tc.object.net.DSOChannelManagerMBean;
 import com.tc.objectserver.api.ObjectInstanceMonitorMBean;
 import com.tc.objectserver.core.api.GlobalServerStats;
-import com.tc.objectserver.locks.LockManagerMBean;
 
 public class ServerManagementContext {
 
   private final DSOChannelManagerMBean        channelMgr;
   private final GlobalServerStats          serverStats;
   private final ChannelStats                  channelStats;
-  private final LockManagerMBean              lockMgr;
   private final ObjectInstanceMonitorMBean    instanceMonitor;
   private final ConnectionPolicy              connectionPolicy;
   private final RemoteManagement              remoteManagement;
 
-  public ServerManagementContext(LockManagerMBean lockMgr, DSOChannelManagerMBean channelMgr,
+  public ServerManagementContext(DSOChannelManagerMBean channelMgr,
                                  GlobalServerStats serverStats, ChannelStats channelStats,
                                  ObjectInstanceMonitorMBean instanceMonitor,
                                  ConnectionPolicy connectionPolicy,
                                  RemoteManagement remoteManagement) {
-    this.lockMgr = lockMgr;
     this.channelMgr = channelMgr;
     this.serverStats = serverStats;
     this.channelStats = channelStats;
@@ -60,10 +57,6 @@ public class ServerManagementContext {
 
   public ChannelStats getChannelStats() {
     return this.channelStats;
-  }
-
-  public LockManagerMBean getLockManager() {
-    return this.lockMgr;
   }
 
   public ObjectInstanceMonitorMBean getInstanceMonitor() {

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/EntityManagerImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/EntityManagerImpl.java
@@ -320,7 +320,11 @@ public class EntityManagerImpl implements EntityManager {
     stateDumper.dumpState("EntityManagerImpl size", Integer.toString(entries.size()));
     for (Map.Entry<EntityID, FetchID> entry : entries) {
       EntityID entityID = entry.getKey();
-      entityIndex.get(entry.getValue()).dumpStateTo(stateDumper.subStateDumper(entityID.getClassName() + ":" + entityID.getEntityName()));
+      try {
+        entityIndex.get(entry.getValue()).dumpStateTo(stateDumper.subStateDumper(entityID.getClassName() + ":" + entityID.getEntityName()));
+      } catch (Throwable t) {
+        stateDumper.subStateDumper(entityID.getClassName() + ":" + entityID.getEntityName()).dumpState("exception", t.getMessage());
+      }
     }
   }
 

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -369,12 +369,16 @@ public class ManagedEntityImpl implements ManagedEntity {
 
   @Override
   public void dumpStateTo(StateDumper stateDumper) {
-    if(activeServerEntity != null) {
-      activeServerEntity.dumpStateTo(stateDumper);
-    }
+    try {
+      if(activeServerEntity != null) {
+        activeServerEntity.dumpStateTo(stateDumper);
+      }
 
-    if(passiveServerEntity != null) {
-      passiveServerEntity.dumpStateTo(stateDumper);
+      if(passiveServerEntity != null) {
+        passiveServerEntity.dumpStateTo(stateDumper);
+      }
+    } catch (Throwable t) {
+      logger.warn("unable to collect state for " + getID(), t);
     }
   }
 

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ReferenceMessage.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ReferenceMessage.java
@@ -82,7 +82,7 @@ public class ReferenceMessage implements VoltronEntityMessage {
     // Since it is a disconnect, that means that this client can't end up in a reconnect scenario.  Therefore, we
     // will return null, here, and define that to mean that the client is no longer requiring persistent ordering.
     // Note that it may be worth making this a more explicit case in case other unexpected null cases are found.
-    return null;
+    return TransactionID.NULL_ID;
   }
 
   @Override

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
@@ -28,11 +28,11 @@ import com.tc.entity.VoltronEntityAppliedResponse;
 import com.tc.entity.VoltronEntityMessage;
 import com.tc.entity.VoltronEntityMultiResponse;
 import com.tc.exception.VoltronEntityUserExceptionWrapper;
-import com.tc.exception.VoltronWrapperException;
 import com.tc.logging.TCLogger;
 import com.tc.logging.TCLogging;
 import com.tc.net.ClientID;
 import com.tc.net.NodeID;
+import com.tc.net.ReconnectionRejectedException;
 import com.tc.net.protocol.tcm.MessageChannel;
 import com.tc.net.protocol.tcm.TCMessage;
 import com.tc.net.protocol.tcm.TCMessageType;
@@ -52,6 +52,7 @@ import com.tc.objectserver.entity.ReferenceMessage;
 import com.tc.objectserver.entity.ServerEntityRequestResponse;
 import com.tc.objectserver.persistence.EntityData;
 import com.tc.objectserver.persistence.EntityPersistor;
+import com.tc.objectserver.persistence.Persistor;
 import com.tc.objectserver.persistence.TransactionOrderPersistor;
 import com.tc.util.Assert;
 import com.tc.util.SparseList;
@@ -73,14 +74,12 @@ import org.terracotta.entity.EntityUserException;
 import org.terracotta.entity.MessageCodecException;
 import org.terracotta.exception.EntityException;
 import org.terracotta.exception.EntityNotFoundException;
-import org.terracotta.exception.EntityServerUncaughtException;
 
 
 public class ProcessTransactionHandler implements ReconnectListener {
   private static final TCLogger LOGGER = TCLogging.getLogger(ProcessTransactionHandler.class);
   
-  private final EntityPersistor entityPersistor;
-  private final TransactionOrderPersistor transactionOrderPersistor;
+  private final Persistor persistor;
   private final Runnable stateManagerCleanup;
   
   private final EntityManager entityManager;
@@ -153,7 +152,7 @@ public class ProcessTransactionHandler implements ReconnectListener {
       boolean doesRequireReplication = message.doesRequireReplication();
       TransactionID oldestTransactionOnClient = message.getOldestTransactionOnClient();
       boolean requestedReceived = message.doesRequestReceived();
-
+      
       ProcessTransactionHandler.this.addMessage(sourceNodeID, descriptor, action, MessagePayload.commonMessagePayloadBusy(extendedData, entityMessage, doesRequireReplication), transactionID, oldestTransactionOnClient, requestedReceived);
     }
 
@@ -178,9 +177,8 @@ public class ProcessTransactionHandler implements ReconnectListener {
     return this.voltronHandler;
   }
 
-  public ProcessTransactionHandler(EntityPersistor entityPersistor, TransactionOrderPersistor transactionOrderPersistor, DSOChannelManager channelManager, EntityManager entityManager, Runnable stateManagerCleanup) {
-    this.entityPersistor = entityPersistor;
-    this.transactionOrderPersistor = transactionOrderPersistor;
+  public ProcessTransactionHandler(Persistor persistor, DSOChannelManager channelManager, EntityManager entityManager, Runnable stateManagerCleanup) {
+    this.persistor = persistor;
     this.dsoChannelManager = channelManager;
     this.entityManager = entityManager;
     this.stateManagerCleanup = stateManagerCleanup;
@@ -236,6 +234,7 @@ public class ProcessTransactionHandler implements ReconnectListener {
       }
     }
   }
+
 // only the process transaction thread will add messages here except for on reconnect
   private void addMessage(ClientID sourceNodeID, EntityDescriptor descriptor, ServerEntityAction action, MessagePayload entityMessage, TransactionID transactionID, TransactionID oldestTransactionOnClient, boolean requiresReceived) {
     // Version error or duplicate creation requests will manifest as exceptions here so catch them so we can send them back
@@ -249,21 +248,17 @@ public class ProcessTransactionHandler implements ReconnectListener {
     // Note that we only want to persist the messages with a true sourceNodeID.  Synthetic invocations and sync messages
     // don't have one (although sync messages shouldn't come down this path).
     Future<Void> transactionOrderPersistenceFuture = null;
-    if (!ClientID.NULL_ID.equals(sourceNodeID)) {
-      if (null != oldestTransactionOnClient) {
+    // if the client is valid and the transaction id is valid, then this came from a real client
+    // and the client expects to be able to reconnect
+    if (sourceNodeID != null && !sourceNodeID.isNull() && transactionID.isValid()) {
+      Assert.assertTrue(oldestTransactionOnClient.isValid());
         // This client still needs transaction order persistence.
-        transactionOrderPersistenceFuture = this.transactionOrderPersistor.updateWithNewMessage(sourceNodeID, transactionID, oldestTransactionOnClient);
-        serverEntityRequest.setTransactionOrderPersistenceFuture(transactionOrderPersistenceFuture);
-      } else {
-        // This is probably a disconnect: we can discard transaction order persistence for this client.
-        this.transactionOrderPersistor.removeTrackingForClient(sourceNodeID);
-        // And the entity journal persistence.
-        this.entityPersistor.removeTrackingForClient(sourceNodeID);
-      }
+      transactionOrderPersistenceFuture = this.persistor.getTransactionOrderPersistor().updateWithNewMessage(sourceNodeID, transactionID, oldestTransactionOnClient);
+      serverEntityRequest.setTransactionOrderPersistenceFuture(transactionOrderPersistenceFuture);
     }
     if (ServerEntityAction.CREATE_ENTITY == action) {
       // The common pattern for this is to pass an empty array on success ("found") or an exception on failure ("not found").
-      long consumerID = this.entityPersistor.getNextConsumerID();
+      long consumerID = this.persistor.getEntityPersistor().getNextConsumerID();
       serverEntityRequest.setAutoRetire();
       try {
         boolean canDelete = !sourceNodeID.isNull();
@@ -272,19 +267,19 @@ public class ProcessTransactionHandler implements ReconnectListener {
         temp.addRequestMessage(serverEntityRequest, entityMessage, serverEntityRequest::received, 
           (result) -> {
             if (!sourceNodeID.isNull()) {
-              entityPersistor.entityCreated(sourceNodeID, transactionID.toLong(), oldestTransactionOnClient.toLong(), entityID, descriptor.getClientSideVersion(), consumerID, canDelete, entityMessage.getRawPayload());
+              this.persistor.getEntityPersistor().entityCreated(sourceNodeID, transactionID.toLong(), oldestTransactionOnClient.toLong(), entityID, descriptor.getClientSideVersion(), consumerID, canDelete, entityMessage.getRawPayload());
               serverEntityRequest.complete();
             } else {
-              entityPersistor.entityCreatedNoJournal(entityID, descriptor.getClientSideVersion(), consumerID, canDelete, entityMessage.getRawPayload());
+              this.persistor.getEntityPersistor().entityCreatedNoJournal(entityID, descriptor.getClientSideVersion(), consumerID, canDelete, entityMessage.getRawPayload());
               serverEntityRequest.complete();
             }
           }, (exception) -> {
-            entityPersistor.entityCreateFailed(sourceNodeID, transactionID.toLong(), oldestTransactionOnClient.toLong(), exception);
+            this.persistor.getEntityPersistor().entityCreateFailed(sourceNodeID, transactionID.toLong(), oldestTransactionOnClient.toLong(), exception);
             serverEntityRequest.failure(exception);
           });
       } catch (EntityException ee) {
         if (!sourceNodeID.isNull()) {
-          entityPersistor.entityCreateFailed(sourceNodeID, transactionID.toLong(), oldestTransactionOnClient.toLong(), ee);
+          this.persistor.getEntityPersistor().entityCreateFailed(sourceNodeID, transactionID.toLong(), oldestTransactionOnClient.toLong(), ee);
         }
         serverEntityRequest.failure(ee);
       }
@@ -357,20 +352,20 @@ public class ProcessTransactionHandler implements ReconnectListener {
           serverEntityRequest.setAutoRetire();
           entity.addRequestMessage(serverEntityRequest, entityMessage, serverEntityRequest::received, 
             (result)-> {
-              EntityExistenceHelpers.recordReconfigureEntity(entityPersistor, entityManager, serverEntityRequest.getNodeID(), serverEntityRequest.getTransaction(), serverEntityRequest.getOldestTransactionOnClient(), descriptor.getEntityID(), descriptor.getClientSideVersion(), entityMessage.getRawPayload(), null);
+              EntityExistenceHelpers.recordReconfigureEntity(this.persistor.getEntityPersistor(), entityManager, serverEntityRequest.getNodeID(), serverEntityRequest.getTransaction(), serverEntityRequest.getOldestTransactionOnClient(), descriptor.getEntityID(), descriptor.getClientSideVersion(), entityMessage.getRawPayload(), null);
               serverEntityRequest.complete(result);
             }, (exception) -> {  
-              EntityExistenceHelpers.recordReconfigureEntity(entityPersistor, entityManager, serverEntityRequest.getNodeID(), serverEntityRequest.getTransaction(), serverEntityRequest.getOldestTransactionOnClient(), descriptor.getEntityID(), descriptor.getClientSideVersion(), entityMessage.getRawPayload(), exception);
+              EntityExistenceHelpers.recordReconfigureEntity(this.persistor.getEntityPersistor(), entityManager, serverEntityRequest.getNodeID(), serverEntityRequest.getTransaction(), serverEntityRequest.getOldestTransactionOnClient(), descriptor.getEntityID(), descriptor.getClientSideVersion(), entityMessage.getRawPayload(), exception);
               serverEntityRequest.failure(exception);
             });
         }  else if (ServerEntityAction.DESTROY_ENTITY == action) {
           serverEntityRequest.setAutoRetire();
           entity.addRequestMessage(serverEntityRequest, entityMessage, serverEntityRequest::received, 
             (result) -> {
-              EntityExistenceHelpers.recordDestroyEntity(entityPersistor, entityManager, sourceNodeID, transactionID, oldestTransactionOnClient, descriptor.getEntityID(), null);
+              EntityExistenceHelpers.recordDestroyEntity(this.persistor.getEntityPersistor(), entityManager, sourceNodeID, transactionID, oldestTransactionOnClient, descriptor.getEntityID(), null);
               serverEntityRequest.complete();
             }, (exception) -> {
-              EntityExistenceHelpers.recordDestroyEntity(entityPersistor, entityManager, sourceNodeID, transactionID, oldestTransactionOnClient, descriptor.getEntityID(), exception);
+              EntityExistenceHelpers.recordDestroyEntity(this.persistor.getEntityPersistor(), entityManager, sourceNodeID, transactionID, oldestTransactionOnClient, descriptor.getEntityID(), exception);
               serverEntityRequest.failure(exception);
             });
         } else if (ServerEntityAction.FETCH_ENTITY == action || ServerEntityAction.RELEASE_ENTITY == action) {
@@ -379,7 +374,11 @@ public class ProcessTransactionHandler implements ReconnectListener {
             (result) -> {
               serverEntityRequest.complete(result);
             }, (exception) -> {
-              serverEntityRequest.failure(exception);
+              if (exception.getCause() instanceof ReconnectionRejectedException) {
+                disconnectClientDueToFailure(sourceNodeID);
+              } else {
+                serverEntityRequest.failure(exception);
+              }
             });
         } else {
           if (ServerEntityAction.MANAGED_ENTITY_GC == action && entity.isRemoveable()) {
@@ -412,9 +411,13 @@ public class ProcessTransactionHandler implements ReconnectListener {
     }
   }
   
+  private void disconnectClientDueToFailure(ClientID clientID) {
+    safeGetChannel(clientID).ifPresent(channel->channel.close());
+  }
+  
   public void loadExistingEntities() {
     // issue-439: We need to sort these entities, ascending by consumerID.
-    List<EntityData.Value> sortingList = new ArrayList<EntityData.Value>(this.entityPersistor.loadEntityData());
+    List<EntityData.Value> sortingList = new ArrayList<EntityData.Value>(this.persistor.getEntityPersistor().loadEntityData());
     Collections.sort(sortingList, new Comparator<EntityData.Value>() {
       @Override
       public int compare(EntityData.Value o1, EntityData.Value o2) {
@@ -451,13 +454,13 @@ public class ProcessTransactionHandler implements ReconnectListener {
     try {
       switch (resentMessage.getVoltronType()) {
         case CREATE_ENTITY:
-          cached = entityPersistor.wasEntityCreatedInJournal(resentMessage.getSource(), resentMessage.getTransactionID().toLong());
+          cached = this.persistor.getEntityPersistor().wasEntityCreatedInJournal(resentMessage.getSource(), resentMessage.getTransactionID().toLong());
           break;
         case DESTROY_ENTITY:
-          cached = entityPersistor.wasEntityDestroyedInJournal(resentMessage.getSource(), resentMessage.getTransactionID().toLong());
+          cached = this.persistor.getEntityPersistor().wasEntityDestroyedInJournal(resentMessage.getSource(), resentMessage.getTransactionID().toLong());
           break;
         case RECONFIGURE_ENTITY:
-          result = entityPersistor.reconfiguredResultInJournal(resentMessage.getSource(), resentMessage.getTransactionID().toLong());
+          result = this.persistor.getEntityPersistor().reconfiguredResultInJournal(resentMessage.getSource(), resentMessage.getTransactionID().toLong());
           if (result != null) {
             cached = true;
           }
@@ -465,7 +468,7 @@ public class ProcessTransactionHandler implements ReconnectListener {
         case FETCH_ENTITY:
         case RELEASE_ENTITY:
         default:
-          index = this.transactionOrderPersistor.getIndexToReplay(resentMessage.getSource(), resentMessage.getTransactionID());
+          index = this.persistor.getTransactionOrderPersistor().getIndexToReplay(resentMessage.getSource(), resentMessage.getTransactionID());
           break;
       }
       if (cached) {
@@ -510,7 +513,7 @@ public class ProcessTransactionHandler implements ReconnectListener {
     this.stateManagerCleanup.run();
 
     // Clear the transaction order persistor since we are starting fresh.
-    this.transactionOrderPersistor.clearAllRecords();
+    this.persistor.getTransactionOrderPersistor().clearAllRecords();
     
     for (ReferenceMessage msg : this.references) {
       LOGGER.debug("RESENDS:" + msg);
@@ -538,7 +541,7 @@ public class ProcessTransactionHandler implements ReconnectListener {
       executeResend(message);
     }
 //  remove tracking for any resent create journal entries
-    entityPersistor.removeTrackingForClient(ClientID.NULL_ID);
+    this.persistor.getEntityPersistor().removeTrackingForClient(ClientID.NULL_ID);
     LOGGER.debug("RESENDS:END");
     this.resendNewList = null;
     

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -851,8 +851,7 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
     });
 
     // XXX: yucky casts
-    this.managementContext = new ServerManagementContext(
-        this.lockManager, (DSOChannelManagerMBean) channelManager,
+    this.managementContext = new ServerManagementContext((DSOChannelManagerMBean) channelManager,
                                                          serverStats, channelStats, instanceMonitor,
                                                          connectionPolicy,
                                                          remoteManagement);

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -190,8 +190,6 @@ import com.tc.properties.ReconnectConfig;
 import com.tc.properties.TCProperties;
 import com.tc.properties.TCPropertiesConsts;
 import com.tc.properties.TCPropertiesImpl;
-import com.tc.runtime.TCMemoryManagerImpl;
-import com.tc.runtime.logging.LongGCLogger;
 import com.tc.server.ServerConnectionValidator;
 import com.tc.server.TCServer;
 import com.tc.server.TCServerMain;
@@ -246,6 +244,7 @@ import com.tc.operatorevent.TerracottaOperatorEvent;
 import com.tc.operatorevent.TerracottaOperatorEventCallback;
 import com.tc.text.PrettyPrinter;
 import com.tc.text.PrettyPrinterImpl;
+import com.tc.util.ProductID;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -253,6 +252,7 @@ import java.io.Writer;
 import java.lang.management.ManagementFactory;
 import java.net.BindException;
 import java.nio.charset.Charset;
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.terracotta.config.TcConfiguration;
@@ -561,7 +561,7 @@ public class DistributedObjectServer implements TCDumper, LockInfoDumpHandler, S
                                                                                                              true, 0L);
 
     ClientStatePersistor clientStateStore = this.persistor.getClientStatePersistor();
-    this.connectionIdFactory = new ConnectionIDFactoryImpl(clientStateStore);
+    this.connectionIdFactory = new ConnectionIDFactoryImpl(clientStateStore, EnumSet.allOf(ProductID.class));
 
     final String dsoBind = l2DSOConfig.tsaPort().getBind();
     this.l1Listener = this.communicationsManager.createListener(new TCSocketAddress(dsoBind, serverPort), true,

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/Persistor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/Persistor.java
@@ -18,6 +18,8 @@
  */
 package com.tc.objectserver.persistence;
 
+import com.tc.net.ClientID;
+import com.tc.objectserver.api.ClientNotFoundException;
 import com.tc.text.PrettyPrintable;
 import com.tc.text.PrettyPrinter;
 
@@ -50,6 +52,20 @@ public class Persistor implements PrettyPrintable {
   }
 
   public void close() {
+  }
+  
+  public void addClientState(ClientID node) {
+    clientStatePersistor.saveClientState(node);
+    entityPersistor.addTrackingForClient(node);
+    transactionOrderPersistor.addTrackingForClient(node);
+  }
+  
+  public void removeClientState(ClientID node) throws ClientNotFoundException {
+    //  removing the client state.  threading doesn't matter here.  A client that is gone will never come back
+    //  code the underlying defensively to handle the fat that the client is gone
+    transactionOrderPersistor.removeTrackingForClient(node);
+    entityPersistor.removeTrackingForClient(node);
+    clientStatePersistor.deleteClientState(node);
   }
   
   public ClientStatePersistor getClientStatePersistor() {

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/TransactionOrderPersistor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/TransactionOrderPersistor.java
@@ -21,7 +21,6 @@ package com.tc.objectserver.persistence;
 import org.terracotta.persistence.IPlatformPersistence;
 
 import com.tc.net.ClientID;
-import com.tc.net.protocol.tcm.ChannelID;
 import com.tc.object.tx.TransactionID;
 import com.tc.text.PrettyPrintable;
 import com.tc.text.PrettyPrinter;
@@ -29,13 +28,11 @@ import com.tc.util.Assert;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 
@@ -77,22 +74,24 @@ public class TransactionOrderPersistor implements PrettyPrintable {
     // This operation requires that the globalList be rebuilt.
     this.globalList = null;
     
-    // Make sure we have tracking for this client.
-    this.clientNodeIDs.add(source.toLong());
-    
     // Increment the number of received transactions.
     this.receivedTransactionCount += 1;
     
-    // Create the new pair.
-    IPlatformPersistence.SequenceTuple transaction = new IPlatformPersistence.SequenceTuple();
-    transaction.localSequenceID = transactionID.toLong();
-    transaction.globalSequenceID = this.receivedTransactionCount;
-    
     // We now pass this straight into the underlying storage.
-    if (!source.isNull()) {
+    if (this.clientNodeIDs.contains(source.toLong())) {
+      // Create the new pair.
+      IPlatformPersistence.SequenceTuple transaction = new IPlatformPersistence.SequenceTuple();
+      transaction.localSequenceID = transactionID.toLong();
+      transaction.globalSequenceID = this.receivedTransactionCount;
+    
       return this.storageManager.fastStoreSequence(source.toLong(), transaction, oldestTransactionOnClient.toLong());
     }
     return null;
+  }
+  
+  public synchronized void addTrackingForClient(ClientID source) {
+    // Make sure we have tracking for this client.
+    this.clientNodeIDs.add(source.toLong());
   }
 
   /**
@@ -140,7 +139,7 @@ public class TransactionOrderPersistor implements PrettyPrintable {
     }
   }
   
-  private List<ClientTransaction> buildGlobalListIfNessessary() {
+  private List<ClientTransaction> buildGlobalListIfNecessary() {
     if (null == this.globalList) {
       TreeMap<Long, ClientTransaction> sortMap = new TreeMap<>();
       for (long clientID : this.clientNodeIDs) {
@@ -150,12 +149,14 @@ public class TransactionOrderPersistor implements PrettyPrintable {
         } catch (IOException e) {
           Assert.fail(e.getLocalizedMessage());
         }
-        for (IPlatformPersistence.SequenceTuple tuple : transactions) {
-          ClientTransaction transaction = new ClientTransaction();
-          transaction.clientID = clientID;
-          transaction.localTransactionID = tuple.localSequenceID;
-          transaction.globalTransactionID = tuple.globalSequenceID;
-          sortMap.put(tuple.globalSequenceID, transaction);
+        if (transactions != null) {
+          for (IPlatformPersistence.SequenceTuple tuple : transactions) {
+            ClientTransaction transaction = new ClientTransaction();
+            transaction.clientID = clientID;
+            transaction.localTransactionID = tuple.localSequenceID;
+            transaction.globalTransactionID = tuple.globalSequenceID;
+            sortMap.put(tuple.globalSequenceID, transaction);
+          }
         }
       }
       globalList = Collections.unmodifiableList(new ArrayList<>(sortMap.values()));
@@ -173,7 +174,7 @@ public class TransactionOrderPersistor implements PrettyPrintable {
     long transactionID = transaction.toLong();
     
     int index = -1;
-    List<ClientTransaction> list = buildGlobalListIfNessessary();
+    List<ClientTransaction> list = buildGlobalListIfNecessary();
     int seek = 0;
     for (ClientTransaction oneTransaction : list) {
       if ((oneTransaction.clientID == sourceID) && (oneTransaction.localTransactionID == transactionID)) {
@@ -197,7 +198,6 @@ public class TransactionOrderPersistor implements PrettyPrintable {
         Assert.fail(e.getLocalizedMessage());
       }
     }
-    this.clientNodeIDs.clear();
   }
 
   /**
@@ -227,9 +227,11 @@ public class TransactionOrderPersistor implements PrettyPrintable {
           Assert.fail(e.getLocalizedMessage());
         }
         out.indent().indent().println("Persisted transaction order for client " + clientNodeID);
-        for (IPlatformPersistence.SequenceTuple transaction : transactions) {
-          out.indent().indent().indent()
-              .println("Global seq Id = " + transaction.localSequenceID + ", local seq id = " + transaction.localSequenceID);
+        if (transactions != null) {
+          for (IPlatformPersistence.SequenceTuple transaction : transactions) {
+            out.indent().indent().indent()
+                .println("Global seq Id = " + transaction.localSequenceID + ", local seq id = " + transaction.localSequenceID);
+          }
         }
       }
     }

--- a/dso-l2/src/main/java/com/tc/server/TCServer.java
+++ b/dso-l2/src/main/java/com/tc/server/TCServer.java
@@ -41,6 +41,8 @@ public interface TCServer extends StateChangeListener {
   boolean isPassiveUnitialized();
   
   boolean isPassiveStandby();
+  
+  boolean isReconnectWindow();
     
   State getState();
 
@@ -67,6 +69,8 @@ public interface TCServer extends StateChangeListener {
   int getTSAListenPort();
 
   int getTSAGroupPort();
+  
+  int getReconnectWindowTimeout();
 
   void waitUntilShutdown();
 

--- a/dso-l2/src/main/java/com/tc/server/TCServerImpl.java
+++ b/dso-l2/src/main/java/com/tc/server/TCServerImpl.java
@@ -54,7 +54,6 @@ import com.tc.text.StringUtils;
 import com.tc.util.Assert;
 import com.tc.util.ProductInfo;
 import com.tc.util.State;
-import com.tc.util.io.IOUtils;
 import java.io.ByteArrayOutputStream;
 
 import java.io.IOException;
@@ -320,6 +319,16 @@ public class TCServerImpl extends SEDA<HttpConnectionContext> implements TCServe
     }
   }
 
+  @Override
+  public boolean isReconnectWindow() {
+    return dsoServer.getContext().getClientHandshakeManager().isStarting();
+  }
+
+  @Override
+  public int getReconnectWindowTimeout() {
+    return configurationSetupManager.dsoL2Config().clientReconnectWindow();
+  }
+  
   @Override
   public State getState() {
     return this.serverState;

--- a/dso-l2/src/main/java/com/tc/services/TerracottaServiceProviderRegistryImpl.java
+++ b/dso-l2/src/main/java/com/tc/services/TerracottaServiceProviderRegistryImpl.java
@@ -144,11 +144,19 @@ public class TerracottaServiceProviderRegistryImpl implements TerracottaServiceP
   @Override
   public void dumpStateTo(StateDumper stateDumper) {
     for (ServiceProvider serviceProvider : serviceProviders) {
-      serviceProvider.dumpStateTo(stateDumper.subStateDumper(serviceProvider.getClass().getName()));
+      try {
+        serviceProvider.dumpStateTo(stateDumper.subStateDumper(serviceProvider.getClass().getName()));
+      } catch (Throwable t) {
+        stateDumper.subStateDumper(serviceProvider.getClass().getName()).dumpState("exception", t.getMessage());
+      }
     }
 
     for (ImplementationProvidedServiceProvider implementationProvidedServiceProvider : implementationProvidedServiceProviders) {
-      implementationProvidedServiceProvider.dumpStateTo(stateDumper.subStateDumper(implementationProvidedServiceProvider.getClass().getName()));
+      try {
+        implementationProvidedServiceProvider.dumpStateTo(stateDumper.subStateDumper(implementationProvidedServiceProvider.getClass().getName()));
+      } catch (Throwable t) {
+        stateDumper.subStateDumper(implementationProvidedServiceProvider.getClass().getName()).dumpState("exception", t.getMessage());
+      }
     }
   }
 

--- a/dso-l2/src/main/java/com/tc/stats/DSO.java
+++ b/dso-l2/src/main/java/com/tc/stats/DSO.java
@@ -73,17 +73,14 @@ import javax.management.ObjectName;
 public class DSO extends AbstractNotifyingMBean implements DSOMBean {
 
   private final static TCLogger                        logger                 = TCLogging.getLogger(DSO.class);
-  private final static String                          DSO_OBJECT_NAME_PREFIX = L2MBeanNames.DSO.getCanonicalName()
-                                                                                + ",";
+  
   private final StatsImpl                           dsoStats;
   private final MBeanServer                            mbeanServer;
-  private final List<ObjectName>                       rootObjectNames        = new ArrayList<>();
   
   private final Set<ObjectName>                        clientObjectNames      = new LinkedHashSet<>();
   
   private final Map<ObjectName, Client>             clientMap              = new HashMap<>();
   private final DSOChannelManagerMBean                 channelMgr;
-  private final LockManagerMBean                       lockMgr;
   private final ChannelStats                           channelStats;
   private final ObjectInstanceMonitorMBean             instanceMonitor;
   private final TerracottaOperatorEventHistoryProvider operatorEventHistoryProvider;
@@ -101,7 +98,6 @@ public class DSO extends AbstractNotifyingMBean implements DSOMBean {
     }
     this.mbeanServer = mbeanServer;
     this.dsoStats = new StatsImpl(managementContext);
-    this.lockMgr = managementContext.getLockManager();
     this.channelMgr = managementContext.getChannelManager();
     this.channelStats = managementContext.getChannelStats();
     this.instanceMonitor = managementContext.getInstanceMonitor();
@@ -173,18 +169,6 @@ public class DSO extends AbstractNotifyingMBean implements DSOMBean {
   @Override
   public Map<String, Integer> getUnreadOperatorEventCount() {
     return operatorEventHistoryProvider.getUnreadCounts();
-  }
-
-  @Override
-  public ObjectName[] getRoots() {
-    synchronized (rootObjectNames) {
-      return rootObjectNames.toArray(new ObjectName[rootObjectNames.size()]);
-    }
-  }
-
-  @Override
-  public LockMBean[] getLocks() {
-    return (this.lockMgr != null) ? this.lockMgr.getAllLocks() : new LockMBean[0];
   }
 
   @Override

--- a/dso-l2/src/main/java/com/tc/stats/api/DSOMBean.java
+++ b/dso-l2/src/main/java/com/tc/stats/api/DSOMBean.java
@@ -41,14 +41,6 @@ public interface DSOMBean extends Stats, TerracottaMBean {
 
   Stats getStats();
 
-  static final String GC_STATUS_UPDATE = "dso.gc.status.update";
-
-  static final String ROOT_ADDED       = "dso.root.added";
-
-  ObjectName[] getRoots();
-
-  LockMBean[] getLocks();
-
   static final String CLIENT_ATTACHED = "dso.client.attached";
   static final String CLIENT_DETACHED = "dso.client.detached";
 

--- a/dso-l2/src/test/java/com/tc/net/groups/TCGroupMessageWrapperTest.java
+++ b/dso-l2/src/test/java/com/tc/net/groups/TCGroupMessageWrapperTest.java
@@ -48,6 +48,7 @@ import com.tc.net.protocol.transport.DisabledHealthCheckerConfigImpl;
 import com.tc.net.protocol.transport.NullConnectionPolicy;
 import com.tc.net.protocol.transport.TransportHandshakeErrorNullHandler;
 import com.tc.object.session.NullSessionManager;
+import com.tc.util.ProductID;
 import com.tc.util.State;
 import com.tc.util.UUID;
 
@@ -144,8 +145,8 @@ public class TCGroupMessageWrapperTest extends TestCase {
     ClientMessageChannel channel;
     clientComms.addClassMapping(TCMessageType.GROUP_WRAPPER_MESSAGE, TCGroupMessageWrapper.class);
     channel = clientComms
-        .createClientChannel(sessionManager,
-                             0, 3000, true);
+        .createClientChannel(ProductID.SERVER, sessionManager,
+                             3000);
     channel.open(Collections.singleton(new ConnectionInfo(LOCALHOST, lsnr.getBindPort())));
 
     assertTrue(channel.isConnected());

--- a/dso-l2/src/test/java/com/tc/net/protocol/tcm/TestCommunicationsManager.java
+++ b/dso-l2/src/test/java/com/tc/net/protocol/tcm/TestCommunicationsManager.java
@@ -19,14 +19,11 @@
 package com.tc.net.protocol.tcm;
 
 import com.tc.net.TCSocketAddress;
-import com.tc.net.core.ConnectionInfo;
 import com.tc.net.core.TCConnectionManager;
 import com.tc.net.protocol.transport.ConnectionIDFactory;
-import com.tc.net.protocol.transport.MessageTransportFactory;
-import com.tc.net.protocol.transport.WireProtocolMessageSink;
 import com.tc.object.session.SessionProvider;
 import com.tc.operatorevent.NodeNameProvider;
-import java.util.Collection;
+import com.tc.util.ProductID;
 
 public class TestCommunicationsManager implements CommunicationsManager {
 
@@ -48,7 +45,7 @@ public class TestCommunicationsManager implements CommunicationsManager {
   }
 
   @Override
-  public ClientMessageChannel createClientChannel(SessionProvider provider, int maxReconnectTries, int timeout, boolean followRedirects) {
+  public ClientMessageChannel createClientChannel(ProductID product, SessionProvider provider, int timeout) {
     throw new UnsupportedOperationException(); 
   }
 

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ProcessTransactionHandlerTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ProcessTransactionHandlerTest.java
@@ -58,6 +58,7 @@ import com.tc.objectserver.entity.PassiveReplicationBroker;
 import com.tc.objectserver.entity.RequestProcessor;
 import com.tc.objectserver.persistence.EntityData;
 import com.tc.objectserver.persistence.EntityPersistor;
+import com.tc.objectserver.persistence.Persistor;
 import com.tc.objectserver.persistence.TransactionOrderPersistor;
 import com.tc.objectserver.testentity.TestEntity;
 import com.tc.services.InternalServiceRegistry;
@@ -93,6 +94,11 @@ public class ProcessTransactionHandlerTest {
     when(this.terracottaServiceProviderRegistry.subRegistry(any(Long.class))).thenReturn(mock(InternalServiceRegistry.class));
     this.entityPersistor = mock(EntityPersistor.class);
     this.transactionOrderPersistor = mock(TransactionOrderPersistor.class);
+
+    Persistor persistor = mock(Persistor.class);
+    when(persistor.getEntityPersistor()).thenReturn(this.entityPersistor);
+    when(persistor.getTransactionOrderPersistor()).thenReturn(this.transactionOrderPersistor);
+    
     this.source = mock(ClientID.class);
     
     when(this.entityPersistor.getNextConsumerID()).thenReturn(1L);
@@ -117,7 +123,7 @@ public class ProcessTransactionHandlerTest {
     entityManager = new EntityManagerImpl(this.terracottaServiceProviderRegistry, clientEntityStateManager, eventCollector, processor, this::sendNoop);
     entityManager.enterActiveState();
 
-    this.processTransactionHandler = new ProcessTransactionHandler(this.entityPersistor, this.transactionOrderPersistor, channelManager, entityManager, mock(Runnable.class));
+    this.processTransactionHandler = new ProcessTransactionHandler(persistor, channelManager, entityManager, mock(Runnable.class));
 
     this.loopbackSink = new ForwardingSink(this.processTransactionHandler.getVoltronMessageHandler());
     Stage mockStage = mock(Stage.class);

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
@@ -50,6 +50,7 @@ import com.tc.objectserver.entity.MessagePayload;
 import com.tc.objectserver.entity.PlatformEntity;
 import com.tc.objectserver.entity.SimpleCompletion;
 import com.tc.objectserver.persistence.EntityPersistor;
+import com.tc.objectserver.persistence.Persistor;
 import com.tc.objectserver.persistence.TransactionOrderPersistor;
 import com.tc.stats.Stats;
 import com.tc.util.Assert;
@@ -98,6 +99,11 @@ public class ReplicatedTransactionHandlerTest {
   public void setUp() throws Exception {
     this.entityPersistor = mock(EntityPersistor.class);
     this.transactionOrderPersistor = mock(TransactionOrderPersistor.class);
+    
+    Persistor persistor = mock(Persistor.class);
+    when(persistor.getEntityPersistor()).thenReturn(this.entityPersistor);
+    when(persistor.getTransactionOrderPersistor()).thenReturn(this.transactionOrderPersistor);
+    
     this.stateManager = mock(StateManager.class);
     this.entityManager = mock(EntityManager.class);
     this.groupManager = mock(GroupManager.class);
@@ -111,7 +117,7 @@ public class ReplicatedTransactionHandlerTest {
       return null;
     }).when(platform).addRequestMessage(any(ServerEntityRequest.class), any(MessagePayload.class), any(Runnable.class), any(Consumer.class), any(Consumer.class));
     when(entityManager.getEntity(Matchers.eq(EntityDescriptor.createDescriptorForLifecycle(PlatformEntity.PLATFORM_ID, 1L)))).thenReturn(Optional.of(platform));
-    this.rth = new ReplicatedTransactionHandler(stateManager, this.transactionOrderPersistor, this.entityManager, this.entityPersistor, this.groupManager);
+    this.rth = new ReplicatedTransactionHandler(stateManager, persistor, this.entityManager, this.groupManager);
     this.rth.setOutgoingResponseSink(new ForwardingSink<ReplicatedTransactionHandler.SedaToken>(this.rth.getOutgoingResponseHandler()));
     // We need to do things like serialize/deserialize this so we can't easily use a mocked source.
     this.source = new ClientID(1);

--- a/dso-l2/src/test/java/com/tc/objectserver/impl/ConnectionIDFactoryImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/impl/ConnectionIDFactoryImplTest.java
@@ -26,7 +26,9 @@ import com.tc.net.protocol.transport.ConnectionID;
 import com.tc.net.protocol.transport.ConnectionIDFactoryListener;
 import com.tc.objectserver.persistence.ClientStatePersistor;
 import com.tc.test.TCTestCase;
+import com.tc.util.ProductID;
 import com.tc.util.sequence.MutableSequence;
+import java.util.EnumSet;
 import org.mockito.Mockito;
 
 import static org.mockito.Mockito.mock;
@@ -46,7 +48,7 @@ public class ConnectionIDFactoryImplTest extends TCTestCase {
   public void setUp() throws Exception {
     sequence = createSequence();
     persistor = createPersistor(sequence);
-    connectionIDFactory = new ConnectionIDFactoryImpl(persistor);
+    connectionIDFactory = new ConnectionIDFactoryImpl(persistor, EnumSet.allOf(ProductID.class));
     listener = mock(ConnectionIDFactoryListener.class);
     connectionIDFactory.activate(new StripeID("abc123"), 0);
     connectionIDFactory.registerForConnectionIDEvents(listener);

--- a/dso-l2/src/test/java/com/tc/objectserver/persistence/EntityPersistorTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/persistence/EntityPersistorTest.java
@@ -39,6 +39,7 @@ public class EntityPersistorTest extends TCTestCase {
     this.persistentStorage = new NullPlatformPersistentStorage();
     this.entityPersistor = new EntityPersistor(this.persistentStorage);
     this.client = new ClientID(1);
+    this.entityPersistor.addTrackingForClient(client);
   }
 
   /**

--- a/dso-l2/src/test/java/com/tc/objectserver/persistence/TransactionOrderPersistorTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/persistence/TransactionOrderPersistorTest.java
@@ -39,6 +39,8 @@ public class TransactionOrderPersistorTest extends TCTestCase {
     this.orderPersistor = new TransactionOrderPersistor(this.persistentStorage, Collections.emptySet());
     this.client1 = new ClientID(1);
     this.client2 = new ClientID(2);
+    this.orderPersistor.addTrackingForClient(client1);
+    this.orderPersistor.addTrackingForClient(client2);
   }
 
   /**

--- a/dso-l2/src/test/java/com/tc/server/NullTCServerInfo.java
+++ b/dso-l2/src/test/java/com/tc/server/NullTCServerInfo.java
@@ -120,6 +120,16 @@ public class NullTCServerInfo extends AbstractTerracottaMBean implements TCServe
   }
 
   @Override
+  public boolean isReconnectWindow() {
+    return false;
+  }
+
+  @Override
+  public int getReconnectWindowTimeout() {
+    return 0;
+  }
+
+  @Override
   public void shutdown() {
     //
   }

--- a/management/src/main/java/com/tc/management/beans/TCServerInfoMBean.java
+++ b/management/src/main/java/com/tc/management/beans/TCServerInfoMBean.java
@@ -96,6 +96,10 @@ public interface TCServerInfoMBean extends TerracottaMBean, RuntimeStatisticCons
   String getState();
 
   boolean isVerboseGC();
+  
+  boolean isReconnectWindow();
+  
+  int getReconnectWindowTimeout();
 
   void setVerboseGC(boolean verboseGC);
 

--- a/tc-messaging/src/main/java/com/tc/net/protocol/transport/ConnectionID.java
+++ b/tc-messaging/src/main/java/com/tc/net/protocol/transport/ConnectionID.java
@@ -42,7 +42,7 @@ public class ConnectionID {
 
   private static final String      NULL_SERVER_ID = "ffffffffffffffffffffffffffffffff";
   public static final String       NULL_JVM_ID    = "ffffffffffffffffffffffffffffffffffffffffffffffff";
-  private static final ProductID   DEFAULT_PRODUCT_ID = ProductID.USER;
+  private static final ProductID   DEFAULT_PRODUCT_ID = ProductID.STRIPE;
   public static final ConnectionID NULL_ID        = new ConnectionID(NULL_JVM_ID, ChannelID.NULL_ID.toLong(),
                                                                      NULL_SERVER_ID);
 
@@ -221,5 +221,9 @@ public class ConnectionID {
   
   public ClientID getClientID() {
     return new ClientID(channelID);
+  }
+  
+  public ConnectionID changeProductId(ProductID product) {
+    return new ConnectionID(jvmID, channelID, serverID, username, password, product);
   }
 }

--- a/tc-messaging/src/main/java/com/tc/net/protocol/transport/TransportHandshakeError.java
+++ b/tc-messaging/src/main/java/com/tc/net/protocol/transport/TransportHandshakeError.java
@@ -18,20 +18,19 @@
  */
 package com.tc.net.protocol.transport;
 
-public interface TransportHandshakeError {
+public enum TransportHandshakeError {
   /**
    * These are the types of error that may happen at the time of handshake
    */
-  public static final short ERROR_NONE                  = 0;
-  public static final short ERROR_HANDSHAKE             = 1;
-  public static final short ERROR_INVALID_CONNECTION_ID = 2;
-  public static final short ERROR_STACK_MISMATCH        = 3;
-  public static final short ERROR_GENERIC               = 4;
-  public static final short ERROR_MAX_CONNECTION_EXCEED = 5;
-  public static final short ERROR_RECONNECTION_REJECTED = 6;
-  public static final short ERROR_REDIRECT_CONNECTION   = 7;
+  ERROR_NONE, ERROR_HANDSHAKE, ERROR_INVALID_CONNECTION_ID, ERROR_STACK_MISMATCH,ERROR_GENERIC,
+  ERROR_MAX_CONNECTION_EXCEED, ERROR_RECONNECTION_REJECTED, ERROR_REDIRECT_CONNECTION, ERROR_NO_ACTIVE,
+  ERROR_PRODUCT_NOT_SUPPORTED;
 
-  public String getMessage();
+  public String getMessage() {
+    return name();
+  }
 
-  public short getErrorType();
+  public short getErrorType() {
+    return (short)ordinal();
+  }
 }

--- a/tc-messaging/src/main/java/com/tc/net/protocol/transport/TransportHandshakeMessageFactory.java
+++ b/tc-messaging/src/main/java/com/tc/net/protocol/transport/TransportHandshakeMessageFactory.java
@@ -30,7 +30,7 @@ public interface TransportHandshakeMessageFactory {
   public TransportHandshakeMessage createSynAck(ConnectionID connectionId, TCConnection source,
                                                 boolean isMaxConnectionsExceeded, int maxConnections, int callbackPort);
 
-  public TransportHandshakeMessage createSynAck(ConnectionID connectionId, TransportHandshakeError error,
+  public TransportHandshakeMessage createSynAck(ConnectionID connectionId, TransportHandshakeError error, String message, 
                                                 TCConnection source, boolean isMaxConnectionsExceeded,
                                                 int maxConnections);
 }

--- a/tc-messaging/src/main/java/com/tc/net/protocol/transport/TransportMessageImpl.java
+++ b/tc-messaging/src/main/java/com/tc/net/protocol/transport/TransportMessageImpl.java
@@ -60,7 +60,7 @@ class TransportMessageImpl extends WireProtocolMessageImpl implements SynMessage
   private final int          maxConnections;
   private final boolean      isMaxConnectionsExceeded;
   private final short        stackLayerFlags;
-  private final short        errorType;
+  private final TransportHandshakeError        errorType;
   private final int          callbackPort;
   private final long         timestamp;
 
@@ -85,7 +85,7 @@ class TransportMessageImpl extends WireProtocolMessageImpl implements SynMessage
       this.hasErrorContext = in.readBoolean();
 
       if (this.hasErrorContext) {
-        this.errorType = in.readShort();
+        this.errorType = TransportHandshakeError.values()[in.readShort()];
         this.errorContext = in.readString();
       } else {
         this.errorType = TransportHandshakeError.ERROR_NONE;
@@ -146,7 +146,7 @@ class TransportMessageImpl extends WireProtocolMessageImpl implements SynMessage
   }
 
   @Override
-  public short getErrorType() {
+  public TransportHandshakeError getErrorType() {
     Assert.eval(hasErrorContext());
     return this.errorType;
   }

--- a/tc-messaging/src/main/java/com/tc/object/tx/TransactionID.java
+++ b/tc-messaging/src/main/java/com/tc/object/tx/TransactionID.java
@@ -38,9 +38,4 @@ public class TransactionID extends AbstractIdentifier {
   public String getIdentifierType() {
     return "TransactionID";
   }
-
-  public TransactionID next() {
-    return new TransactionID(toLong() + 1);
-  }
-
 }

--- a/tc-messaging/src/main/java/com/tc/util/ProductID.java
+++ b/tc-messaging/src/main/java/com/tc/util/ProductID.java
@@ -23,16 +23,28 @@ package com.tc.util;
  * @author tim
  */
 public enum ProductID {
-  DIAGNOSTIC(true), TMS(true), WAN(true), USER(false);
+  DIAGNOSTIC(true, false, false), STRIPE(false, true, true), SERVER(true, false, true);
 
   private final boolean internal;
+  private final boolean reconnect;
+  private final boolean redirect;
 
-  ProductID(boolean internal) {
+  ProductID(boolean internal, boolean reconnect, boolean redirect) {
     this.internal = internal;
+    this.reconnect = reconnect;
+    this.redirect = redirect;
   }
 
   public boolean isInternal() {
     return internal;
+  }
+  
+  public boolean isReconnectEnabled() {
+    return reconnect;
+  }
+
+  public boolean isRedirectEnabled() {
+    return redirect;
   }
   
   public String toString() {

--- a/tc-messaging/src/test/java/com/tc/net/protocol/transport/ConnectionIDTest.java
+++ b/tc-messaging/src/test/java/com/tc/net/protocol/transport/ConnectionIDTest.java
@@ -34,25 +34,25 @@ public class ConnectionIDTest {
   
   @Test
   public void testSerializeFullyPopulated() throws Exception {
-    ConnectionID id = new ConnectionID("abcd", 1, "abcd", "abcd", "abcd".toCharArray(), ProductID.USER);
+    ConnectionID id = new ConnectionID("abcd", 1, "abcd", "abcd", "abcd".toCharArray(), ProductID.STRIPE);
     checkSerializeDeserialize(id);
   }
 
   @Test
   public void testSerializeEmptyPassword() throws Exception {
-    ConnectionID id = new ConnectionID("abcd", 1, "abcd", "abcd", null, ProductID.TMS);
+    ConnectionID id = new ConnectionID("abcd", 1, "abcd", "abcd", null, ProductID.DIAGNOSTIC);
     checkSerializeDeserialize(id);
   }
 
   @Test
   public void testSerializeEmptyUsername() throws Exception {
-    ConnectionID id = new ConnectionID("abcd", 1, "abcd", null, "abcd".toCharArray(), ProductID.TMS);
+    ConnectionID id = new ConnectionID("abcd", 1, "abcd", null, "abcd".toCharArray(), ProductID.DIAGNOSTIC);
     checkSerializeDeserialize(id);
   }
 
   @Test
   public void testNoCredentials() throws Exception {
-    ConnectionID id = new ConnectionID("abcd", 1, "abcd", null, null, ProductID.TMS);
+    ConnectionID id = new ConnectionID("abcd", 1, "abcd", null, null, ProductID.DIAGNOSTIC);
     checkSerializeDeserialize(id);
   }
 


### PR DESCRIPTION
add reconnect query to Server MBean
Refactor handshake error handling
Support different type of connection behaviors
Refactor platform state objects
cluster dumps should not crash the system, just log errors in the dump
entity reconnect failures result in disconnect of the client not crash of the server