### PR TITLE
Changes in PlatformConfiguration interface to provide host and port

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -422,13 +422,6 @@ public class DistributedObjectServer implements TCDumper, ServerConnectionValida
     this.tcProperties = TCPropertiesImpl.getProperties();
     this.l1ReconnectConfig = new L1ReconnectConfigImpl();
     
-    String serverName = this.configSetupManager.dsoL2Config().serverName();
-//  this is character replacement for windows platform file names.  This is probably a bogus way to 
-//  handle this.  Re-evaluate the way data directories are managed for 5.0 and fix this when a plan is
-//  devised
-    serverName = serverName.replace('.', '-');
-    serverName = serverName.replace(':', '$');
-
     final int maxStageSize = tcProperties.getInt(TCPropertiesConsts.L2_SEDA_STAGE_SINK_CAPACITY);
     final StageManager stageManager = this.seda.getStageManager();
 
@@ -437,7 +430,7 @@ public class DistributedObjectServer implements TCDumper, ServerConnectionValida
 
     // Set up the ServiceRegistry.
     TcConfiguration base = this.configSetupManager.commonl2Config().getTCConfiguration();
-    PlatformConfiguration platformConfiguration = new PlatformConfigurationImpl(this.configSetupManager.getL2Identifier(), base);
+    PlatformConfiguration platformConfiguration = new PlatformConfigurationImpl(this.configSetupManager.dsoL2Config(), base);
     serviceRegistry.initialize(platformConfiguration, base, Thread.currentThread().getContextClassLoader());
     serviceRegistry.registerImplementationProvided(new PlatformServiceProvider(this));
 

--- a/dso-l2/src/main/java/com/tc/services/PlatformConfigurationImpl.java
+++ b/dso-l2/src/main/java/com/tc/services/PlatformConfigurationImpl.java
@@ -22,22 +22,34 @@ import java.util.Collection;
 import org.terracotta.config.TcConfiguration;
 import org.terracotta.entity.PlatformConfiguration;
 
+import com.tc.object.config.schema.L2Config;
+
 /**
  * @author vmad
  */
 public class PlatformConfigurationImpl implements PlatformConfiguration {
 
-  private final String serverName;
+  private final L2Config l2Config;
   private final TcConfiguration config;
 
-  public PlatformConfigurationImpl(String serverName, TcConfiguration config) {
-    this.serverName = serverName;
+  public PlatformConfigurationImpl(L2Config l2Config, TcConfiguration config) {
+    this.l2Config = l2Config;
     this.config = config;
   }
 
   @Override
   public String getServerName() {
-    return this.serverName;
+    return l2Config.serverName();
+  }
+
+  @Override
+  public String getHost() {
+    return l2Config.host();
+  }
+
+  @Override
+  public int getTsaPort() {
+    return l2Config.tsaPort().getValue();
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <tc-shader.version>1.2</tc-shader.version>
     <skip.deploy>false</skip.deploy>
 
-    <terracotta-apis.version>1.5.0-pre1</terracotta-apis.version>
+    <terracotta-apis.version>1.5.0-pre2</terracotta-apis.version>
     <terracotta-configuration.version>10.5.0-pre1</terracotta-configuration.version>
     <galvan.version>1.4.1</galvan.version>
   </properties>


### PR DESCRIPTION
Implemented changes in PlatformConfiguration interface towards providing server host and port information.

Depends on https://github.com/Terracotta-OSS/terracotta-apis/pull/293 and a corresponding version bump.