### PR TITLE
TCVoter refactoring for extensions

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -116,7 +116,7 @@
       <dependency>
         <groupId>commons-cli</groupId>
         <artifactId>commons-cli</artifactId>
-        <version>1.1</version>
+        <version>1.3.1</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>

--- a/terracotta-kit/src/assemble/voter/bin/base-voter.bat
+++ b/terracotta-kit/src/assemble/voter/bin/base-voter.bat
@@ -1,0 +1,48 @@
+@echo off
+
+REM
+REM The contents of this file are subject to the Terracotta Public License Version
+REM 2.0 (the "License"); You may not use this file except in compliance with the
+REM License. You may obtain a copy of the License at
+REM
+REM      http://terracotta.org/legal/terracotta-public-license.
+REM
+REM Software distributed under the License is distributed on an "AS IS" basis,
+REM WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+REM the specific language governing rights and limitations under the License.
+REM
+REM The Covered Software is Terracotta Platform.
+REM
+REM The Initial Developer of the Covered Software is
+REM     Terracotta, Inc., a Software AG company
+REM
+
+setlocal
+
+if exist %TC_VOTER_DIR%\bin\setenv.bat (
+  call %TC_VOTER_DIR%\bin\setenv.bat
+)
+
+if not defined JAVA_HOME (
+  echo Environment variable JAVA_HOME needs to be set
+  exit /b 1
+)
+
+set TC_KIT_ROOT="%TC_VOTER_DIR%\.."
+set TC_KIT_ROOT="%TC_KIT_ROOT:"=%"
+set TC_LOGGING_ROOT="%TC_KIT_ROOT%\client\logging"
+set TC_LOGGING_ROOT="%TC_LOGGING_ROOT:"=%"
+set TC_CLIENT_ROOT="%TC_KIT_ROOT%\client\lib"
+set TC_CLIENT_ROOT="%TC_CLIENT_ROOT:"=%"
+set TC_SERVER_ROOT="%TC_KIT_ROOT%\server\"
+set TC_SERVER_ROOT="%TC_SERVER_ROOT:"=%"
+
+set CLASSPATH="%TC_VOTER_DIR%\lib\*;%TC_CLIENT_ROOT%\*;%TC_SERVER_ROOT%\plugins\lib\*;%TC_LOGGING_ROOT%\*;%TC_LOGGING_ROOT%\impl\*;%TC_LOGGING_ROOT%\impl"
+set CLASSPATH="%CLASSPATH:"=%"
+set JAVA="%JAVA_HOME%\bin\java.exe"
+set JAVA="%JAVA:"=%"
+
+%JAVA% %JAVA_OPTS% -cp %CLASSPATH% %TC_VOTER_MAIN% %*
+
+exit /b %ERRORLEVEL%
+endlocal

--- a/terracotta-kit/src/assemble/voter/bin/base-voter.sh
+++ b/terracotta-kit/src/assemble/voter/bin/base-voter.sh
@@ -17,7 +17,21 @@
 #
 
 
-TC_VOTER_DIR=$(dirname "$(cd "$(dirname "$0")";pwd)")
-TC_VOTER_MAIN=org.terracotta.voter.TCVoterMain
+# this will only happen if using sag installer
+if [ -r "${TC_VOTER_DIR}/bin/setenv.sh" ] ; then
+  . "${TC_VOTER_DIR}/bin/setenv.sh"
+fi
 
-. "${TC_VOTER_DIR}/bin/base-voter.sh"
+if ! [ -d "${JAVA_HOME}" ]; then
+  echo "$0: the JAVA_HOME environment variable is not defined correctly"
+  exit 2
+fi
+
+TC_KIT_ROOT=$(dirname "$TC_VOTER_DIR")
+TC_LOGGING_ROOT=$TC_KIT_ROOT/client/logging
+TC_CLIENT_ROOT=$TC_KIT_ROOT/client/lib
+TC_SERVER_ROOT=$TC_KIT_ROOT/server
+
+CLASS_PATH="${TC_VOTER_DIR}/lib/*:${TC_SERVER_ROOT}/plugins/lib/*:${TC_CLIENT_ROOT}/*:${TC_LOGGING_ROOT}/*:${TC_LOGGING_ROOT}/impl/*:${TC_LOGGING_ROOT}/impl/"
+
+"$JAVA_HOME/bin/java" ${JAVA_OPTS} -cp "$CLASS_PATH" $TC_VOTER_MAIN "$@"

--- a/terracotta-kit/src/assemble/voter/bin/start-tc-voter.bat
+++ b/terracotta-kit/src/assemble/voter/bin/start-tc-voter.bat
@@ -1,34 +1,23 @@
-:: Copyright (c) 2011-2018 Software AG, Darmstadt, Germany and/or Software AG USA Inc., Reston, VA, USA, and/or its subsidiaries and/or its affiliates and/or their licensors.
-:: Use, reproduction, transfer, publication or disclosure is prohibited except as specifically provided for in your License Agreement with Software AG.
 @echo off
-setlocal
 
