### PR TITLE
Configuration extension for server logging

### DIFF
--- a/dso-l2/src/main/resources/logback.xml
+++ b/dso-l2/src/main/resources/logback.xml
@@ -27,5 +27,7 @@
     <appender-ref ref="TC_BASE" />
   </logger>
 
+  <include optional="true" resource="logback-ext.xml"/>
+
 </configuration>
 

--- a/galvan-support/src/main/java/org/terracotta/testing/rules/BasicExternalCluster.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/rules/BasicExternalCluster.java
@@ -52,6 +52,7 @@ class BasicExternalCluster extends Cluster {
   private final String entityFragment;
   private final int clientReconnectWindowTime;
   private final Properties tcProperties = new Properties();
+  private final String logConfigExt;
 
   private String displayName;
   private ReadyStripe cluster;
@@ -65,7 +66,7 @@ class BasicExternalCluster extends Cluster {
   private Thread shepherdingThread;
   private boolean isSafe;
 
-  BasicExternalCluster(File clusterDirectory, int stripeSize, List<File> serverJars, String namespaceFragment, String serviceFragment, String entityFragment, int clientReconnectWindowTime, Properties tcProperties) {
+  BasicExternalCluster(File clusterDirectory, int stripeSize, List<File> serverJars, String namespaceFragment, String serviceFragment, String entityFragment, int clientReconnectWindowTime, Properties tcProperties, String logConfigExt) {
     if (clusterDirectory.exists()) {
       if (clusterDirectory.isFile()) {
         throw new IllegalArgumentException("Cluster directory is a file: " + clusterDirectory);
@@ -84,6 +85,7 @@ class BasicExternalCluster extends Cluster {
     this.serverJars = serverJars;
     this.clientReconnectWindowTime = clientReconnectWindowTime;
     this.tcProperties.putAll(tcProperties);
+    this.logConfigExt = logConfigExt;
     
     this.clientThread = Thread.currentThread();
   }
@@ -143,10 +145,9 @@ class BasicExternalCluster extends Cluster {
     interlock = new GalvanStateInterlock(verboseManager.createComponentManager("[Interlock]").createHarnessLogger(), stateManager);
 
     cluster = ReadyStripe.configureAndStartStripe(interlock, stateManager, displayVerboseManager,
-        serverInstallDirectory.getAbsolutePath(),
-        testParentDirectory.getAbsolutePath(),
-        stripeSize, heapInM, serverPort, serverDebugStartPort, 0,
-        serverJarPaths, namespaceFragment, serviceFragment, entityFragment, clientReconnectWindowTime, tcProperties);
+        serverInstallDirectory.getAbsolutePath(), testParentDirectory.getAbsolutePath(), stripeSize, heapInM, serverPort,
+        serverDebugStartPort, 0, serverJarPaths, namespaceFragment, serviceFragment, entityFragment,
+        clientReconnectWindowTime, tcProperties, logConfigExt);
     // Spin up an extra thread to call waitForFinish on the stateManager.
     // This is required since galvan expects that the client is running in a different thread (different process, usually)
     // than the framework, and the framework waits for the finish so that it can terminate the clients/servers if any of

--- a/galvan-support/src/main/java/org/terracotta/testing/rules/BasicExternalClusterBuilder.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/rules/BasicExternalClusterBuilder.java
@@ -17,6 +17,8 @@ public class BasicExternalClusterBuilder {
   private String entityFragment = "";
   private int clientReconnectWindowTime = ConfigBuilder.DEFAULT_CLIENT_RECONNECT_WINDOW_TIME;
   private Properties tcProperties = new Properties();
+  private String logConfigExt = "logback-ext.xml";
+
 
   private BasicExternalClusterBuilder(final int stripeSize) {
     this.stripeSize = stripeSize;
@@ -88,8 +90,13 @@ public class BasicExternalClusterBuilder {
     return this;
   }
 
+  public BasicExternalClusterBuilder logConfigExtensionResourceName(String logConfigExt) {
+    this.logConfigExt = logConfigExt;
+    return this;
+  }
+
   public BasicExternalCluster build() {
     return new BasicExternalCluster(clusterDirectory, stripeSize, serverJars, namespaceFragment, serviceFragment, entityFragment,
-        clientReconnectWindowTime, tcProperties);
+        clientReconnectWindowTime, tcProperties, logConfigExt);
   }
 }

--- a/galvan-support/src/test/java/org/terracotta/testing/rules/SimpleActivePassiveWithClassRuleIT.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/rules/SimpleActivePassiveWithClassRuleIT.java
@@ -34,7 +34,7 @@ import org.terracotta.passthrough.IClusterControl;
 @Ignore
 public class SimpleActivePassiveWithClassRuleIT {
   @ClassRule
-  public static final Cluster CLUSTER = BasicExternalClusterBuilder.newCluster(2).build();
+  public static final Cluster CLUSTER = BasicExternalClusterBuilder.newCluster(2).logConfigExtensionResourceName("custom-logback-ext.xml").build();
 
   /**
    * This will ensure that a fail-over correctly happens.

--- a/galvan-support/src/test/resources/custom-logback-ext.xml
+++ b/galvan-support/src/test/resources/custom-logback-ext.xml
@@ -1,0 +1,5 @@
+<included>
+  <root level="DEBUG">
+    <appender-ref ref="TC_BASE" />
+  </root>
+</included>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <terracotta-apis.version>1.3.0-pre13</terracotta-apis.version>
     <terracotta-configuration.version>10.3.0-pre16</terracotta-configuration.version>
-    <galvan.version>1.3.0-pre8</galvan.version>
+    <galvan.version>1.3.0-pre9</galvan.version>
   </properties>
 
   <modules>

--- a/terracotta-kit/src/assemble/server/lib/logback-ext.xml
+++ b/terracotta-kit/src/assemble/server/lib/logback-ext.xml
@@ -1,0 +1,27 @@
+<included>
+  <!--
+  This is an extension point for TC server logging configuration.
+  This extension is done using the file inclusion feature of logback.
+  Refer to https://logback.qos.ch/manual/configuration.html#fileInclusion for more details.
+
+  You are free to define and use your own appenders and loggers here.
+  You can also use predefined TC appenders.
+  Use the appender name "TC_BASE" to refer to the Terracotta base appender that logs to the terracotta-server.log file.
+  Use the appender name "STDOUT" to refer to the Terracotta console appender.
+  -->
+
+  <!--
+    You can change the Terracotta root log level by uncommenting the following block and changing the level.
+  -->
+  <!--<root level="DEBUG">
+    <appender-ref ref="TC_BASE" />
+  </root>-->
+
+  <!--
+    You can customize log levels for specific loggers by defining config blocks as follows:
+  -->
+  <!--<logger name="some.specific.logger.name" level="DEBUG">
+    <appender-ref ref="TC_BASE" />
+  </logger>-->
+
+</included>


### PR DESCRIPTION
This `logback-ext.xml` is intended to be used by developers. This file is packaged as part of the kit and is documented in itself. If we don't want this file exposed like this we could make it a hidden file and document the existence of such a file elsewhere. Otherwise we could completely avoid packaging this file and have this template also included in the documentation. Not sure what's the best thing to do here. So suggestions welcome.