### PR TITLE
TCVoterImpl.register to handle just a single stripe

### DIFF
--- a/galvan-support/pom.xml
+++ b/galvan-support/pom.xml
@@ -50,6 +50,12 @@ limitations under the License.
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>voter</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>galvan</artifactId>
       <version>${galvan.version}</version>

--- a/galvan-support/src/test/java/org/terracotta/testing/rules/BasicExternalClusterFOPConsistencyVoterIT.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/rules/BasicExternalClusterFOPConsistencyVoterIT.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing.rules;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.terracotta.voter.TCVoter;
+import org.terracotta.voter.TCVoterImpl;
+import org.terracotta.voter.VoterStatus;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class BasicExternalClusterFOPConsistencyVoterIT {
+
+  @ClassRule
+  public static final Cluster CLUSTER = BasicExternalClusterBuilder.newCluster(2).withFailoverPriorityVoterCount(1).build();
+
+  @Test(expected = TimeoutException.class)
+  public void testDirectConnection() throws Exception {
+    CLUSTER.getClusterControl().waitForActive();
+    CLUSTER.getClusterControl().waitForRunningPassivesInStandby();
+
+    TCVoter voter = new TCVoterImpl();
+    Future<VoterStatus> voterStatus = voter.register("MyCluster", CLUSTER.getClusterHostPorts());
+    voterStatus.get();
+
+    CLUSTER.getClusterControl().terminateActive();
+
+    CompletableFuture<Void> connectionFuture = CompletableFuture.runAsync(() -> {
+      try {
+        CLUSTER.getClusterControl().waitForActive();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+    connectionFuture.get(5, TimeUnit.SECONDS);
+  }
+
+}


### PR DESCRIPTION
TCVoterImpl.register was failing with an `AssertionError: Received invalid config from server` while parsing the server config.

The changes in this PR eliminates the need for parsing tc-configs from the target servers.