### PR TITLE
Disable version compatibility check.

### DIFF
--- a/common/src/main/java/com/tc/properties/TCPropertiesConsts.java
+++ b/common/src/main/java/com/tc/properties/TCPropertiesConsts.java
@@ -356,14 +356,6 @@ public interface TCPropertiesConsts {
 
   /*********************************************************************************************************************
    * <code>
-   * Section :  Version Settings
-   * version.compatibility.check - check version compatibility for client<->server and server<-> connections
-   * </code>
-   ********************************************************************************************************************/
-  public static final String VERSION_COMPATIBILITY_CHECK                                    = "version.compatibility.check";
-
-  /*********************************************************************************************************************
-   * <code>
    * Section :  Some useful subcategories
    * </code>
    ********************************************************************************************************************/

--- a/common/src/main/java/com/tc/util/version/VersionCompatibility.java
+++ b/common/src/main/java/com/tc/util/version/VersionCompatibility.java
@@ -18,6 +18,9 @@
  */
 package com.tc.util.version;
 
+/**
+ * Version compatibility check is currently disabled.
+ */
 public class VersionCompatibility {
   private static final Version MINIMUM_COMPATIBLE_PERSISTENCE = new Version("4.1.2");
 

--- a/common/src/main/resources/com/tc/properties/tc.properties
+++ b/common/src/main/resources/com/tc/properties/tc.properties
@@ -323,9 +323,3 @@ l2.logs.store = 1500
 l1.shutdown.threadgroup.gracetime = 30000
 l1.shutdown.force.finalization = true
 
-###########################################################################################
-# Section :  Version Settings
-# version.compatibility.check - check version compatibility for client<->server and server<-> connections
-###########################################################################################
-version.compatibility.check = true
-

--- a/common/src/test/java/com/tc/util/version/VersionCompatibilityTest.java
+++ b/common/src/test/java/com/tc/util/version/VersionCompatibilityTest.java
@@ -20,6 +20,9 @@ package com.tc.util.version;
 
 import junit.framework.TestCase;
 
+/**
+ * Version compatibility check is currently disabled.
+ */
 public class VersionCompatibilityTest extends TestCase {
 
   private VersionCompatibility versionCompatibility;

--- a/dso-l1/src/main/java/com/tc/object/handshakemanager/ClientHandshakeManagerImpl.java
+++ b/dso-l1/src/main/java/com/tc/object/handshakemanager/ClientHandshakeManagerImpl.java
@@ -180,14 +180,7 @@ public class ClientHandshakeManagerImpl implements ClientHandshakeManager {
   }
 
   protected void checkClientServerVersionCompatibility(String serverVersion) {
-    final boolean check = TCPropertiesImpl.getProperties().getBoolean(TCPropertiesConsts.VERSION_COMPATIBILITY_CHECK);
-
-    if (check && !new VersionCompatibility().isCompatibleClientServer(new Version(clientVersion), new Version(serverVersion))) {
-      final String msg = "Client/Server versions are not compatible: Client Version: " + clientVersion + ", Server Version: "
-                         + serverVersion + ".  Terminating client now.";
-      LOGGER.error(msg);
-      throw new IllegalStateException(msg);
-    } else if (!Objects.equals(clientVersion, serverVersion)) {
+    if (!Objects.equals(clientVersion, serverVersion)) {
       String message = String.format("Client version %s is different from server version %s.",
               clientVersion, serverVersion);
       logger.info(message);

--- a/dso-l2/src/main/java/com/tc/net/groups/TCGroupManagerImpl.java
+++ b/dso-l2/src/main/java/com/tc/net/groups/TCGroupManagerImpl.java
@@ -1199,15 +1199,6 @@ public class TCGroupManagerImpl implements GroupManager<AbstractGroupMessage>, C
       @Override
       public void execute(TCGroupHandshakeMessage msg) {
         setPeerNodeID(msg);
-        if (!new VersionCompatibility().isCompatibleServerServer(new Version(version), new Version(msg.getVersion()))) {
-          switchToState(STATE_FAILURE);
-          if (checkWeights(msg)) {
-            logger.error("Node " + peerNodeID + " has an incompatible version " + msg.getVersion());
-            return;
-          } else {
-            throw new TCShutdownServerException("Version incompatible with the rest of the cluster.");
-          }
-        }
         if (!manager.getDiscover().isValidClusterNode(peerNodeID)) {
           logger.warn("Drop connection from non-member node " + peerNodeID);
           switchToState(STATE_FAILURE);

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -500,7 +500,7 @@ public class DistributedObjectServer implements TCDumper, ServerConnectionValida
     //  if the DB was zapped, reset the flag until the server has finished sync
     persistor.getClusterStatePersistor().setDBClean(!wasZapped);
 
-    new ServerPersistenceVersionChecker(persistor.getClusterStatePersistor()).checkAndSetVersion();
+    new ServerPersistenceVersionChecker().checkAndBumpPersistedVersion(persistor.getClusterStatePersistor());
 
     this.threadGroup
         .addCallbackOnExitExceptionHandler(ZapDirtyDbServerNodeException.class,

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/ServerPersistenceVersionChecker.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/ServerPersistenceVersionChecker.java
@@ -19,52 +19,30 @@
 
 package com.tc.objectserver.impl;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.tc.objectserver.persistence.ClusterStatePersistor;
 import com.tc.util.ProductInfo;
 import com.tc.util.version.Version;
-import com.tc.util.version.VersionCompatibility;
 
 /**
  * @author tim
  */
 public class ServerPersistenceVersionChecker {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ServerPersistenceVersionChecker.class);
-  private final ClusterStatePersistor clusterStatePersistor;
   private final ProductInfo productInfo;
-  private final VersionCompatibility versionCompatibility;
 
-  public ServerPersistenceVersionChecker(ClusterStatePersistor clusterStatePersistor) {
-    this(clusterStatePersistor, ProductInfo.getInstance(), new VersionCompatibility());
+  ServerPersistenceVersionChecker() {
+    this(ProductInfo.getInstance());
   }
 
-  ServerPersistenceVersionChecker(ClusterStatePersistor clusterStatePersistor, ProductInfo productInfo,
-                                  VersionCompatibility versionCompatibility) {
-    this.clusterStatePersistor = clusterStatePersistor;
+  ServerPersistenceVersionChecker(ProductInfo productInfo) {
     this.productInfo = productInfo;
-    this.versionCompatibility = versionCompatibility;
   }
 
-  private boolean checkVersion(Version persisted, Version current) {
-    if (persisted != null) { return versionCompatibility.isCompatibleServerPersistence(persisted, current); }
-    return true;
-  }
-
-  public void checkAndSetVersion() {
+  void checkAndBumpPersistedVersion(ClusterStatePersistor clusterStatePersistor) {
     Version currentVersion = new Version(productInfo.version());
     Version persistedVersion = clusterStatePersistor.getVersion();
-    if (checkVersion(clusterStatePersistor.getVersion(), currentVersion)) {
-      
-      // only move persisted version forward
-      if (persistedVersion == null || currentVersion.compareTo(persistedVersion) > 0) {
-        clusterStatePersistor.setVersion(currentVersion);
-      }
-    } else {
-      LOGGER.error("Incompatible data format detected. Found data for version " + persistedVersion +" expecting data for version " + currentVersion + ".");
-      LOGGER.error("Verify that the correct data is in the server data path, and try again.");
-      throw new IllegalStateException("Incompatible data format version. Got " + persistedVersion + " expected " + currentVersion);
+    // only move persisted version forward
+    if (persistedVersion == null || currentVersion.compareTo(persistedVersion) > 0) {
+      clusterStatePersistor.setVersion(currentVersion);
     }
   }
 }


### PR DESCRIPTION
Completely disabled version compatibility checks in code. Removed configuration. Left the VersionCompatibility class and its test as they are (can we deprecate?)