### PR TITLE
Redirects are only advisory not handshake error. 

### DIFF
--- a/common/src/main/java/com/tc/net/protocol/transport/ClientMessageTransport.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ClientMessageTransport.java
@@ -172,6 +172,8 @@ public class ClientMessageTransport extends MessageTransportBase {
         case ERROR_NO_ACTIVE:
           if (this.getConnectionId().getProductId().isRedirectEnabled()) {
             throw new NoActiveException();
+          } else {
+            Assert.assertTrue(this.getConnectionId().getProductId().isInternal());
           }
           break;
         case ERROR_MAX_CONNECTION_EXCEED:
@@ -188,6 +190,8 @@ public class ClientMessageTransport extends MessageTransportBase {
         case ERROR_REDIRECT_CONNECTION:
           if (this.getConnectionId().getProductId().isRedirectEnabled()) {
             throw new TransportRedirect(result.synAck.getErrorContext());
+          } else {
+            Assert.assertTrue(this.getConnectionId().getProductId().isInternal());
           }
           break;
         case ERROR_PRODUCT_NOT_SUPPORTED:

--- a/common/src/main/java/com/tc/net/protocol/transport/ServerStackProvider.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ServerStackProvider.java
@@ -272,6 +272,8 @@ public class ServerStackProvider implements NetworkStackProvider, MessageTranspo
       }
       if (!isHandshakeError) {
         this.transport.receiveTransportMessage(message);
+      } else {
+        throw new AssertionError("clients should not send messages after handshake error");
       }
     }
 
@@ -381,7 +383,6 @@ public class ServerStackProvider implements NetworkStackProvider, MessageTranspo
       if (!validateTransport.test(this.transport)) {
         sendSynAck(connectionId, new TransportHandshakeErrorContext("connection not allowed", TransportHandshakeError.ERROR_NO_ACTIVE), 
             syn.getSource(), isMaxConnectionReached);
-        this.isHandshakeError = true;
         return;
       }
       sendSynAck(transport.getConnectionId(), syn.getSource(), isMaxConnectionReached);
@@ -422,7 +423,6 @@ public class ServerStackProvider implements NetworkStackProvider, MessageTranspo
           synAck = handshakeMessageFactory.createSynAck(connectionId, TransportHandshakeError.ERROR_NO_ACTIVE, "no active", 
                 source, isMaxConnectionsReached, maxConnections);
         }
-        this.isHandshakeError = true;
       } else {
         int callbackPort = source.getLocalAddress().getPort();
         synAck = handshakeMessageFactory.createSynAck(connectionId, source, isMaxConnectionsReached, maxConnections, callbackPort);

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/ChannelStatsImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/ChannelStatsImpl.java
@@ -55,8 +55,7 @@ public class ChannelStatsImpl implements ChannelStats, DSOChannelManagerEventLis
   public Counter getCounter(MessageChannel channel, String name) {
     Counter rv = (Counter) channel.getAttachment(name);
     if (rv == null) {
-      createStatsCountersIfNeeded(channel, name);
-      rv = (Counter) channel.getAttachment(name);
+      rv = createStatsCountersIfNeeded(channel, name);
       if (rv == null) throw new NullPointerException("StatsCounter : " + name + " not attached to channel "
                                                      + channel.getChannelID()
                                                      + " ! Probably not initialized. Check ChannelStats Interface. ");
@@ -64,7 +63,7 @@ public class ChannelStatsImpl implements ChannelStats, DSOChannelManagerEventLis
     return rv;
   }
 
-  private synchronized void createStatsCountersIfNeeded(MessageChannel channel, String name) {
+  private synchronized Counter createStatsCountersIfNeeded(MessageChannel channel, String name) {
     Counter rv = (Counter) channel.getAttachment(name);
     if (rv == null) {
       for (StatsConfig config : STATS_CONFIG) {
@@ -72,6 +71,7 @@ public class ChannelStatsImpl implements ChannelStats, DSOChannelManagerEventLis
         channel.addAttachment(config.getStatsName(), counter, true);
       }
     }
+    return (Counter) channel.getAttachment(name);
   }
 
   @Override

--- a/galvan-support/src/test/java/org/terracotta/testing/rules/BasicExternalClusterFOPConsistencyVoterIT.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/rules/BasicExternalClusterFOPConsistencyVoterIT.java
@@ -24,14 +24,13 @@ import org.terracotta.voter.VoterStatus;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public class BasicExternalClusterFOPConsistencyVoterIT {
 
   @ClassRule
   public static final Cluster CLUSTER = BasicExternalClusterBuilder.newCluster(2).withFailoverPriorityVoterCount(1).build();
 
-  @Test(expected = TimeoutException.class)
+  @Test
   public void testDirectConnection() throws Exception {
     CLUSTER.getClusterControl().waitForActive();
     CLUSTER.getClusterControl().waitForRunningPassivesInStandby();
@@ -49,7 +48,7 @@ public class BasicExternalClusterFOPConsistencyVoterIT {
         throw new RuntimeException(e);
       }
     });
-    connectionFuture.get(5, TimeUnit.SECONDS);
+    connectionFuture.get(10, TimeUnit.SECONDS);
   }
 
 }


### PR DESCRIPTION
Diagnostic clients must use this connection and cannot be blocked.