### PR TITLE
Use only target passives in equality for passive synch channels

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -1403,16 +1403,12 @@ public class ManagedEntityImpl implements ManagedEntity {
 
       EntityMessagePassiveSynchronizationChannelImpl channel = (EntityMessagePassiveSynchronizationChannelImpl) o;
 
-      if (concurrencyKey != channel.concurrencyKey) {
-        return false;
-      }
       return passives.equals(channel.passives);
     }
 
     @Override
     public int hashCode() {
       int result = passives.hashCode();
-      result = 31 * result + concurrencyKey;
       return result;
     }
   }


### PR DESCRIPTION
As Abhilash points out, the concurrency key is not useful for this equality check. 