### PR TITLE
Use absolute path names in CLASSPATH

### DIFF
--- a/terracotta-kit/src/assemble/server/bin/start-tc-server.bat
+++ b/terracotta-kit/src/assemble/server/bin/start-tc-server.bat
@@ -33,7 +33,9 @@ exit /b 0
 :start
 setlocal enabledelayedexpansion enableextensions
 
-set TC_SERVER_DIR=%~d0%~p0..
+pushd "%~d0%~p0.."
+set TC_SERVER_DIR=%CD%
+popd
 set TC_SERVER_DIR="%TC_SERVER_DIR:"=%"
 set PLUGIN_LIB_DIR=%TC_SERVER_DIR%\plugins\lib
 set PLUGIN_API_DIR=%TC_SERVER_DIR%\plugins\api


### PR DESCRIPTION
This commit fixes #930 by changing start-tc-server.bat to use absolute
path names in CLASSPATH instead of relative path names.  This avoids
setting up the conditions leading to the "MULTIPLE instances" messages
in the log.