### PR TITLE
New exception for shutdown connections #845

### DIFF
--- a/connection-impl/src/main/java/com/terracotta/connection/TerracottaConnection.java
+++ b/connection-impl/src/main/java/com/terracotta/connection/TerracottaConnection.java
@@ -24,6 +24,7 @@ import org.terracotta.connection.entity.EntityRef;
 import org.terracotta.entity.EntityClientService;
 import org.terracotta.entity.EntityMessage;
 import org.terracotta.entity.EntityResponse;
+import org.terracotta.exception.ConnectionShutdownException;
 import org.terracotta.exception.EntityNotProvidedException;
 
 import com.tc.object.ClientEntityManager;
@@ -89,7 +90,7 @@ public class TerracottaConnection implements Connection {
 
   private void checkShutdown() {
     if (isShutdown) {
-      throw new IllegalStateException("Already shut down");
+      throw new ConnectionShutdownException("Already shut down");
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <tc-shader.version>1.2</tc-shader.version>
     <skip.deploy>false</skip.deploy>
 
-    <terracotta-apis.version>1.4.0-pre9</terracotta-apis.version>
+    <terracotta-apis.version>1.4.0-pre10</terracotta-apis.version>
     <terracotta-configuration.version>10.4.0-pre10</terracotta-configuration.version>
     <galvan.version>1.4.0-pre6</galvan.version>
   </properties>


### PR DESCRIPTION
This is the only place I think we need, but I may be wrong.
So I think as and when we find some more places, we replace Illegalstates with `ConnectionShutdownException` or `ConnectionClosedException`, which ever fits/suits