### PR TITLE
Issue 609: Fix for InvokeContextImpl client info test method

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/InvokeContextImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/InvokeContextImpl.java
@@ -43,7 +43,7 @@ public class InvokeContextImpl implements InvokeContext {
 
   @Override
   public boolean isValidClientInformation() {
-    return oldestid >= 0 && currentId >= 0 && clientDescriptor.isValid();
+    return currentId >= 0 && clientDescriptor.isValid();
   }
 
   @Override


### PR DESCRIPTION
The eldest txid should not contribute to the validity of the client
info.