### PR TITLE
Fix OSGI classloading issue with ClientBuilderFactory

### DIFF
--- a/dso-l1/src/main/java/com/tc/object/ClientBuilderFactory.java
+++ b/dso-l1/src/main/java/com/tc/object/ClientBuilderFactory.java
@@ -9,7 +9,8 @@ public interface ClientBuilderFactory {
 
     ClientBuilderFactory clientBuilderFactory = null;
 
-    for (ClientBuilderFactory factory : ServiceLoader.load(ClientBuilderFactory.class)) {
+    for (ClientBuilderFactory factory : ServiceLoader.load(ClientBuilderFactory.class,
+                                                           ClientBuilderFactory.class.getClassLoader())) {
       if (clientBuilderFactory == null) {
         clientBuilderFactory = factory;
       } else {


### PR DESCRIPTION
classloading issue: 

an instance of com.terracottatech.store.StoreException <java.util.ServiceConfigurationError: com.tc.object.ClientBuilderFactory: Provider com.tc.object.StandardClientBuilderFactory not a subtype> is a java.util.ServiceConfigurationError
Stacktrace was: java.util.ServiceConfigurationError: com.tc.object.ClientBuilderFactory: Provider com.tc.object.StandardClientBuilderFactory not a subtype
	at java.util.ServiceLoader.fail(ServiceLoader.java:239)
	at java.util.ServiceLoader.access$300(ServiceLoader.java:185)
	at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:376)
	at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:404)
	at java.util.ServiceLoader$1.next(ServiceLoader.java:480)
	at com.tc.object.ClientBuilderFactory.get(ClientBuilderFactory.java:12)
	at com.terracotta.connection.TerracottaInternalClientImpl.buildClientCreator(TerracottaInternalClientImpl.java:52)
	at com.terracotta.connection.TerracottaInternalClientImpl.<init>(TerracottaInternalClientImpl.java:44)
	at com.terracotta.connection.TerracottaInternalClientFactoryImpl.createClient(TerracottaInternalClientFactoryImpl.java:47)
	at com.terracotta.connection.TerracottaInternalClientFactoryImpl.createL1Client(TerracottaInternalClientFactoryImpl.java:42)
	at com.terracotta.connection.api.AbstractConnectionService.connect(AbstractConnectionService.java:76)
	at com.terracottatech.connection.TopoConnectionService.connect(TopoConnectionService.java:63)
	at org.terracotta.connection.ConnectionFactory.connect(ConnectionFactory.java:46)