+REM
+REM The contents of this file are subject to the Terracotta Public License Version
+REM 2.0 (the "License"); You may not use this file except in compliance with the
+REM License. You may obtain a copy of the License at
+REM
+REM      http://terracotta.org/legal/terracotta-public-license.
+REM
+REM Software distributed under the License is distributed on an "AS IS" basis,
+REM WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+REM the specific language governing rights and limitations under the License.
+REM
+REM The Covered Software is Terracotta Platform.
+REM
+REM The Initial Developer of the Covered Software is
+REM     Terracotta, Inc., a Software AG company
+REM
 
 set TC_VOTER_DIR=%~d0%~p0..
-set TC_VOTER_DIR="%TC_VOTER_DIR:"=%"
+set TC_VOTER_MAIN=org.terracotta.voter.TCVoterMain
 
-if exist %TC_VOTER_DIR%\bin\setenv.bat (
-  call %TC_VOTER_DIR%\bin\setenv.bat
-)
-
-if not defined JAVA_HOME (
-  echo Environment variable JAVA_HOME needs to be set
-  exit /b 1
-)
-
-set TC_KIT_ROOT="%TC_VOTER_DIR%\.."
-set TC_KIT_ROOT="%TC_KIT_ROOT:"=%"
-set TC_LOGGING_ROOT="%TC_KIT_ROOT%\client\logging"
-set TC_LOGGING_ROOT="%TC_LOGGING_ROOT:"=%"
-set TC_CLIENT_ROOT="%TC_KIT_ROOT%\client\logging"
-set TC_CLIENT_ROOT="%TC_CLIENT_ROOT:"=%"
-
-set CLASSPATH="%TC_VOTER_DIR%\lib\*;%TC_LOGGING_ROOT%\*;%TC_CLIENT_ROOT%\*;%TC_LOGGING_ROOT%\impl\*;%TC_LOGGING_ROOT%\impl\"
-set CLASSPATH="%CLASSPATH:"=%"
-set JAVA="%JAVA_HOME%\bin\java.exe"
-set JAVA="%JAVA:"=%"
-
-%JAVA% %JAVA_OPTS% -cp %CLASSPATH% org.terracotta.voter.TCVoterMain %*
-
-exit /b %ERRORLEVEL%
-endlocal
+call "%TC_VOTER_DIR%\bin\base-voter.bat"

