### PR TITLE
[PROPOSAL] Close #782: Do not flush cached data sent with pushBestEffortsData() after promotion

### DIFF
--- a/dso-l2/src/main/java/com/tc/services/BestEffortsMonitoring.java
+++ b/dso-l2/src/main/java/com/tc/services/BestEffortsMonitoring.java
@@ -60,23 +60,7 @@ public class BestEffortsMonitoring {
   public synchronized void flushAfterActivePromotion(PlatformServer thisServer, TerracottaServiceProviderRegistry globalRegistry) {
     // We no longer care about the timer so clear it, if one exists.
     ensureTimerCancelled();
-    
-    // Walk each consumerID, looking up their registries, and flushing all entries to the implementation.
-    for (Map.Entry<Long, Map<String, Serializable>> perConsumerEntry : this.bestEffortsCache.entrySet()) {
-      IStripeMonitoring collector = null;
-      try {
-        IStripeMonitoring underlyingCollector = globalRegistry.subRegistry(perConsumerEntry.getKey()).getService(new BasicServiceConfiguration<>(IStripeMonitoring.class));
-        // NOTE:  We assert that there _is_ a registry for IStripeMonitoring if we received this call.
-        Assert.assertNotNull(underlyingCollector);
-        collector = new IStripeMonitoringWrapper(underlyingCollector, LOGGER);
-      } catch (ServiceException e) {
-        Assert.fail("Multiple IStripeMonitoring implementations found!");
-      }
 
-      for (Map.Entry<String, Serializable> entry : perConsumerEntry.getValue().entrySet()) {
-        collector.pushBestEffortsData(thisServer, entry.getKey(), entry.getValue());
-      }
-    }
     // We can now drop this (gratuitous but makes it clear we are done).
     this.bestEffortsCache.clear();
   }


### PR DESCRIPTION
For context, see discussions in PR and issues:

- https://github.com/Terracotta-OSS/terracotta-platform/pull/413
- https://github.com/Terracotta-OSS/terracotta-core/issues/781
- https://github.com/Terracotta-OSS/terracotta-core/issues/782

With this changes, PR https://github.com/Terracotta-OSS/terracotta-platform/pull/413 will pass.

Data cached from `pushBestEffortsData ` calls is cleared and not replayed after a promotion.

This change will fix https://github.com/Terracotta-OSS/terracotta-core/issues/781, https://github.com/Terracotta-OSS/terracotta-platform/pull/413 and will cancel issue https://github.com/Terracotta-OSS/terracotta-core/issues/781.

This will also let the `IMonitoringProducer.addNode()` method unused from any M&M classes. We will only use `IMonitoringProducer.pushBestEffortsData()`