### PR TITLE
Fix #939 - Reconnect needs to rebuild with ConnectionID not ClientID

### DIFF
--- a/common/src/main/java/com/tc/net/protocol/tcm/CommunicationsManagerImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/CommunicationsManagerImpl.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 import com.tc.net.core.BufferManagerFactory;
 import com.tc.net.core.ClearTextBufferManagerFactory;
 import com.tc.util.ProductID;
-import com.tc.net.ClientID;
 import com.tc.net.ServerID;
 import com.tc.net.TCSocketAddress;
 import com.tc.net.core.Constants;
@@ -39,6 +38,7 @@ import com.tc.net.protocol.transport.ClientMessageTransport;
 import com.tc.net.protocol.transport.ConnectionHealthChecker;
 import com.tc.net.protocol.transport.ConnectionHealthCheckerEchoImpl;
 import com.tc.net.protocol.transport.ConnectionHealthCheckerImpl;
+import com.tc.net.protocol.transport.ConnectionID;
 import com.tc.net.protocol.transport.ConnectionIDFactory;
 import com.tc.net.protocol.transport.ConnectionPolicy;
 import com.tc.net.protocol.transport.DisabledHealthCheckerConfigImpl;
@@ -359,7 +359,7 @@ public class CommunicationsManagerImpl implements CommunicationsManager {
   }
 
   TCListener createCommsListener(TCSocketAddress addr, ServerMessageChannelFactory channelFactory,
-                                 boolean resueAddr, Set<ClientID> initialConnectionIDs, NodeNameProvider activeProvider, Predicate<MessageTransport> validation, ConnectionIDFactory connectionIdFactory,
+                                 boolean resueAddr, Set<ConnectionID> initialConnectionIDs, NodeNameProvider activeProvider, Predicate<MessageTransport> validation, ConnectionIDFactory connectionIdFactory,
                                  WireProtocolMessageSink wireProtocolMessageSink) throws IOException {
 
     MessageTransportFactory transportFactory = new MessageTransportFactory() {

--- a/common/src/main/java/com/tc/net/protocol/tcm/NetworkListener.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/NetworkListener.java
@@ -18,7 +18,7 @@
  */
 package com.tc.net.protocol.tcm;
 
-import com.tc.net.ClientID;
+import com.tc.net.protocol.transport.ConnectionID;
 import com.tc.util.TCTimeoutException;
 
 import java.io.IOException;
@@ -27,7 +27,7 @@ import java.util.Set;
 
 public interface NetworkListener {
 
-  public void start(Set<ClientID> initialConnectionIDs) throws IOException;
+  public void start(Set<ConnectionID> initialConnectionIDs) throws IOException;
 
   public void stop(long timeout) throws TCTimeoutException;
 

--- a/common/src/main/java/com/tc/net/protocol/tcm/NetworkListenerImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/NetworkListenerImpl.java
@@ -18,9 +18,9 @@
  */
 package com.tc.net.protocol.tcm;
 
-import com.tc.net.ClientID;
 import com.tc.net.TCSocketAddress;
 import com.tc.net.core.TCListener;
+import com.tc.net.protocol.transport.ConnectionID;
 import com.tc.net.protocol.transport.ConnectionIDFactory;
 import com.tc.net.protocol.transport.MessageTransport;
 import com.tc.net.protocol.transport.WireProtocolMessageSink;
@@ -71,7 +71,7 @@ class NetworkListenerImpl implements NetworkListener {
    * @throws IOException if an IO error occurs (this will most likely be a problem binding to the specified port/address)
    */
   @Override
-  public synchronized void start(Set<ClientID> initialConnectionIDs) throws IOException {
+  public synchronized void start(Set<ConnectionID> initialConnectionIDs) throws IOException {
     this.lsnr = this.commsMgr.createCommsListener(this.addr, this.channelManager, this.reuseAddr, initialConnectionIDs, this.activeProvider,
                                                   this.validation, this.connectionIdFactory, this.wireProtoMsgSnk);
     this.started = true;

--- a/common/src/main/java/com/tc/net/protocol/transport/ServerStackProvider.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ServerStackProvider.java
@@ -70,7 +70,7 @@ public class ServerStackProvider implements NetworkStackProvider, MessageTranspo
   private final Predicate<MessageTransport>                validateTransport;
 
   // used only in test
-  public ServerStackProvider(Set<ClientID> initialConnectionIDs, NetworkStackHarnessFactory harnessFactory,
+  public ServerStackProvider(Set<ConnectionID> initialConnectionIDs, NetworkStackHarnessFactory harnessFactory,
                              ServerMessageChannelFactory channelFactory,
                              MessageTransportFactory messageTransportFactory,
                              TransportHandshakeMessageFactory handshakeMessageFactory,
@@ -81,7 +81,7 @@ public class ServerStackProvider implements NetworkStackProvider, MessageTranspo
          CommunicationsManager.COMMSMGR_SERVER);
   }
 
-  public ServerStackProvider(Set<ClientID> initialConnectionIDs, NodeNameProvider activeProvider, Predicate<MessageTransport> validate, NetworkStackHarnessFactory harnessFactory,
+  public ServerStackProvider(Set<ConnectionID> initialConnectionIDs, NodeNameProvider activeProvider, Predicate<MessageTransport> validate, NetworkStackHarnessFactory harnessFactory,
                              ServerMessageChannelFactory channelFactory,
                              MessageTransportFactory messageTransportFactory,
                              TransportHandshakeMessageFactory handshakeMessageFactory,
@@ -102,12 +102,15 @@ public class ServerStackProvider implements NetworkStackProvider, MessageTranspo
     Assert.assertNotNull(licenseLock);
     this.licenseLock = licenseLock;
     this.commsMgrName = commsMgrName;
-    for (final ClientID clientID : initialConnectionIDs) {
-      logger.info("Preparing comms stack for previously connected client: " + clientID);
-      newStackHarness(clientID, messageTransportFactory.createNewTransport(
+    for (final ConnectionID client : initialConnectionIDs) {
+      logger.info("Preparing comms stack for previously connected client: " + client);
+      MessageTransport transport = messageTransportFactory.createNewTransport(
           createHandshakeErrorHandler(),
           handshakeMessageFactory,
-          transportListeners)).finalizeStack();
+          transportListeners);
+      //  create a fake connection id for use until the real transport connection is made
+      transport.initConnectionID(client);
+      newStackHarness(client.getClientID(), transport).finalizeStack();
     }
     this.activeProvider = activeProvider;
     this.validateTransport = validate;

--- a/common/src/test/java/com/tc/net/core/NoReconnectThreadTest.java
+++ b/common/src/test/java/com/tc/net/core/NoReconnectThreadTest.java
@@ -40,6 +40,7 @@ import com.tc.net.protocol.tcm.TCMessage;
 import com.tc.net.protocol.tcm.TCMessageRouterImpl;
 import com.tc.net.protocol.tcm.TCMessageType;
 import com.tc.net.protocol.transport.ClientConnectionEstablisher;
+import com.tc.net.protocol.transport.ConnectionID;
 import com.tc.net.protocol.transport.DefaultConnectionIdFactory;
 import com.tc.net.protocol.transport.HealthCheckerConfigImpl;
 import com.tc.net.protocol.transport.NullConnectionPolicy;
@@ -119,7 +120,7 @@ public class NoReconnectThreadTest extends TCTestCase implements ChannelEventLis
     );
     NetworkListener listener = serverCommsMgr.createListener(new TCSocketAddress(0), true,
                                                              new DefaultConnectionIdFactory(), (t)->true);
-    listener.start(Collections.<ClientID>emptySet());
+    listener.start(Collections.<ConnectionID>emptySet());
     int serverPort = listener.getBindPort();
 
     int proxyPort = new PortChooser().chooseRandomPort();
@@ -183,7 +184,7 @@ public class NoReconnectThreadTest extends TCTestCase implements ChannelEventLis
     );
     NetworkListener listener = serverCommsMgr.createListener(new TCSocketAddress(0), true,
                                                              new DefaultConnectionIdFactory(), (t)->true);
-    listener.start(Collections.<ClientID>emptySet());
+    listener.start(Collections.<ConnectionID>emptySet());
     int serverPort = listener.getBindPort();
 
     int proxyPort = new PortChooser().chooseRandomPort();

--- a/common/src/test/java/com/tc/net/core/OOOReconnectTimeoutTest.java
+++ b/common/src/test/java/com/tc/net/core/OOOReconnectTimeoutTest.java
@@ -18,7 +18,6 @@
  */
 package com.tc.net.core;
 
-import com.tc.net.ClientID;
 import com.tc.net.ServerID;
 import com.tc.net.TCSocketAddress;
 import com.tc.net.protocol.NetworkStackHarnessFactory;
@@ -34,6 +33,7 @@ import com.tc.net.protocol.tcm.NullMessageMonitor;
 import com.tc.net.protocol.tcm.TCMessage;
 import com.tc.net.protocol.tcm.TCMessageRouterImpl;
 import com.tc.net.protocol.tcm.TCMessageType;
+import com.tc.net.protocol.transport.ConnectionID;
 import com.tc.net.protocol.transport.DefaultConnectionIdFactory;
 import com.tc.net.protocol.transport.HealthCheckerConfigImpl;
 import com.tc.net.protocol.transport.NullConnectionPolicy;
@@ -111,7 +111,7 @@ public class OOOReconnectTimeoutTest extends TCTestCase {
                                                                    Collections.<TCMessageType, GeneratedMessageFactory>emptyMap());
     NetworkListener listener = commsMgr.createListener(new TCSocketAddress(0), true,
                                                        new DefaultConnectionIdFactory(), (t)->true);
-    listener.start(Collections.<ClientID>emptySet());
+    listener.start(Collections.<ConnectionID>emptySet());
     int serverPort = listener.getBindPort();
 
     int proxyPort = new PortChooser().chooseRandomPort();

--- a/common/src/test/java/com/tc/net/core/TCWorkerCommManagerTest.java
+++ b/common/src/test/java/com/tc/net/core/TCWorkerCommManagerTest.java
@@ -21,7 +21,6 @@ package com.tc.net.core;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.tc.net.ClientID;
 import com.tc.net.ServerID;
 import com.tc.net.TCSocketAddress;
 import com.tc.net.protocol.NetworkStackHarnessFactory;
@@ -38,6 +37,7 @@ import com.tc.net.protocol.tcm.TCMessage;
 import com.tc.net.protocol.tcm.TCMessageRouterImpl;
 import com.tc.net.protocol.tcm.TCMessageType;
 import com.tc.net.protocol.transport.ClientMessageTransport;
+import com.tc.net.protocol.transport.ConnectionID;
 import com.tc.net.protocol.transport.DefaultConnectionIdFactory;
 import com.tc.net.protocol.transport.HealthCheckerConfigImpl;
 import com.tc.net.protocol.transport.MessageTransport;
@@ -115,7 +115,7 @@ public class TCWorkerCommManagerTest extends TCTestCase {
                                                                    new NullConnectionPolicy(), 4);
     NetworkListener listener = commsMgr.createListener(new TCSocketAddress(0), true,
                                                        new DefaultConnectionIdFactory(), (t)->true);
-    listener.start(Collections.<ClientID>emptySet());
+    listener.start(Collections.<ConnectionID>emptySet());
     int port = listener.getBindPort();
 
     ClientMessageTransport client1 = createClient("client1");
@@ -164,7 +164,7 @@ public class TCWorkerCommManagerTest extends TCTestCase {
                                                                    new NullConnectionPolicy(), 3);
     NetworkListener listener = commsMgr.createListener(new TCSocketAddress(0), true,
                                                        new DefaultConnectionIdFactory(), (t)->true);
-    listener.start(Collections.<ClientID>emptySet());
+    listener.start(Collections.<ConnectionID>emptySet());
     int port = listener.getBindPort();
     
     ConnectionInfo connectTo = new ConnectionInfo("localhost", port);
@@ -220,7 +220,7 @@ public class TCWorkerCommManagerTest extends TCTestCase {
                                                                    new NullConnectionPolicy(), 3);
     NetworkListener listener = commsMgr.createListener(new TCSocketAddress(0), true,
                                                        new DefaultConnectionIdFactory(), (t)->true);
-    listener.start(Collections.<ClientID>emptySet());
+    listener.start(Collections.<ConnectionID>emptySet());
     int port = listener.getBindPort();
     
     ConnectionInfo connectTo = new ConnectionInfo("localhost", port);
@@ -320,7 +320,7 @@ public class TCWorkerCommManagerTest extends TCTestCase {
                                                                      Collections.<TCMessageType, GeneratedMessageFactory>emptyMap());
       NetworkListener listener = commsMgr.createListener(new TCSocketAddress(0), true,
                                                          new DefaultConnectionIdFactory(), (t)->true);
-      listener.start(Collections.<ClientID>emptySet());
+      listener.start(Collections.<ConnectionID>emptySet());
       int serverPort = listener.getBindPort();
 
       int proxyPort = new PortChooser().chooseRandomPort();

--- a/common/src/test/java/com/tc/net/protocol/tcm/LazyHandshakeTest.java
+++ b/common/src/test/java/com/tc/net/protocol/tcm/LazyHandshakeTest.java
@@ -22,13 +22,13 @@ import org.slf4j.LoggerFactory;
 
 import com.tc.lang.TCThreadGroup;
 import com.tc.lang.ThrowableHandlerImpl;
-import com.tc.net.ClientID;
 import com.tc.net.CommStackMismatchException;
 import com.tc.net.MaxConnectionsExceededException;
 import com.tc.net.TCSocketAddress;
 import com.tc.net.core.ConnectionInfo;
 import com.tc.net.protocol.PlainNetworkStackHarnessFactory;
 import com.tc.net.protocol.transport.ClientMessageTransport;
+import com.tc.net.protocol.transport.ConnectionID;
 import com.tc.net.protocol.transport.DefaultConnectionIdFactory;
 import com.tc.net.protocol.transport.NullConnectionPolicy;
 import com.tc.net.proxy.TCPProxy;
@@ -86,7 +86,7 @@ public class LazyHandshakeTest extends TCTestCase {
                                           new DefaultConnectionIdFactory(), (t)->true);
 
     try {
-      listener.start(new HashSet<ClientID>());
+      listener.start(new HashSet<ConnectionID>());
     } catch (Exception e) {
       System.out.println("lsnr Excep");
     }

--- a/common/src/test/java/com/tc/net/protocol/tcm/MessageChannelTest.java
+++ b/common/src/test/java/com/tc/net/protocol/tcm/MessageChannelTest.java
@@ -21,12 +21,12 @@ package com.tc.net.protocol.tcm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.tc.net.ClientID;
 import com.tc.net.TCSocketAddress;
 import com.tc.net.core.ConnectionInfo;
 import com.tc.net.protocol.NetworkStackHarnessFactory;
 import com.tc.net.protocol.PlainNetworkStackHarnessFactory;
 import com.tc.net.protocol.tcm.msgs.PingMessage;
+import com.tc.net.protocol.transport.ConnectionID;
 import com.tc.net.protocol.transport.DefaultConnectionIdFactory;
 import com.tc.net.protocol.transport.DisabledHealthCheckerConfigImpl;
 import com.tc.net.protocol.transport.NullConnectionPolicy;
@@ -171,7 +171,7 @@ try {
         lsnr = serverComms.createListener(new TCSocketAddress(port), false,
             new DefaultConnectionIdFactory(), (t)->true);
       }
-      lsnr.start(new HashSet<ClientID>());
+      lsnr.start(new HashSet<ConnectionID>());
       connectTo = new ConnectionInfo("localhost", lsnr.getBindPort());
   }
 
@@ -324,7 +324,7 @@ try {
                                        new DefaultConnectionIdFactory(), (t)->true);
     }
 
-    rv.start(new HashSet<ClientID>());
+    rv.start(new HashSet<ConnectionID>());
     return rv;
   }
 

--- a/common/src/test/java/com/tc/net/protocol/tcm/NetworkListenerTest.java
+++ b/common/src/test/java/com/tc/net/protocol/tcm/NetworkListenerTest.java
@@ -18,9 +18,9 @@
  */
 package com.tc.net.protocol.tcm;
 
-import com.tc.net.ClientID;
 import com.tc.net.TCSocketAddress;
 import com.tc.net.protocol.PlainNetworkStackHarnessFactory;
+import com.tc.net.protocol.transport.ConnectionID;
 import com.tc.net.protocol.transport.ConnectionIDFactory;
 import com.tc.net.protocol.transport.DefaultConnectionIdFactory;
 import com.tc.net.protocol.transport.NullConnectionPolicy;
@@ -65,14 +65,14 @@ public class NetworkListenerTest extends TestCase {
     NetworkListener lsnr = commsMgr.createListener(new TCSocketAddress(0), true, cidf, (t)->true);
 
     try {
-      lsnr.start(Collections.<ClientID>emptySet());
+      lsnr.start(Collections.<ConnectionID>emptySet());
     } catch (IOException ioe) {
       fail(ioe.getMessage());
     }
 
     NetworkListener lsnr2 = commsMgr.createListener(new TCSocketAddress(lsnr.getBindPort()), true, cidf, (t)->true);
     try {
-      lsnr2.start(Collections.<ClientID>emptySet());
+      lsnr2.start(Collections.<ConnectionID>emptySet());
       // NOTE (issue-529):  When running on Windows, in a pre-Java7u25 JVM, this bind succeeds.
       if (isWindows() && isJava6()) {
         System.err.println("WARNING:  bind success due to lack of SO_EXCLUSIVEADDRUSE - ignoring test failure");
@@ -102,7 +102,7 @@ public class NetworkListenerTest extends TestCase {
           .getByName("127.0.0.1"), 0), true, new DefaultConnectionIdFactory(), (t)->true);
 
       try {
-        lsnr.start(Collections.<ClientID>emptySet());
+        lsnr.start(Collections.<ConnectionID>emptySet());
         listeners[i] = lsnr;
       } catch (IOException ioe) {
         fail(ioe.getMessage());

--- a/common/src/test/java/com/tc/net/protocol/transport/ConnectionHealthCheckerReconnectTest.java
+++ b/common/src/test/java/com/tc/net/protocol/transport/ConnectionHealthCheckerReconnectTest.java
@@ -130,7 +130,7 @@ public class ConnectionHealthCheckerReconnectTest extends TCTestCase {
     serverLsnr = serverComms.createListener(new TCSocketAddress(0), false,
                                             new DefaultConnectionIdFactory(), (t)->true);
 
-    serverLsnr.start(new HashSet<ClientID>());
+    serverLsnr.start(new HashSet<ConnectionID>());
 
     int serverPort = serverLsnr.getBindPort();
     proxyPort = new PortChooser().chooseRandomPort();

--- a/dso-l2/src/main/java/com/tc/l2/ha/StripeIDStateManagerImpl.java
+++ b/dso-l2/src/main/java/com/tc/l2/ha/StripeIDStateManagerImpl.java
@@ -42,10 +42,11 @@ public class StripeIDStateManagerImpl implements StripeIDStateManager {
   }
 
   private int loadStripeIDFromDB() {
-    StripeID id = clusterStatePersistor.getStripeID();
-    return id.isNull() ? 1 : 0;
+    stripeID = clusterStatePersistor.getStripeID();
+    return stripeID.isNull() ? 1 : 0;
   }
   
+  @Override
   public StripeID getStripeID() {
     return stripeID;
   }
@@ -61,8 +62,8 @@ public class StripeIDStateManagerImpl implements StripeIDStateManager {
   }
 
   @Override
-  public boolean verifyOrSaveStripeID(StripeID stripeID, boolean overwrite) {
-    if (stripeID.isNull()) {
+  public boolean verifyOrSaveStripeID(StripeID newID, boolean overwrite) {
+    if (newID.isNull()) {
       logger.warn("Ignore null StripeID");
       return false;
     }
@@ -70,11 +71,11 @@ public class StripeIDStateManagerImpl implements StripeIDStateManager {
     StripeID oldID = this.stripeID;
 
     if (overwrite || oldID.isNull()) {
-      putToStore(stripeID);
+      putToStore(newID);
       if (oldID.isNull()) unKnownIDCount.decrementAndGet();
-      logger.debug("Collected " + stripeID + " count: " + unKnownIDCount.get());
-
-      notifyLocalStripeIDReady(stripeID);
+      logger.debug("Collected " + newID + " count: " + unKnownIDCount.get());
+      stripeID = newID;
+      notifyLocalStripeIDReady(newID);
     } else {
       if (!oldID.equals(stripeID)) {
         logger.error("Mismatch StripeID " + oldID + " with " + stripeID);

--- a/dso-l2/src/main/java/com/tc/net/groups/TCGroupManagerImpl.java
+++ b/dso-l2/src/main/java/com/tc/net/groups/TCGroupManagerImpl.java
@@ -35,7 +35,6 @@ import com.tc.l2.L2DebugLogging.LogLevel;
 import com.tc.l2.ha.L2HAZapNodeRequestProcessor;
 import com.tc.l2.ha.WeightGeneratorFactory;
 import com.tc.l2.msg.L2StateMessage;
-import com.tc.net.ClientID;
 import com.tc.net.CommStackMismatchException;
 import com.tc.net.MaxConnectionsExceededException;
 import com.tc.net.NodeID;
@@ -64,6 +63,7 @@ import com.tc.net.protocol.tcm.TCMessageHydrateSink;
 import com.tc.net.protocol.tcm.TCMessageRouter;
 import com.tc.net.protocol.tcm.TCMessageRouterImpl;
 import com.tc.net.protocol.tcm.TCMessageType;
+import com.tc.net.protocol.transport.ConnectionID;
 import com.tc.net.protocol.transport.ConnectionPolicy;
 import com.tc.net.protocol.transport.DefaultConnectionIdFactory;
 import com.tc.net.protocol.transport.HealthCheckerConfigImpl;
@@ -416,7 +416,7 @@ public class TCGroupManagerImpl implements GroupManager<AbstractGroupMessage>, C
     discover.setupNodes(thisNode, nodesStore.getAllNodes());
     discover.start();
     try {
-      groupListener.start(new HashSet<ClientID>());
+      groupListener.start(new HashSet<ConnectionID>());
     } catch (IOException e) {
       throw new GroupException(e);
     }

--- a/dso-l2/src/main/java/com/tc/objectserver/persistence/ClusterStatePersistor.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/persistence/ClusterStatePersistor.java
@@ -61,15 +61,6 @@ public class ClusterStatePersistor {
     return s == null ? StripeID.NULL_ID : new StripeID(s);
   }
 
-  public void setThisStripeID(StripeID stripeID) {
-    putAndStore(STRIPE_ID_KEY, stripeID.getName());
-  }
-
-  public StripeID getThisStripeID() {
-    String s = map.get(STRIPE_ID_KEY);
-    return s == null ? StripeID.NULL_ID : new StripeID(s);
-  }
-
   public State getInitialState() {
     return initialState;
   }

--- a/dso-l2/src/test/java/com/tc/net/protocol/transport/ServerStackProviderTest.java
+++ b/dso-l2/src/test/java/com/tc/net/protocol/transport/ServerStackProviderTest.java
@@ -151,8 +151,8 @@ public class ServerStackProviderTest extends TCTestCase {
 
     ConnectionID connectionID1 = new ConnectionID("JVM", 1, "server1");
     ConnectionID connectionID2 = new ConnectionID("JVM", 2, "server1");
-    Set<ClientID> rebuild = new HashSet<>();
-    rebuild.add(connectionID1.getClientID());
+    Set<ConnectionID> rebuild = new HashSet<>();
+    rebuild.add(connectionID1);
     
 
     provider = new ServerStackProvider(rebuild, harnessFactory,
@@ -224,8 +224,8 @@ public class ServerStackProviderTest extends TCTestCase {
     ConnectionID connectionID1 = new ConnectionID("JVM", 1, "server1");
     ConnectionID connectionID2 = new ConnectionID("JVM", 2, "server1");
 
-    Set<ClientID> rebuild = new HashSet<>();
-    rebuild.add(connectionID1.getClientID());
+    Set<ConnectionID> rebuild = new HashSet<>();
+    rebuild.add(connectionID1);
 
     provider = new ServerStackProvider(rebuild, harnessFactory,
                                        serverMessageChannelFactory, messageTransportFactory, null, factory, connectionPolicy,


### PR DESCRIPTION
cherry-picked from master a4768fbca9ae7f08cff4a32553f6b79065b3e0f7

Conflicts:
	common/src/main/java/com/tc/net/protocol/transport/ServerStackProvider.java
	dso-l2/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java