### PR TITLE
Enable compatibility across minor versions.

### DIFF
--- a/common/src/main/java/com/tc/util/version/VersionCompatibility.java
+++ b/common/src/main/java/com/tc/util/version/VersionCompatibility.java
@@ -41,7 +41,7 @@ public class VersionCompatibility {
 
   private static boolean isCompatible(Version v1, Version v2) {
     if (v1 == null || v2 == null) { throw new NullPointerException(); }
-    return ((v1.major() == v2.major()) && (v1.minor() == v2.minor()));
+    return (v1.major() == v2.major());
   }
 
   public Version getMinimumCompatiblePersistence() {

--- a/common/src/test/java/com/tc/util/version/VersionCompatibilityTest.java
+++ b/common/src/test/java/com/tc/util/version/VersionCompatibilityTest.java
@@ -18,17 +18,17 @@
  */
 package com.tc.util.version;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class VersionCompatibilityTest extends TestCase {
+import static com.tc.util.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
-  private VersionCompatibility versionCompatibility;
+public class VersionCompatibilityTest {
 
-  @Override
-  protected void setUp() throws Exception {
-    this.versionCompatibility = new VersionCompatibility();
-  }
+  private final VersionCompatibility versionCompatibility = new VersionCompatibility();
 
+  @Test
   public void testNull() {
     try {
       versionCompatibility.isCompatibleClientServer(v("1.0.0"), null);
@@ -52,24 +52,28 @@ public class VersionCompatibilityTest extends TestCase {
     }
   }
 
-  public void testPersistenceCompatibleWithMinimum() throws Exception {
+  @Test
+  public void testPersistenceCompatibleWithMinimum() {
     assertTrue(versionCompatibility.isCompatibleServerPersistence(versionCompatibility.getMinimumCompatiblePersistence(),
         incrementedVersion(versionCompatibility.getMinimumCompatiblePersistence(), 0, 1, 0)));
   }
 
-  public void testPersistenceIncompatibleWithLessThanMinimum() throws Exception {
+  @Test
+  public void testPersistenceIncompatibleWithLessThanMinimum() {
     assertFalse(versionCompatibility.isCompatibleServerPersistence(
         incrementedVersion(versionCompatibility.getMinimumCompatiblePersistence(), -1, 0, 0),
         incrementedVersion(versionCompatibility.getMinimumCompatiblePersistence(), 0, 1, 0)));
   }
 
-  public void testPersistenceCompatibleWithBetweenMinAndCurrent() throws Exception {
+  @Test
+  public void testPersistenceCompatibleWithBetweenMinAndCurrent() {
     assertTrue(versionCompatibility.isCompatibleServerPersistence(
         incrementedVersion(versionCompatibility.getMinimumCompatiblePersistence(), 0, 1, 0),
         incrementedVersion(versionCompatibility.getMinimumCompatiblePersistence(), 0, 2, 0)));
   }
 
-  public void testPersistenceCompatibleWithinMinor() throws Exception {
+  @Test
+  public void testPersistenceCompatibleWithinMinor() {
     assertTrue(versionCompatibility.isCompatibleServerPersistence(
         incrementedVersion(versionCompatibility.getMinimumCompatiblePersistence(), 0, 0, 1),
         incrementedVersion(versionCompatibility.getMinimumCompatiblePersistence(), 0, 0, 2)));
@@ -78,7 +82,8 @@ public class VersionCompatibilityTest extends TestCase {
         incrementedVersion(versionCompatibility.getMinimumCompatiblePersistence(), 0, 0, 1)));
   }
 
-  public void testPersistedSameMinorAsMinButLowerDot() throws Exception {
+  @Test
+  public void testPersistedSameMinorAsMinButLowerDot() {
     // Doesn't matter on .0's but check that the versions lower than the minimum are properly excluded.
     if (versionCompatibility.getMinimumCompatiblePersistence().micro() != 0) {
       assertFalse(versionCompatibility.isCompatibleServerPersistence(
@@ -93,58 +98,72 @@ public class VersionCompatibilityTest extends TestCase {
                        (base.micro() + microIncrement));
   }
 
+  @Test
   public void testSame() {
     assertTrue(versionCompatibility.isCompatibleClientServer(v("1.0.0"), v("1.0.0")));
   }
 
+  @Test
   public void testMajorBump() {
     assertFalse(versionCompatibility.isCompatibleClientServer(v("1.0.0"), v("2.0.0")));
   }
 
+  @Test
   public void testMajorDrop() {
     assertFalse(versionCompatibility.isCompatibleClientServer(v("2.0.0"), v("1.0.0")));
   }
 
+  @Test
   public void testMinorBump() {
-    assertFalse(versionCompatibility.isCompatibleClientServer(v("1.0.0"), v("1.1.0")));
+    assertTrue(versionCompatibility.isCompatibleClientServer(v("1.0.0"), v("1.1.0")));
   }
 
+  @Test
   public void testMinorDrop() {
-    assertFalse(versionCompatibility.isCompatibleClientServer(v("1.1.0"), v("1.0.0")));
+    assertTrue(versionCompatibility.isCompatibleClientServer(v("1.1.0"), v("1.0.0")));
   }
 
+  @Test
   public void testDotBump() {
     assertTrue(versionCompatibility.isCompatibleClientServer(v("1.0.0"), v("1.0.1")));
   }
 
+  @Test
   public void testDotDrop() {
     assertTrue(versionCompatibility.isCompatibleClientServer(v("1.0.1"), v("1.0.0")));
   }
 
+  @Test
   public void testPatchBump() {
     assertTrue(versionCompatibility.isCompatibleClientServer(v("1.0.1.1.134"), v("1.0.1.2.25")));
   }
 
+  @Test
   public void testPatchDrop() {
     assertTrue(versionCompatibility.isCompatibleClientServer(v("1.0.1.1.134"), v("1.0.1.0.25")));
   }
 
+  @Test
   public void testBuildBump() {
     assertTrue(versionCompatibility.isCompatibleClientServer(v("1.0.1.1.134"), v("1.0.1.1.142")));
   }
 
+  @Test
   public void testBuildDrop() {
     assertTrue(versionCompatibility.isCompatibleClientServer(v("1.0.1.1.134"), v("1.0.1.1.25")));
   }
 
+  @Test
   public void testSpecifierAdd() {
     assertTrue(versionCompatibility.isCompatibleClientServer(v("1.0.1.1.134"), v("1.0.1.1.134_fix1")));
   }
 
+  @Test
   public void testSpecifierDrop() {
     assertTrue(versionCompatibility.isCompatibleClientServer(v("1.0.1.1.134_fix1"), v("1.0.1.1.134")));
   }
 
+  @Test
   public void testSnapshots() {
     assertTrue(versionCompatibility.isCompatibleClientServer(v("1.0.0"), v("1.0.0-SNAPSHOT")));
     assertTrue(versionCompatibility.isCompatibleClientServer(v("1.0.0.1.34"), v("1.0.0-SNAPSHOT")));
@@ -158,9 +177,9 @@ public class VersionCompatibilityTest extends TestCase {
     assertTrue(versionCompatibility.isCompatibleClientServer(v("1.0.1-SNAPSHOT"), v("1.0.0")));
     assertTrue(versionCompatibility.isCompatibleClientServer(v("1.0.1-SNAPSHOT"), v("1.0.0-SNAPSHOT")));
 
-    assertFalse(versionCompatibility.isCompatibleClientServer(v("1.1.0"), v("1.0.0-SNAPSHOT")));
-    assertFalse(versionCompatibility.isCompatibleClientServer(v("1.1.0-SNAPSHOT"), v("1.0.0")));
-    assertFalse(versionCompatibility.isCompatibleClientServer(v("1.1.0-SNAPSHOT"), v("1.0.0-SNAPSHOT")));
+    assertTrue(versionCompatibility.isCompatibleClientServer(v("1.1.0"), v("1.0.0-SNAPSHOT")));
+    assertTrue(versionCompatibility.isCompatibleClientServer(v("1.1.0-SNAPSHOT"), v("1.0.0")));
+    assertTrue(versionCompatibility.isCompatibleClientServer(v("1.1.0-SNAPSHOT"), v("1.0.0-SNAPSHOT")));
 
     assertFalse(versionCompatibility.isCompatibleClientServer(v("2.0.0"), v("1.0.0-SNAPSHOT")));
     assertFalse(versionCompatibility.isCompatibleClientServer(v("2.0.0-SNAPSHOT"), v("1.0.0")));

--- a/dso-l1/src/test/java/com/tc/object/handshakemanager/ClientHandshakeManagerTest.java
+++ b/dso-l1/src/test/java/com/tc/object/handshakemanager/ClientHandshakeManagerTest.java
@@ -76,7 +76,7 @@ public class ClientHandshakeManagerTest {
   private TCProperties properties;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     initMocks(this);
     when(properties.getBoolean(TCPropertiesConsts.VERSION_COMPATIBILITY_CHECK))
             .thenReturn(checkVersionCompatibility);
@@ -111,15 +111,14 @@ public class ClientHandshakeManagerTest {
 
   @Test
   public void testClientVersionIsNull() {
-    checkCompatibilityIfConfiguredAndDifferenceEitherWay(null, "1.1.1.1",
+    checkCompatibilityIfConfiguredAndDifferenceEitherWay(null,
             NullPointerException.class);
   }
 
   private void checkCompatibilityIfConfiguredAndDifferenceEitherWay(String clientVersion,
-                                                                    String serverVersion,
                                                                     Class<? extends Throwable> exceptionClass) {
     expectErrorIfCheckingCompatibility(exceptionClass);
-    checkClientServerVersionCompatibility(clientVersion, serverVersion);
+    checkClientServerVersionCompatibility(clientVersion, "1.1.1.1");
     checkLoggedDifferenceIfNotCheckingCompatibility();
   }
 
@@ -148,20 +147,19 @@ public class ClientHandshakeManagerTest {
 
   @Test
   public void testClientVersionIsInvalid() {
-    checkCompatibilityIfConfiguredAndDifferenceEitherWay("${version}", "1.1.1.1",
+    checkCompatibilityIfConfiguredAndDifferenceEitherWay("${version}",
             IllegalArgumentException.class);
   }
 
   @Test
   public void testMajorVersionsDifferent() {
-    checkCompatibilityIfConfiguredAndDifferenceEitherWay("2.1.1.1", "1.1.1.1",
+    checkCompatibilityIfConfiguredAndDifferenceEitherWay("2.1.1.1",
             IllegalStateException.class);
   }
 
   @Test
   public void testMinorVersionsDifferent() {
-    checkCompatibilityIfConfiguredAndDifferenceEitherWay("1.2.1.11", "1.1.1.1",
-            IllegalStateException.class);
+    checkDifferenceOnly("1.2.1.11", "1.1.1.1");
   }
 
   @Test

--- a/dso-l2/src/test/java/com/tc/net/groups/TCGroupManagerImplTest.java
+++ b/dso-l2/src/test/java/com/tc/net/groups/TCGroupManagerImplTest.java
@@ -561,13 +561,13 @@ public class TCGroupManagerImplTest extends TCTestCase {
 
     // Incompatible version, higher weights. Close down the handshake, the other guy will zap himself.
     MessageChannel channel1 = mockMessageChannel();
-    tcGroupManager.receivedHandshake(mockHandshakeMessage(channel1, "4.3.1", new long [] { 4, 5 }));
+    tcGroupManager.receivedHandshake(mockHandshakeMessage(channel1, "5.3.1", new long [] { 4, 5 }));
     verify(channel1).close();
 
     // Incompatible version, lower weights. Zap yourself.
     MessageChannel channel2 = mockMessageChannel();
     try {
-      tcGroupManager.receivedHandshake(mockHandshakeMessage(channel2, "4.3.1", new long [] { 6, 1 }));
+      tcGroupManager.receivedHandshake(mockHandshakeMessage(channel2, "5.3.1", new long [] { 6, 1 }));
       fail("Should have zapped here due to low weights");
     } catch (TCShutdownServerException e) {
       // expected


### PR DESCRIPTION
Enabled only compatibility within a major version - not clear whether we need it across major versions as well? Also cleaned up warnings in test code, and switched VersionCompatibilityTest from junit.framework to org.junit. 