### PR TITLE
Setting JAVA_HOME via installer setenv if available

### DIFF
--- a/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
+++ b/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
@@ -30,6 +30,11 @@ esac
 TC_SERVER_DIR=$(dirname "$(cd "$(dirname "$0")";pwd)")
 PLUGIN_LIB_DIR="${TC_SERVER_DIR}/plugins/lib"
 PLUGIN_API_DIR="${TC_SERVER_DIR}/plugins/api"
+INSTALLER_DIR="$(dirname $(dirname "$TC_SERVER_DIR"))/install"
+
+if [ -r "$INSTALLER_DIR"/bin/setenv.sh ] ; then
+  . "$INSTALLER_DIR"/bin/setenv.sh
+fi
 
 if ! [ -d "${JAVA_HOME}" ]; then
   echo "$0: the JAVA_HOME environment variable is not defined correctly"


### PR DESCRIPTION
Similar behavior to tc 4.x - if installed via installer, use the installer JVM