### PR TITLE
Adapted to PlatformService interface changes and added implementation for TCServerImpl::stop

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DiagnosticsHandler.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DiagnosticsHandler.java
@@ -89,7 +89,7 @@ public class DiagnosticsHandler implements TCMessageSink {
           result = "".getBytes(set);
           break;
         case "forceTerminateServer":
-          Runtime.getRuntime().exit(0);
+          TCServerMain.getServer().stop();
           // never used, server is dead
           result = "".getBytes(set);
           break;

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -432,7 +432,7 @@ public class DistributedObjectServer implements TCDumper, ServerConnectionValida
     TcConfiguration base = this.configSetupManager.commonl2Config().getTCConfiguration();
     PlatformConfiguration platformConfiguration = new PlatformConfigurationImpl(this.configSetupManager.dsoL2Config(), base);
     serviceRegistry.initialize(platformConfiguration, base, Thread.currentThread().getContextClassLoader());
-    serviceRegistry.registerImplementationProvided(new PlatformServiceProvider(this));
+    serviceRegistry.registerImplementationProvided(new PlatformServiceProvider(server));
 
     final EntityMessengerProvider messengerProvider = new EntityMessengerProvider();
     this.serviceRegistry.registerImplementationProvided(messengerProvider);

--- a/dso-l2/src/main/java/com/tc/server/TCServerImpl.java
+++ b/dso-l2/src/main/java/com/tc/server/TCServerImpl.java
@@ -180,15 +180,9 @@ public class TCServerImpl extends SEDA implements TCServer, StateChangeListener 
     }
   }
 
-  /**
-   * I realize this is wrong, since the server can still be starting but we'll have to deal with the whole stopping
-   * issue later, and there's the TCStop feature which should be removed.
-   */
   @Override
   public void stop() {
-    // XXX: This is part of the now-deprecated JMX 4.x Management interface called from TCServerInfo.
-    // TODO:  Remove the com.tc.mangement.beans package and then this method.
-    throw new UnsupportedOperationException("Management can no longer request a server shutdown");
+    Runtime.getRuntime().exit(0);
   }
 
   @Override

--- a/dso-l2/src/main/java/com/tc/services/PlatformServiceImpl.java
+++ b/dso-l2/src/main/java/com/tc/services/PlatformServiceImpl.java
@@ -18,7 +18,7 @@
  */
 package com.tc.services;
 
-import com.tc.management.beans.TCDumper;
+import com.tc.server.TCServer;
 import com.tc.server.TCServerMain;
 import java.io.InputStream;
 import org.terracotta.monitoring.PlatformService;
@@ -28,17 +28,22 @@ import org.terracotta.monitoring.PlatformService;
  */
 public class PlatformServiceImpl implements PlatformService {
 
-    private final TCDumper tcDumper;
+    private final TCServer tcServer;
 
-    public PlatformServiceImpl(TCDumper tcDumper) {
-        this.tcDumper = tcDumper;
+    public PlatformServiceImpl(TCServer tcServer) {
+        this.tcServer = tcServer;
     }
 
     @Override
     public void dumpPlatformState() {
-        this.tcDumper.dump();
+        tcServer.dump();
     }
-    
+
+    @Override
+    public void stopPlatform() {
+        tcServer.stop();
+    }
+
     @Override
     public InputStream getPlatformConfiguration() {
       return TCServerMain.getSetupManager().rawConfigFile();

--- a/dso-l2/src/main/java/com/tc/services/PlatformServiceProvider.java
+++ b/dso-l2/src/main/java/com/tc/services/PlatformServiceProvider.java
@@ -18,8 +18,9 @@
  */
 package com.tc.services;
 
-import com.tc.management.beans.TCDumper;
 import com.tc.objectserver.api.ManagedEntity;
+import com.tc.server.TCServer;
+
 import org.terracotta.entity.ServiceConfiguration;
 import org.terracotta.entity.ServiceProviderCleanupException;
 import org.terracotta.monitoring.PlatformService;
@@ -32,8 +33,8 @@ public class PlatformServiceProvider implements ImplementationProvidedServicePro
 
     private final PlatformServiceImpl platformService;
 
-    public PlatformServiceProvider(TCDumper tcDumper) {
-        this.platformService = new PlatformServiceImpl(tcDumper);
+    public PlatformServiceProvider(TCServer tcServer) {
+        this.platformService = new PlatformServiceImpl(tcServer);
     }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
     <tc-shader.version>1.2</tc-shader.version>
     <skip.deploy>false</skip.deploy>
 
-    <terracotta-apis.version>1.5.0-pre2</terracotta-apis.version>
-    <terracotta-configuration.version>10.5.0-pre2</terracotta-configuration.version>
+    <terracotta-apis.version>1.5.0-pre3</terracotta-apis.version>
+    <terracotta-configuration.version>10.5.0-pre3</terracotta-configuration.version>
     <galvan.version>1.4.1</galvan.version>
   </properties>
 


### PR DESCRIPTION
Added implementation for TCServerImpl::stop and make everyone use it instead of doing `Runtime.getRuntime().exit()`