### PR TITLE
Prototype for traceability

### DIFF
--- a/common/src/main/java/com/tc/tracing/Trace.java
+++ b/common/src/main/java/com/tc/tracing/Trace.java
@@ -1,0 +1,69 @@
+package com.tc.tracing;
+
+import com.tc.entity.VoltronEntityMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Trace {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(Trace.class);
+
+  private static final ThreadLocal<Trace> ACTIVE_TRACE = new ThreadLocal<Trace>();
+  private static final Trace DUMMY = new Trace("DummyID", "DummyComponent");
+
+  private final String id;
+  private final String componentName;
+  private final Trace parent;
+
+  private long startTime;
+
+  public Trace(String id, String componentName) {
+    this(id, componentName, null);
+  }
+
+  public Trace(String id, String componentName, Trace parent) {
+    this.id = id;
+    this.componentName = componentName;
+    this.parent = parent;
+  }
+
+  public Trace subTrace(String subComponentName) {
+    return new Trace(id, componentName + ":" + subComponentName, this);
+  }
+
+  public void log(String message) {
+    LOGGER.trace("[trace - {}] {} - {}", id, componentName, message);
+  }
+
+  public void start() {
+    this.startTime = System.nanoTime();
+    LOGGER.info("[trace - {}] start trace for componentName - {}", id, this.componentName);
+    ACTIVE_TRACE.set(this);
+  }
+
+  public void end() {
+    LOGGER.info("[trace - {}] end trace for componentName - {}, elapsed {} ns", id, componentName, System.nanoTime() - startTime);
+    if(parent != null) {
+      ACTIVE_TRACE.set(parent);
+    } else {
+      ACTIVE_TRACE.set(null);
+    }
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public static Trace activeTrace() {
+    Trace trace = ACTIVE_TRACE.get();
+    return trace != null ? trace : DUMMY;
+  }
+
+  public static Trace newTrace(VoltronEntityMessage message, String componentName) {
+    try {
+      return new Trace(message.getSource() + ":" + message.getTransactionID().toLong(), componentName);
+    } catch (Exception e) {
+      return DUMMY;
+    }
+  }
+}

--- a/dso-l1/src/test/java/com/tc/object/ClientEntityManagerTest.java
+++ b/dso-l1/src/test/java/com/tc/object/ClientEntityManagerTest.java
@@ -651,6 +651,6 @@ public class ClientEntityManagerTest extends TestCase {
     public void resetStats() {
       throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
-    
+
   }
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/api/ServerEntityRequest.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/api/ServerEntityRequest.java
@@ -51,4 +51,8 @@ public interface ServerEntityRequest {
  * @return the passives that this request needs to be replicated to
  */  
   Set<NodeID> replicateTo(Set<NodeID> passives);
+
+  default String getTraceID() {
+    return getNodeID().toLong() + ":" + getTransaction().toLong();
+  }
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -52,6 +52,7 @@ import com.tc.objectserver.entity.PlatformEntity;
 import com.tc.objectserver.handler.GroupMessageBatchContext.IBatchableMessageFactory;
 import com.tc.objectserver.persistence.Persistor;
 import com.tc.properties.TCPropertiesImpl;
+import com.tc.tracing.Trace;
 import com.tc.util.Assert;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -276,6 +277,8 @@ public class ReplicatedTransactionHandler {
 
 //  don't need to worry about resends here for lifecycle messages.  active will filer them  
   private void replicatedActivityReceived(ServerID activeSender, SyncReplicationActivity activity) throws EntityException {
+    Trace trace = new Trace(activity.getActivityID().toString(), "Replication");
+    trace.start();
     ClientID sourceNodeID = activity.getSource();
     TransactionID transactionID = activity.getTransactionID();
     TransactionID oldestTransactionOnClient = activity.getOldestTransactionOnClient();
@@ -381,6 +384,7 @@ public class ReplicatedTransactionHandler {
         acknowledge(activeSender, activity, ReplicationResultCode.FAIL);
       }
     }
+    trace.end();
   }
   
   private void establishNewPassive() {
@@ -400,6 +404,8 @@ public class ReplicatedTransactionHandler {
   }  
   
   private void syncActivityReceived(ServerID activeSender, SyncReplicationActivity activity) {
+    Trace trace = new Trace(activity.getActivityID().toString(), "Sync");
+    trace.start();
     SyncReplicationActivity.ActivityType thisActivityType = activity.getActivityType();
     FetchID fetch = activity.getFetchID();
     EntityDescriptor descriptor = EntityDescriptor.createDescriptorForInvoke(fetch, ClientInstanceID.NULL_ID);
@@ -464,6 +470,7 @@ public class ReplicatedTransactionHandler {
     } catch (EntityException ee) {
       throw new RuntimeException(ee);
     }
+    trace.end();
   }
   
   private void start() {

--- a/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
+++ b/dso-l2/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
@@ -151,6 +151,7 @@ public class ReplicatedTransactionHandlerTest {
     when(activity.getFetchID()).thenReturn(fetch);
     when(activity.getOldestTransactionOnClient()).thenReturn(TransactionID.NULL_ID);
     when(activity.getExtendedData()).thenReturn(new byte[0]);
+    when(activity.getActivityID()).thenReturn(SyncReplicationActivity.ActivityID.getNextID());
     ReplicationMessage msg = mock(ReplicationMessage.class);
     when(msg.messageFrom()).thenReturn(sid);
     when(msg.getActivities()).thenReturn(Collections.singletonList(activity));
@@ -203,6 +204,7 @@ public class ReplicatedTransactionHandlerTest {
     when(activity.getEntityID()).thenReturn(eid);
     when(activity.getFetchID()).thenReturn(fetch);
     when(activity.getOldestTransactionOnClient()).thenReturn(TransactionID.NULL_ID);
+    when(activity.getActivityID()).thenReturn(SyncReplicationActivity.ActivityID.getNextID());
     ReplicationMessage msg = mock(ReplicationMessage.class);
     MessageCodec codec = mock(MessageCodec.class);
     when(msg.messageFrom()).thenReturn(sid);


### PR DESCRIPTION
Creating this PR to discuss traceability in more detail, this work is in very early stage and lot of code polishing is needed. 

**Notes**
- ClientID:TranscationID is used to track a particular message
- Not all code paths are covered. 

**Sample output**
```
➜  system-tests git:(master) ✗ grep 'trace - 1:2' target/test-classes/testing_directory/org.terracotta.kit_testing.GalvanDumperTest/OneActive/client0/stdout.log
2017-07-11 17:31:32,321 [main] INFO com.tc.tracing.Trace - [trace - 1:2] start trace for componentName - ClientEntityManagerImpl.invokeAction
2017-07-11 17:31:32,321 [main] INFO com.tc.tracing.Trace - [trace - 1:2] InFlightMessage - Received ACK: SENT
2017-07-11 17:31:32,321 [main] INFO com.tc.tracing.Trace - [trace - 1:2] ClientEntityManagerImpl.invokeAction - InFlightMessage.send()
2017-07-11 17:31:32,321 [main] INFO com.tc.tracing.Trace - [trace - 1:2] ClientEntityManagerImpl.invokeAction - InFlightMessage.waitForAcks
2017-07-11 17:31:32,321 [main] INFO com.tc.tracing.Trace - [trace - 1:2] end trace for componentName - ClientEntityManagerImpl.invokeAction, elapsed 276694 ns
2017-07-11 17:31:32,322 [main] INFO com.tc.tracing.Trace - [trace - 1:2] InFlightMessage - InFlightMessage.get()
2017-07-11 17:31:32,336 [WorkerThread(multi_request_ack_stage, 0)] INFO com.tc.tracing.Trace - [trace - 1:2] InFlightMessage - Received ACK: RECEIVED
2017-07-11 17:31:32,370 [WorkerThread(multi_request_ack_stage, 0)] INFO com.tc.tracing.Trace - [trace - 1:2] InFlightMessage - Received Result: [B@78744ace ; Exception: None
2017-07-11 17:31:32,371 [WorkerThread(multi_request_ack_stage, 0)] INFO com.tc.tracing.Trace - [trace - 1:2] InFlightMessage - Received ACK: RETIRED
➜  system-tests git:(master) ✗ grep 'trace - 1:2' target/test-classes/testing_directory/org.terracotta.kit_testing.GalvanDumperTest/OneActive/stripe0/testServer0/stdout.log
2017-07-11 17:31:32,323 [WorkerThread(voltron_message_stage, 0)] INFO com.tc.tracing.Trace - [trace - 1:2] start trace for componentName - ProcessTransactionHandler.AddMessage
2017-07-11 17:31:32,323 [WorkerThread(voltron_message_stage, 0)] INFO com.tc.tracing.Trace - [trace - 1:2] ProcessTransactionHandler.AddMessage - Handling INVOKE_ACTION
2017-07-11 17:31:32,325 [WorkerThread(voltron_message_stage, 0)] INFO com.tc.tracing.Trace - [trace - 1:2] ProcessTransactionHandler.AddMessage - ManagedEntityImpl.addRequestMessage
2017-07-11 17:31:32,325 [WorkerThread(voltron_message_stage, 0)] INFO com.tc.tracing.Trace - [trace - 1:2] ProcessTransactionHandler.AddMessage - ManagedEntityImpl.processInvokeRequest
2017-07-11 17:31:32,327 [WorkerThread(voltron_message_stage, 0)] INFO com.tc.tracing.Trace - [trace - 1:2] ProcessTransactionHandler.AddMessage - ManagedEntityImpl.scheduleInOrder
2017-07-11 17:31:32,328 [WorkerThread(voltron_message_stage, 0)] INFO com.tc.tracing.Trace - [trace - 1:2] end trace for componentName - ProcessTransactionHandler.AddMessage, elapsed 5079224 ns
2017-07-11 17:31:32,328 [WorkerThread(request_processor_stage, 4, 4)] INFO com.tc.tracing.Trace - [trace - 1:2] start trace for componentName - ManagedEntityImpl.invoke
2017-07-11 17:31:32,329 [WorkerThread(request_processor_stage, 4, 4)] INFO com.tc.tracing.Trace - [trace - 1:2] ManagedEntityImpl.invoke - ManagedEntityImpl.performAction
2017-07-11 17:31:32,336 [WorkerThread(request_processor_stage, 4, 4)] INFO com.tc.tracing.Trace - [trace - 1:2] start trace for componentName - ManagedEntityImpl.invoke:invokeActive
2017-07-11 17:31:32,370 [WorkerThread(request_processor_stage, 4, 4)] INFO com.tc.tracing.Trace - [trace - 1:2] end trace for componentName - ManagedEntityImpl.invoke:performAction.invokeActive, elapsed 33644662 ns
2017-07-11 17:31:32,371 [WorkerThread(request_processor_stage, 4, 4)] INFO com.tc.tracing.Trace - [trace - 1:2] end trace for componentName - ManagedEntityImpl.invoke, elapsed 42346361 ns
➜  system-tests git:(master) ✗
```