### PR TITLE
Add tracing for deferred messages

### DIFF
--- a/common/src/main/java/com/tc/tracing/Trace.java
+++ b/common/src/main/java/com/tc/tracing/Trace.java
@@ -61,7 +61,7 @@ public class Trace {
 
   public static Trace newTrace(VoltronEntityMessage message, String componentName) {
     try {
-      return new Trace(message.getSource() + ":" + message.getTransactionID().toLong(), componentName);
+      return new Trace(message.getSource().toLong() + ":" + message.getTransactionID().toLong(), componentName);
     } catch (Exception e) {
       return DUMMY;
     }

--- a/dso-l2/src/main/java/com/tc/objectserver/api/Retiree.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/api/Retiree.java
@@ -30,4 +30,5 @@ import com.tc.object.tx.TransactionID;
 public interface Retiree {
   void retired(); 
   TransactionID getTransaction();
+  String getTraceID();
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/AbstractServerEntityRequestResponse.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/AbstractServerEntityRequestResponse.java
@@ -87,6 +87,11 @@ public abstract class AbstractServerEntityRequestResponse implements ServerEntit
   }
 
   @Override
+  public String getTraceID() {
+    return src.toLong() + ":" + transaction.toLong();
+  }
+
+  @Override
   public ClientID getNodeID() {
     return src;
   }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -761,6 +761,7 @@ public class ManagedEntityImpl implements ManagedEntity {
     long currentId = wrappedRequest.getTransaction().toLong();
     long oldestId = wrappedRequest.getOldestTransactionOnClient().toLong();
     EntityMessage em = message.decodeRawMessage(raw->this.codec.decodeMessage(raw));
+    Trace.activeTrace().log("invoking " + em);
     if (this.isInActiveState) {
       if (null == this.activeServerEntity) {
         throw new IllegalStateException("Actions on a non-existent entity.");
@@ -776,8 +777,8 @@ public class ManagedEntityImpl implements ManagedEntity {
               new InvokeContextImpl(clientDescriptor, oldestId, currentId),
               em);
             byte[] er = runWithHelper(()->codec.encodeResponse(resp));
-            response.complete(er);
             trace.end();
+            response.complete(er);
           } else {
             response.complete(new byte[0]);
           }
@@ -1299,6 +1300,7 @@ public class ManagedEntityImpl implements ManagedEntity {
     }
     
     public void received() {
+      Trace.activeTrace().log("received ");
       this.receivedSent.set();
       if (received != null) {
         received.run();
@@ -1306,6 +1308,7 @@ public class ManagedEntityImpl implements ManagedEntity {
     }
     
     public void complete() {
+      Trace.activeTrace().log("Completed without result ");
       if (!this.receivedSent.isSet()) {
         received();
       }
@@ -1325,6 +1328,7 @@ public class ManagedEntityImpl implements ManagedEntity {
     }  
     
     public void complete(byte[] value) {
+      Trace.activeTrace().log("Completed with result: " + value);
       if (!this.receivedSent.isSet()) {
         received();
       }
@@ -1344,6 +1348,7 @@ public class ManagedEntityImpl implements ManagedEntity {
     }
     
     public void failure(EntityException ee) {
+      Trace.activeTrace().log("Failure - exception: " + ee.getLocalizedMessage());
       if (!this.receivedSent.isSet()) {
         received();
       }

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ProcessTransactionHandler.java
@@ -231,6 +231,7 @@ public class ProcessTransactionHandler implements ReconnectListener {
     List<Retiree> readyToRetire = entity.getRetirementManager().retireForCompletion(message);
     for (Retiree toRetire : readyToRetire) {
       if (null != toRetire) {
+        Trace.activeTrace().log("Retiring message with trace id " + toRetire.getTraceID());
         toRetire.retired();
       }
     }
@@ -325,6 +326,11 @@ public class ProcessTransactionHandler implements ReconnectListener {
                 public TransactionID getTransaction() {
                   return serverEntityRequest.getTransaction();
                 }
+
+                @Override
+                public String getTraceID() {
+                  return serverEntityRequest.getTraceID();
+                }
               });
               
               retireMessagesForEntity(locked, message);
@@ -345,6 +351,11 @@ public class ProcessTransactionHandler implements ReconnectListener {
                 @Override
                 public TransactionID getTransaction() {
                   return serverEntityRequest.getTransaction();
+                }
+
+                @Override
+                public String getTraceID() {
+                  return serverEntityRequest.getTraceID();
                 }
               });
               

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -277,7 +277,7 @@ public class ReplicatedTransactionHandler {
 
 //  don't need to worry about resends here for lifecycle messages.  active will filer them  
   private void replicatedActivityReceived(ServerID activeSender, SyncReplicationActivity activity) throws EntityException {
-    Trace trace = new Trace(activity.getActivityID().toString(), "Replication");
+    Trace trace = new Trace(String.valueOf(activity.getActivityID().id), "Replication");
     trace.start();
     ClientID sourceNodeID = activity.getSource();
     TransactionID transactionID = activity.getTransactionID();
@@ -404,7 +404,7 @@ public class ReplicatedTransactionHandler {
   }  
   
   private void syncActivityReceived(ServerID activeSender, SyncReplicationActivity activity) {
-    Trace trace = new Trace(activity.getActivityID().toString(), "Sync");
+    Trace trace = new Trace(String.valueOf(activity.getActivityID().id), "Sync");
     trace.start();
     SyncReplicationActivity.ActivityType thisActivityType = activity.getActivityType();
     FetchID fetch = activity.getFetchID();

--- a/dso-l2/src/main/java/com/tc/objectserver/handler/RetirementManager.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/handler/RetirementManager.java
@@ -19,6 +19,7 @@
 package com.tc.objectserver.handler;
 
 import com.tc.objectserver.api.Retiree;
+import com.tc.tracing.Trace;
 import com.tc.util.Assert;
 import org.terracotta.entity.ConcurrencyStrategy;
 import org.terracotta.entity.EntityMessage;
@@ -147,6 +148,7 @@ public class RetirementManager {
   }
 
   public synchronized void deferRetirement(EntityMessage invokeMessageToDefer, EntityMessage laterMessage) {
+    Trace.activeTrace().log("Deferring retirement for " + invokeMessageToDefer + " until " + laterMessage + " is finished");
     LogicalSequence myRequest = this.currentlyRunning.get(invokeMessageToDefer);
     
     if (myRequest == null) {

--- a/dso-l2/src/main/java/com/tc/services/EntityMessengerService.java
+++ b/dso-l2/src/main/java/com/tc/services/EntityMessengerService.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Implements the IEntityMessenger interface by maintaining a "fake" EntityDescriptor (as there is no actual reference from
@@ -238,6 +239,8 @@ public class EntityMessengerService implements IEntityMessenger, CreateListener 
    * We fake up a Voltron entity message to enqueue for the entity to process in the future.
    */
   private static class FakeEntityMessage implements VoltronEntityMessage {
+    private static final AtomicLong NEXT_FAKE_TXN_ID = new AtomicLong(0);
+
     private final EntityDescriptor descriptor;
     private final EntityMessage identityMessage;
     private final byte[] message;
@@ -257,7 +260,7 @@ public class EntityMessengerService implements IEntityMessenger, CreateListener 
 
     @Override
     public TransactionID getTransactionID() {
-      return TransactionID.NULL_ID;
+      return new TransactionID(NEXT_FAKE_TXN_ID.getAndIncrement());
     }
 
     @Override


### PR DESCRIPTION
Tracing deferred messages is possible now. 

➜  system-tests git:(master) ✗ grep Deferring target/test-classes/testing_directory/org.terracotta.kit_testing.GalvanEntityMessengerTest/OneActive/stripe0/testServer0/stdout.log
2017-07-14 19:00:39,851 [WorkerThread(request_processor_stage, 7, 7)] INFO com.tc.tracing.Trace - [0:5] ManagedEntityImpl.invoke:invokeActive - Deferring retirement for GrabBagMessage{op=org.terracotta.entity.grabbag.PostAsyncMessageOperation@666fa268} until GrabBagMessage{op=org.terracotta.entity.grabbag.OneStringOperation@18dd227b} is finished
➜  system-tests git:(master) ✗ grep 'GrabBagMessage{op=org.terracotta.entity.grabbag.OneStringOperation@18dd227b}' target/test-classes/testing_directory/org.terracotta.kit_testing.GalvanEntityMessengerTest/OneActive/stripe0/testServer0/stdout.log
2017-07-14 19:00:39,851 [WorkerThread(request_processor_stage, 7, 7)] INFO com.tc.tracing.Trace - [0:5] ManagedEntityImpl.invoke:invokeActive - Deferring retirement for GrabBagMessage{op=org.terracotta.entity.grabbag.PostAsyncMessageOperation@666fa268} until GrabBagMessage{op=org.terracotta.entity.grabbag.OneStringOperation@18dd227b} is finished
2017-07-14 19:00:39,853 [WorkerThread(request_processor_stage, 7, 7)] INFO com.tc.tracing.Trace - [-1:1] ManagedEntityImpl.invoke - invoking GrabBagMessage{op=org.terracotta.entity.grabbag.OneStringOperation@18dd227b}
➜  system-tests git:(master) ✗ grep -e '-1:1' target/test-classes/testing_directory/org.terracotta.kit_testing.GalvanEntityMessengerTest/OneActive/stripe0/testServer0/stdout.log
2017-07-14 19:00:39,852 [WorkerThread(voltron_message_stage, 0)] INFO com.tc.tracing.Trace - [-1:1] start trace for componentName - ProcessTransactionHandler.AddMessage
2017-07-14 19:00:39,852 [WorkerThread(voltron_message_stage, 0)] INFO com.tc.tracing.Trace - [-1:1] ProcessTransactionHandler.AddMessage - Handling INVOKE_ACTION
2017-07-14 19:00:39,852 [WorkerThread(voltron_message_stage, 0)] INFO com.tc.tracing.Trace - [-1:1] ProcessTransactionHandler.AddMessage - ManagedEntityImpl.addRequestMessage
2017-07-14 19:00:39,852 [WorkerThread(voltron_message_stage, 0)] INFO com.tc.tracing.Trace - [-1:1] ProcessTransactionHandler.AddMessage - ManagedEntityImpl.processInvokeRequest
2017-07-14 19:00:39,852 [WorkerThread(voltron_message_stage, 0)] INFO com.tc.tracing.Trace - [-1:1] ProcessTransactionHandler.AddMessage - ManagedEntityImpl.scheduleInOrder
2017-07-14 19:00:39,853 [WorkerThread(voltron_message_stage, 0)] INFO com.tc.tracing.Trace - [-1:1] end trace for componentName - ProcessTransactionHandler.AddMessage, elapsed 1121654 ns
2017-07-14 19:00:39,853 [WorkerThread(request_processor_stage, 7, 7)] INFO com.tc.tracing.Trace - [-1:1] start trace for componentName - ManagedEntityImpl.invoke
2017-07-14 19:00:39,853 [WorkerThread(request_processor_stage, 7, 7)] INFO com.tc.tracing.Trace - [-1:1] ManagedEntityImpl.invoke - received false
2017-07-14 19:00:39,853 [WorkerThread(request_processor_stage, 7, 7)] INFO com.tc.tracing.Trace - [-1:1] ManagedEntityImpl.invoke - ManagedEntityImpl.performAction
2017-07-14 19:00:39,853 [WorkerThread(request_processor_stage, 7, 7)] INFO com.tc.tracing.Trace - [-1:1] ManagedEntityImpl.invoke - invoking GrabBagMessage{op=org.terracotta.entity.grabbag.OneStringOperation@18dd227b}
2017-07-14 19:00:39,853 [WorkerThread(request_processor_stage, 7, 7)] INFO com.tc.tracing.Trace - [-1:1] start trace for componentName - ManagedEntityImpl.invoke:invokeActive
2017-07-14 19:00:39,853 [WorkerThread(request_processor_stage, 7, 7)] INFO com.tc.tracing.Trace - [-1:1] end trace for componentName - ManagedEntityImpl.invoke:invokeActive, elapsed 47432 ns
2017-07-14 19:00:39,853 [WorkerThread(request_processor_stage, 7, 7)] INFO com.tc.tracing.Trace - [-1:1] ManagedEntityImpl.invoke - Completed with result: [B@4736cdf5 false
2017-07-14 19:00:39,854 [WorkerThread(request_processor_stage, 7, 7)] INFO com.tc.tracing.Trace - [-1:1] ManagedEntityImpl.invoke - Retiring 0:5
2017-07-14 19:00:39,854 [WorkerThread(request_processor_stage, 7, 7)] INFO com.tc.tracing.Trace - [-1:1] ManagedEntityImpl.invoke - Retiring -1:1
2017-07-14 19:00:39,854 [WorkerThread(request_processor_stage, 7, 7)] INFO com.tc.tracing.Trace - [-1:1] end trace for componentName - ManagedEntityImpl.invoke, elapsed 1512758 ns
➜  system-tests git:(master) ✗ grep -e '0:5' target/test-classes/testing_directory/org.terracotta.kit_testing.GalvanEntityMessengerTest/OneActive/client0/stdout.log
2017-07-14 19:00:39,572 [main] INFO com.tc.net.protocol.tcm.CommunicationsManager - HealthCheck CallbackPort Listener started at /0:0:0:0:0:0:0:0:59787
2017-07-14 19:00:39,847 [main] INFO com.tc.tracing.Trace - [0:5] start trace for componentName - ClientEntityManagerImpl.invokeAction
2017-07-14 19:00:39,847 [main] INFO com.tc.tracing.Trace - [0:5] InFlightMessage - Received ACK: SENT
2017-07-14 19:00:39,847 [main] INFO com.tc.tracing.Trace - [0:5] ClientEntityManagerImpl.invokeAction - InFlightMessage.send()
2017-07-14 19:00:39,848 [main] INFO com.tc.tracing.Trace - [0:5] ClientEntityManagerImpl.invokeAction - InFlightMessage.waitForAcks
2017-07-14 19:00:39,848 [main] INFO com.tc.tracing.Trace - [0:5] end trace for componentName - ClientEntityManagerImpl.invokeAction, elapsed 654312 ns
2017-07-14 19:00:39,848 [main] INFO com.tc.tracing.Trace - [0:5] InFlightMessage - get()
2017-07-14 19:00:39,852 [WorkerThread(multi_request_ack_stage, 0)] INFO com.tc.tracing.Trace - [0:5] InFlightMessage - Received ACK: RECEIVED
2017-07-14 19:00:39,854 [WorkerThread(multi_request_ack_stage, 0)] INFO com.tc.tracing.Trace - [0:5] InFlightMessage - Received Result: [B@2655d294 ; Exception: None
2017-07-14 19:00:39,855 [WorkerThread(multi_request_ack_stage, 0)] INFO com.tc.tracing.Trace - [0:5] InFlightMessage - Received ACK: RETIRED
➜  system-tests git:(master) ✗