### PR TITLE
APIs Issue 237: Add Serializable to ClientDescriptor

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ClientDescriptorImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ClientDescriptorImpl.java
@@ -36,14 +36,18 @@ public class ClientDescriptorImpl implements ClientDescriptor {
   // The specific node where the referenced instance lives.
   private final ClientID nodeID;
   private final ClientInstanceID clientInstance;
-  
+
   public ClientDescriptorImpl(ClientID nodeID, ClientInstanceID clientInstance) {
     Assert.assertNotNull(nodeID);
     Assert.assertNotNull(clientInstance);
     this.nodeID = nodeID;
     this.clientInstance = clientInstance;
   }
-  
+
+  public ClientDescriptorImpl() {
+    this(ClientID.NULL_ID, ClientInstanceID.NULL_ID);
+  }
+
   public ClientID getNodeID() {
     return this.nodeID;
   }
@@ -75,5 +79,9 @@ public class ClientDescriptorImpl implements ClientDescriptor {
           && this.clientInstance.equals(that.clientInstance);
     }
     return doesMatch;
+  }
+
+  public boolean isValid() {
+    return nodeID.toLong() >= 0 && clientInstance.getID() >= 0;
   }
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/InvokeContextImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/InvokeContextImpl.java
@@ -8,7 +8,7 @@ public class InvokeContextImpl implements InvokeContext {
 
   public static InvokeContext NULL_CONTEXT=new InvokeContextImpl();
 
-  private final ClientDescriptor clientDescriptor;
+  private final ClientDescriptorImpl clientDescriptor;
   private final long oldestid;
   private final long currentId;
 
@@ -16,11 +16,11 @@ public class InvokeContextImpl implements InvokeContext {
     this(ClientDescriptorImpl.NULL_ID, TransactionID.NULL_ID.toLong(), TransactionID.NULL_ID.toLong());
   }
 
-  public InvokeContextImpl(ClientDescriptor descriptor) {
+  public InvokeContextImpl(ClientDescriptorImpl descriptor) {
     this(descriptor, TransactionID.NULL_ID.toLong(), TransactionID.NULL_ID.toLong());
   }
 
-  public InvokeContextImpl(ClientDescriptor descriptor, long oldestid, long currentId) {
+  public InvokeContextImpl(ClientDescriptorImpl descriptor, long oldestid, long currentId) {
     clientDescriptor = descriptor;
     this.oldestid = oldestid;
     this.currentId = currentId;
@@ -39,6 +39,11 @@ public class InvokeContextImpl implements InvokeContext {
   @Override
   public long getOldestTransactionId() {
     return oldestid;
+  }
+
+  @Override
+  public boolean isValidClientInformation() {
+    return oldestid >= 0 && currentId >= 0 && clientDescriptor.isValid();
   }
 
   @Override

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ClientDescriptorImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ClientDescriptorImplTest.java
@@ -1,0 +1,51 @@
+package com.tc.objectserver.entity;
+
+import com.tc.net.ClientID;
+import com.tc.object.ClientInstanceID;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.hamcrest.Matchers.is;
+
+public class ClientDescriptorImplTest {
+
+
+  @Test
+  public void testSerialization() throws IOException, ClassNotFoundException {
+
+    {
+      ClientDescriptorImpl cd1 = new ClientDescriptorImpl(new ClientID(10), new ClientInstanceID(11));
+      ClientDescriptorImpl cd2 = (ClientDescriptorImpl) serializeDeserialize(cd1);
+      Assert.assertThat(cd1, is(cd2));
+      Assert.assertThat(cd1.isValid(), is(true));
+    }
+    {
+      ClientDescriptorImpl cd1 = new ClientDescriptorImpl();
+      ClientDescriptorImpl cd2 = (ClientDescriptorImpl) serializeDeserialize(cd1);
+      Assert.assertThat(cd1, is(cd2));
+      Assert.assertThat(cd1.isValid(), is(false));
+    }
+    {
+      ClientDescriptorImpl cd1 = new ClientDescriptorImpl(new ClientID(-1), new ClientInstanceID(-1));
+      ClientDescriptorImpl cd2 = (ClientDescriptorImpl) serializeDeserialize(cd1);
+      Assert.assertThat(cd1, is(cd2));
+      Assert.assertThat(cd1.isValid(), is(false));
+    }
+  }
+
+  private static Object serializeDeserialize(ClientDescriptorImpl cd1) throws IOException, ClassNotFoundException {
+    ByteArrayOutputStream baos=new ByteArrayOutputStream();
+    ObjectOutputStream oos=new ObjectOutputStream(baos);
+    oos.writeUnshared(cd1);
+    oos.flush();
+    ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
+    Object tmp= ois.readObject();
+    return tmp;
+  }
+}

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/InvokeContextImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/InvokeContextImplTest.java
@@ -1,0 +1,33 @@
+package com.tc.objectserver.entity;
+
+import com.tc.net.ClientID;
+import com.tc.object.ClientInstanceID;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+
+public class InvokeContextImplTest {
+
+  @Test
+  public void testValid() {
+    InvokeContextImpl ctx = new InvokeContextImpl(
+      new ClientDescriptorImpl(new ClientID(1), new ClientInstanceID(2)),
+      1,
+      2);
+    Assert.assertThat(ctx.isValidClientInformation(), is(true));
+  }
+
+  @Test
+  public void testInvalid() {
+    InvokeContextImpl ctx = new InvokeContextImpl(new ClientDescriptorImpl(), 1, 2);
+    Assert.assertThat(ctx.isValidClientInformation(), is(false));
+    ctx = new InvokeContextImpl(new ClientDescriptorImpl(), -1, -1);
+    Assert.assertThat(ctx.isValidClientInformation(), is(false));
+    ctx = new InvokeContextImpl(new ClientDescriptorImpl(new ClientID(1), new ClientInstanceID(2)), -1, 2);
+    Assert.assertThat(ctx.isValidClientInformation(), is(false));
+    ctx = new InvokeContextImpl(new ClientDescriptorImpl(new ClientID(1), new ClientInstanceID(2)), 1, -1);
+    Assert.assertThat(ctx.isValidClientInformation(), is(false));
+  }
+
+}

--- a/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/entity/ManagedEntityImplTest.java
@@ -102,7 +102,7 @@ public class ManagedEntityImplTest {
   private ClientEntityStateManager clientEntityStateManager;
   private ITopologyEventCollector eventCollector;
   private ClientID nodeID;
-  private ClientDescriptor clientDescriptor;
+  private ClientDescriptorImpl clientDescriptor;
   private static ExecutorService exec;
   private static ExecutorService pth;
   private InvokeContextImpl invokeContext;

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
     <tc-shader.version>1.2</tc-shader.version>
     <skip.deploy>false</skip.deploy>
 
-    <terracotta-apis.version>1.3.0-pre9</terracotta-apis.version>
-    <terracotta-configuration.version>10.3.0-pre9</terracotta-configuration.version>
+    <terracotta-apis.version>1.3.0-pre10</terracotta-apis.version>
+    <terracotta-configuration.version>10.3.0-pre10</terracotta-configuration.version>
     <galvan.version>1.3.0-pre3</galvan.version>
   </properties>
 

--- a/tc-messaging/src/main/java/com/tc/net/ClientID.java
+++ b/tc-messaging/src/main/java/com/tc/net/ClientID.java
@@ -21,6 +21,7 @@ package com.tc.net;
 import com.tc.io.TCByteBufferInput;
 import com.tc.io.TCByteBufferOutput;
 import com.tc.net.protocol.tcm.ChannelID;
+import com.tc.util.Assert;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/tc-messaging/src/main/java/com/tc/object/ClientInstanceID.java
+++ b/tc-messaging/src/main/java/com/tc/object/ClientInstanceID.java
@@ -22,15 +22,17 @@ package com.tc.object;
 import com.tc.io.TCByteBufferInput;
 import com.tc.io.TCByteBufferOutput;
 import com.tc.io.TCSerializable;
+import com.tc.util.Assert;
 
 import java.io.IOException;
+import java.io.Serializable;
 
 /**
  * @author jdis
  * Used to identify a specific acquire result of an Entity, on a client.  Note that this ID isn't a global value, but must be
  * considered within the context of a specific Entity type on a specific client.
  */
-public class ClientInstanceID implements TCSerializable<ClientInstanceID> {
+public class ClientInstanceID implements TCSerializable<ClientInstanceID>, Serializable {
   // We create this NULL_ID for cases such as CREATE/DELETE where an instance ID is still needed for the request but ideally
   // this would be removed in the future as those calls will never have instance IDs.
   public static final ClientInstanceID NULL_ID = new ClientInstanceID(0);


### PR DESCRIPTION
Actually, I had to add Serializable to ClientDescriptor and
ClientInstanceID. Also, InvokeContextImpl takes ClientDescriptorImpl
as an argument, not ClientDescriptor; this allowed for the
implementation of isClientInformationValid() on InvokeContext,
to better handle HA/MessageTracker cases.