### PR TITLE
Fix #613: Add extended configurations state to cluster state dump

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -23,6 +23,7 @@ import com.tc.async.api.EventHandlerException;
 
 import com.tc.logging.TCLogging;
 import com.tc.objectserver.api.EntityManager;
+import com.tc.services.MappedStateCollector;
 import com.tc.services.PlatformConfigurationImpl;
 import com.tc.services.PlatformServiceProvider;
 import com.tc.services.SingleThreadedTimer;
@@ -332,12 +333,21 @@ public class DistributedObjectServer implements TCDumper, ServerConnectionValida
     this.l2Coordinator.prettyPrint(pp);
     this.entityManager.prettyPrint(pp);
     this.serviceRegistry.prettyPrint(pp);
+    addExtendedConfigState(pp);
     return pp.toString().getBytes(set);
   }
 
   @Override
   public void dump() {
     TCLogging.getDumpLogger().info(new String(getClusterState(Charset.defaultCharset()), Charset.defaultCharset()));
+  }
+
+  private void addExtendedConfigState(PrettyPrinter prettyPrinter) {
+    MappedStateCollector mappedStateCollector = new MappedStateCollector("collector");
+    this.configSetupManager.commonl2Config().getBean().addStateTo(mappedStateCollector);
+    Map<String, Object> state = new HashMap<>();
+    state.put("ExtendedConfigs", mappedStateCollector.getMap());
+    prettyPrinter.println(state);
   }
 
   public synchronized void start() throws IOException, LocationNotCreatedException, FileNotCreatedException {

--- a/dso-l2/src/main/java/com/tc/services/MappedStateCollector.java
+++ b/dso-l2/src/main/java/com/tc/services/MappedStateCollector.java
@@ -32,7 +32,6 @@ public class MappedStateCollector implements StateDumpCollector {
 
   public MappedStateCollector(String name) {
     this.name = name;
-    dumpState.put("name", name);
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <skip.deploy>false</skip.deploy>
 
     <terracotta-apis.version>1.3.0-pre11</terracotta-apis.version>
-    <terracotta-configuration.version>10.3.0-pre12</terracotta-configuration.version>
+    <terracotta-configuration.version>10.3.0-pre13</terracotta-configuration.version>
     <galvan.version>1.3.0-pre6</galvan.version>
   </properties>
 


### PR DESCRIPTION
updated the PR with new terracotta-configuration 10.3.0-pre13 release 