--- a/voter/src/main/java/org/terracotta/voter/ActiveVoter.java
+++ b/voter/src/main/java/org/terracotta/voter/ActiveVoter.java
@@ -22,6 +22,7 @@ import com.tc.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -68,6 +69,7 @@ public class ActiveVoter implements AutoCloseable {
   }
 
   private Thread voterThread(String... hostPorts) {
+    LOGGER.info("Registering with stripe: {} ", Arrays.toString(hostPorts));
     return new Thread(() -> {
       ScheduledExecutorService executorService = Executors.newScheduledThreadPool(hostPorts.length);
       List<ClientVoterManager> voterManagers = Stream.of(hostPorts).map(ClientVoterManagerImpl::new).collect(toList());

--- a/voter/src/main/java/org/terracotta/voter/ClientVoterManager.java
+++ b/voter/src/main/java/org/terracotta/voter/ClientVoterManager.java
@@ -43,6 +43,12 @@ public interface ClientVoterManager extends VoterManager {
   String getServerState() throws TimeoutException;
 
   /**
+   *
+   * @return the configuration of the server that this voter is connected to.
+   */
+  String getServerConfig() throws TimeoutException;
+
+  /**
    * Close the connection with the server.
    */
   void close();

--- a/voter/src/main/java/org/terracotta/voter/ClientVoterManagerImpl.java
+++ b/voter/src/main/java/org/terracotta/voter/ClientVoterManagerImpl.java
@@ -112,6 +112,11 @@ public class ClientVoterManagerImpl implements ClientVoterManager {
     return processInvocation(diagnostics.getState());
   }
 
+  @Override
+  public String getServerConfig() throws TimeoutException {
+    return processInvocation(diagnostics.getConfig());
+  }
+
   String processInvocation(String invocation) throws TimeoutException {
     if (invocation == null) {
       return "UNKNOWN";

--- a/voter/src/main/java/org/terracotta/voter/TCVoterImpl.java
+++ b/voter/src/main/java/org/terracotta/voter/TCVoterImpl.java
@@ -18,20 +18,33 @@
  */
 package org.terracotta.voter;
 
+import com.tc.config.schema.setup.ConfigurationSetupException;
 import com.tc.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terracotta.config.TCConfigurationParser;
+import org.terracotta.config.TcConfiguration;
+import org.xml.sax.SAXException;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
+import java.util.TreeSet;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
+
+import static java.util.stream.Collectors.toList;
 
 public class TCVoterImpl implements TCVoter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TCVoterImpl.class);
 
-  private final String id;
-  private final Map<String, AutoCloseable> registeredClusters = new ConcurrentHashMap<>();
+  protected final String id;
+  private final Map<String, List<ActiveVoter>> registeredClusters = new ConcurrentHashMap<>();
 
   public TCVoterImpl() {
     this.id = UUID.getUUID().toString();
@@ -43,7 +56,7 @@ public class TCVoterImpl implements TCVoter {
     ClientVoterManager voterManager = new ClientVoterManagerImpl(hostPort);
     voterManager.connect();
     String id = UUID.getUUID().toString();
-    boolean veto = false;
+    boolean veto;
     try {
       veto = voterManager.vetoVote(id);
     } catch (TimeoutException e) {
@@ -61,19 +74,70 @@ public class TCVoterImpl implements TCVoter {
 
   @Override
   public void register(String clusterName, String... hostPorts) {
-    if (registeredClusters.putIfAbsent(clusterName, new ActiveVoter(id, hostPorts).start()) != null) {
+    TreeSet<List<String>> cluster = extractStripesFromHostPorts(hostPorts); // Using a TreeSet here to establish a defined order in which the stripes are processed by different voters.
+    validateStripesLimit(cluster.size(), hostPorts);
+    List<ActiveVoter> voters = new ArrayList<>(cluster.size());
+    for (List<String> stripe : cluster) {
+      ActiveVoter activeVoter = new ActiveVoter(id, stripe.toArray(new String[stripe.size()])).start();
+      voters.add(activeVoter);
+    }
+
+    if (registeredClusters.putIfAbsent(clusterName, voters) != null) {
       throw new RuntimeException("Another cluster is already registered with the name: " + clusterName);
+    }
+  }
+
+  private TreeSet<List<String>> extractStripesFromHostPorts(String... hostPorts) {
+    TreeSet<List<String>> cluster = new TreeSet<>(Comparator.comparing(List::toString));
+    List<CompletableFuture<Void>> completableFutures = new ArrayList<>(hostPorts.length);
+    for (String hostPort : hostPorts) {
+      CompletableFuture<Void> completableFuture = CompletableFuture.runAsync(() -> {
+        ClientVoterManagerImpl voterManager = new ClientVoterManagerImpl(hostPort);
+        voterManager.connect();
+        String serverConfig;
+        try {
+          serverConfig = voterManager.getServerConfig();
+          TcConfiguration config;
+
+          try {
+            config = TCConfigurationParser.parse(serverConfig);
+          } catch (SAXException | IOException e) {
+            throw new AssertionError("Received invalid config from server: " + serverConfig);
+          }
+
+          List<String> stripe = config.getPlatformConfiguration().getServers().getServer().stream()
+              .map(s -> s.getHost() + ":" + s.getTsaPort().getValue())
+              .sorted()
+              .collect(toList());
+          cluster.add(stripe);
+
+        } catch (TimeoutException e) {
+
+        }
+      });
+      completableFutures.add(completableFuture);
+    }
+
+    CompletableFuture.allOf(completableFutures.toArray(new CompletableFuture[completableFutures.size()])).join();
+    return cluster;
+  }
+
+  protected void validateStripesLimit(int stripes, String... hostPorts) {
+    if (stripes > 1) {
+      throw new RuntimeException(Arrays.toString(hostPorts) + " do not belong to a single stripe and multiple stripes are not supported");
     }
   }
 
   @Override
   public void deregister(String clusterName) {
-    AutoCloseable removed = registeredClusters.remove(clusterName);
-    if (removed != null) {
-      try {
-        removed.close();
-      } catch (Exception exp) {
-      throw new RuntimeException(exp);
+    List<ActiveVoter> voters = registeredClusters.remove(clusterName);
+    if (voters != null) {
+      for (AutoCloseable voter : voters) {
+        try {
+          voter.close();
+        } catch (Exception exp) {
+          throw new RuntimeException(exp);
+        }
       }
     } else {
       throw new RuntimeException("A cluster with the given name: " + clusterName + " is not registered with this voter");

--- a/voter/src/test/resources/tc-config.xml
+++ b/voter/src/test/resources/tc-config.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~
+  ~  The contents of this file are subject to the Terracotta Public License Version
+  ~  2.0 (the "License"); You may not use this file except in compliance with the
+  ~  License. You may obtain a copy of the License at
+  ~
+  ~  http://terracotta.org/legal/terracotta-public-license.
+  ~
+  ~  Software distributed under the License is distributed on an "AS IS" basis,
+  ~  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+  ~  the specific language governing rights and limitations under the License.
+  ~
+  ~  The Covered Software is Terracotta Core.
+  ~
+  ~  The Initial Developer of the Covered Software is
+  ~  Terracotta, Inc., a Software AG company
+  ~
+  -->
+
+<!-- This config file is used by the server and bootjar tool when none is specified. -->
+
+<tc-config xmlns="http://www.terracotta.org/config">
+    <servers>
+        <server host="foo">
+            <tsa-port>1234</tsa-port>
+        </server>
+        <server host="bar">
+            <tsa-port>2345</tsa-port>
+        </server>
+    </servers>
+</tc-config>


### PR DESCRIPTION
The original voter script was split into two: a base script with most of the original content + the main script that just passes the main method name to be executed to the base script. This facilitates the reuse of the base script by extensions.