### PR TITLE
[release/5.3] Issue #794 Degrade when memory pools not identified

### DIFF
--- a/common/src/main/java/com/tc/runtime/TCMemoryManagerImpl.java
+++ b/common/src/main/java/com/tc/runtime/TCMemoryManagerImpl.java
@@ -146,12 +146,10 @@ public class TCMemoryManagerImpl implements TCMemoryManager {
           if (run) {
             interrupt = true;
           }
+        } catch (InternalError ie) {
+          // Do nothing - sometimes the information, while bean setup worked, will fail to be accessed
+          logger.debug("Memory information could not be accessed at this time", ie);
         } catch (Throwable t) {
-          // for debugging purpose
-          StackTraceElement[] trace = t.getStackTrace();
-          for (StackTraceElement element : trace)
-            logger.warn(element.toString());
-          logger.error("Exception: ", t);
           throw new TCRuntimeException(t);
         }
       }

--- a/common/src/main/java/com/tc/runtime/TCMemoryManagerJdk15PoolMonitor.java
+++ b/common/src/main/java/com/tc/runtime/TCMemoryManagerJdk15PoolMonitor.java
@@ -37,13 +37,24 @@ class TCMemoryManagerJdk15PoolMonitor extends TCMemoryManagerJdk15Basic {
   private static final String          IBMJDK_TENURED_GEN_NAME = "Java heap";
   private static final String          JROCKETJDK_OLD_GEN_NAME = "Old Space";
 
+  private final boolean memoryPoolMonitoringSupported;
   private final MemoryPoolMXBean       oldGenBean;
   private final GarbageCollectorMXBean oldGenCollectorBean;
 
   public TCMemoryManagerJdk15PoolMonitor() {
-    super();
-    this.oldGenBean = getOldGenMemoryPoolBean();
-    this.oldGenCollectorBean = getOldGenCollectorBean();
+    boolean memoryPoolMonitoringSupportedTmp = false;
+    MemoryPoolMXBean oldGenBeanTmp = null;
+    GarbageCollectorMXBean oldGenCollectorBeanTmp = null;
+    try {
+      oldGenBeanTmp = getOldGenMemoryPoolBean();
+      oldGenCollectorBeanTmp = getOldGenCollectorBean();
+      memoryPoolMonitoringSupportedTmp = true;
+    } catch (AssertionError e) {
+      // Ignore, will indicate memory monitoring is not supported
+    }
+    this.oldGenBean = oldGenBeanTmp;
+    this.oldGenCollectorBean = oldGenCollectorBeanTmp;
+    this.memoryPoolMonitoringSupported = memoryPoolMonitoringSupportedTmp;
   }
 
   private MemoryPoolMXBean getOldGenMemoryPoolBean() {
@@ -87,7 +98,7 @@ class TCMemoryManagerJdk15PoolMonitor extends TCMemoryManagerJdk15Basic {
 
   @Override
   public boolean isMemoryPoolMonitoringSupported() {
-    return true;
+    return memoryPoolMonitoringSupported;
   }
 
   @Override

--- a/terracotta-kit/src/assemble/server/bin/start-tc-server.bat
+++ b/terracotta-kit/src/assemble/server/bin/start-tc-server.bat
@@ -48,11 +48,11 @@ if not defined JAVA_HOME (
 )
 
 set JAVA_HOME="%JAVA_HOME:"=%"
-for %%C in ("\bin\java -d64 -server -XX:MaxDirectMemorySize=9223372036854775807" ^
-			"\bin\java -server -XX:MaxDirectMemorySize=9223372036854775807" ^
-			"\bin\java -d64 -client  -XX:MaxDirectMemorySize=9223372036854775807" ^
-			"\bin\java -client -XX:MaxDirectMemorySize=9223372036854775807" ^
-			"\bin\java -XX:MaxDirectMemorySize=9223372036854775807") ^
+for %%C in ("\bin\java -d64 -server -XX:MaxDirectMemorySize=1048576g" ^
+			"\bin\java -server -XX:MaxDirectMemorySize=1048576g" ^
+			"\bin\java -d64 -client  -XX:MaxDirectMemorySize=1048576g" ^
+			"\bin\java -client -XX:MaxDirectMemorySize=1048576g" ^
+			"\bin\java -XX:MaxDirectMemorySize=1048576g") ^
 do (
 
   set JAVA_COMMAND=%JAVA_HOME%%%~C

--- a/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
+++ b/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
@@ -38,11 +38,11 @@ fi
 
 # Determine supported JVM args
 for JAVA_COMMAND_ARGS in \
-    "-d64 -server -XX:MaxDirectMemorySize=9223372036854775807" \
-    "-server -XX:MaxDirectMemorySize=9223372036854775807" \
-    "-d64 -client  -XX:MaxDirectMemorySize=9223372036854775807" \
-    "-client -XX:MaxDirectMemorySize=9223372036854775807" \
-    "-XX:MaxDirectMemorySize=9223372036854775807"
+    "-d64 -server -XX:MaxDirectMemorySize=1048576g" \
+    "-server -XX:MaxDirectMemorySize=1048576g" \
+    "-d64 -client  -XX:MaxDirectMemorySize=1048576g" \
+    "-client -XX:MaxDirectMemorySize=1048576g" \
+    "-XX:MaxDirectMemorySize=1048576g"
 do
     # accept the first one that works
     "${JAVA_HOME}/bin/java" $JAVA_COMMAND_ARGS -version > /dev/null 2>&1 && break


### PR DESCRIPTION
Also update the max direct memory value used on command line, IBM VM no
longer parses 2^63-1 properly