### PR TITLE
add gc monitoring

### DIFF
--- a/common/src/main/java/com/tc/properties/TCPropertiesConsts.java
+++ b/common/src/main/java/com/tc/properties/TCPropertiesConsts.java
@@ -176,13 +176,17 @@ public interface TCPropertiesConsts {
    * <code>
    * Section : Common Stage Monitoring properties for both L1 and L2
    * Description : Stage monitoring can be enabled or disabled for debugging.
-   * stage.monitor.enabled                : <true/false>    - Enable or Disable Monitoring
+   * gc.monitor.enabled                   : <true/false>    - Enable or Disable GC Monitoring
+   * gc.monitor.delay                     : long            - frequency in milliseconds
+   * stage.monitor.enabled                : <true/false>    - Enable or Disable stage Monitoring
    * stage.monitor.delay                  : long            - frequency in milliseconds
    * bytebuffer.pooling.enabled           : Enable/disable tc byte buffer pooling
    * bytebuffer.common.pool.maxcount      : Max size of pool for tc byte buffer
    * bytebuffer.threadlocal.pool.maxcount : Thread pool size
    * </code>
    ********************************************************************************************************************/
+  public static final String TC_GC_MONITOR_ENABLED                                          = "tc.gc.monitor.enabled";
+  public static final String TC_GC_MONITOR_DELAY                                            = "tc.gc.monitor.delay";
   public static final String TC_STAGE_MONITOR_ENABLED                                       = "tc.stage.monitor.enabled";
   public static final String TC_STAGE_MONITOR_DELAY                                         = "tc.stage.monitor.delay";
   public static final String TC_MESSAGE_GROUPING_ENABLED                                    = "tc.messages.grouping.enabled";

--- a/common/src/main/java/com/tc/runtime/GcMonitor.java
+++ b/common/src/main/java/com/tc/runtime/GcMonitor.java
@@ -1,0 +1,124 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.runtime;
+
+import com.tc.properties.TCPropertiesConsts;
+import com.tc.properties.TCPropertiesImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.ListenerNotFoundException;
+import javax.management.NotificationEmitter;
+import javax.management.NotificationListener;
+import javax.management.openmbean.CompositeData;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.util.List;
+import java.util.Queue;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class GcMonitor {
+
+  private static final Logger logger = LoggerFactory.getLogger(GcMonitor.class);
+
+  private final Queue<GcStats> gcStatsQueue = new ConcurrentLinkedQueue<>();
+  private final Timer timer = new Timer("GcMonitor-timer", true);
+  private final NotificationListener listener = (notification, handback) -> {
+    if (notification.getType().equals("com.sun.management.gc.notification")) {
+      CompositeData userData = (CompositeData) notification.getUserData();
+      CompositeData gcInfo = (CompositeData) userData.get("gcInfo");
+
+      GcStats gcStats = new GcStats(
+          (Long) gcInfo.get("duration"),
+          (String) userData.get("gcAction"),
+          (Long) gcInfo.get("startTime"),
+          (String) userData.get("gcCause"),
+          (String) userData.get("gcName")
+      );
+      gcStatsQueue.add(gcStats);
+    }
+  };
+
+
+  public GcMonitor() {
+  }
+
+  public void init() {
+    long delay = TCPropertiesImpl.getProperties().getLong(TCPropertiesConsts.TC_GC_MONITOR_DELAY);
+
+    List<GarbageCollectorMXBean> gcMxBeans = java.lang.management.ManagementFactory.getGarbageCollectorMXBeans();
+    for (GarbageCollectorMXBean gcMxBean : gcMxBeans) {
+      NotificationEmitter emitter = (NotificationEmitter)gcMxBean;
+      emitter.addNotificationListener(listener, null, null);
+    }
+    timer.schedule(new TimerTask() {
+      @Override
+      public void run() {
+        dump();
+      }
+    }, delay, delay);
+  }
+
+  public void close() {
+    List<GarbageCollectorMXBean> gcMxBeans = java.lang.management.ManagementFactory.getGarbageCollectorMXBeans();
+    for (GarbageCollectorMXBean gcMxBean : gcMxBeans) {
+      NotificationEmitter emitter = (NotificationEmitter)gcMxBean;
+
+      try {
+        emitter.removeNotificationListener(listener);
+      } catch (ListenerNotFoundException e) {
+        //
+      }
+    }
+    timer.cancel();
+  }
+
+  private void dump() {
+    while (true) {
+      GcStats gcStats = gcStatsQueue.poll();
+      if (gcStats == null) break;
+      logger.info("GC event : startTime={} / duration={} / action={} / cause={} / name={}", gcStats.startTimestamp, gcStats.duration, gcStats.action, gcStats.cause, gcStats.name);
+    }
+
+    MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
+    java.lang.management.MemoryUsage heapUsage = memoryMXBean.getHeapMemoryUsage();
+    logger.info("Heap usage : init={} / used={} / committed={} / max={}", heapUsage.getInit(), heapUsage.getUsed(), heapUsage.getCommitted(), heapUsage.getMax());
+  }
+
+
+  private static class GcStats {
+    private final long startTimestamp;
+    private final long duration;
+    private final String action;
+    private final String cause;
+    private final String name;
+
+    private GcStats(long duration, String action, long startTimestamp, String cause, String name) {
+      this.duration = duration;
+      this.action = action;
+      this.startTimestamp = startTimestamp;
+      this.cause = cause;
+      this.name = name;
+    }
+  }
+
+}

--- a/common/src/main/java/com/tc/runtime/TCRuntime.java
+++ b/common/src/main/java/com/tc/runtime/TCRuntime.java
@@ -26,6 +26,7 @@ import com.tc.util.Assert;
 public class TCRuntime {
 
   private static JVMMemoryManager memoryManager;
+  private static GcMonitor gcMonitor;
 
   static {
     init();
@@ -43,6 +44,11 @@ public class TCRuntime {
       memoryManager = new TCMemoryManagerJdk15Basic();
     } else {
       memoryManager = new TCMemoryManagerJdk15PoolMonitor();
+    }
+
+    if (props.getBoolean(TCPropertiesConsts.TC_GC_MONITOR_ENABLED)) {
+      gcMonitor = new GcMonitor();
+      gcMonitor.init();
     }
   }
 }

--- a/common/src/main/resources/com/tc/properties/tc.properties
+++ b/common/src/main/resources/com/tc/properties/tc.properties
@@ -137,12 +137,16 @@ logging.longgc.threshold = 8000
 ###########################################################################################
 # Section                             : Common Stage Monitoring properties for both L1 and L2
 # Description                         : Stage monitoring can be enabled or disabled for debugging.
-# stage.monitor.enabled               : <true/false>    - Enable or Disable Monitoring
+# gc.monitor.enabled                  : <true/false>    - Enable or Disable GC Monitoring
+# gc.monitor.delay                    : long            - frequency in milliseconds
+# stage.monitor.enabled               : <true/false>    - Enable or Disable stage Monitoring
 # stage.monitor.delay                 : long            - frequency in milliseconds
 # bytebuffer.pooling.enabled          : Enable/disable tc byte buffer pooling
 # bytebuffer.common.pool.maxcount     : Max size of pool for tc byte buffer
 # bytebuffer.threadlocal.pool.maxcount: Thread pool size
 ###########################################################################################
+tc.gc.monitor.enabled = false
+tc.gc.monitor.delay = 5000
 tc.stage.monitor.enabled = false
 tc.stage.monitor.delay = 5000
 tc.messages.grouping.enabled = false


### PR DESCRIPTION
Similar to the stages monitoring, this patch will log GC activity and heap occupation every few seconds.

I am not certain we want this in the server, so I have no hard feelings if you don't want to merge this. But this logs the basics to quickly help us figure out if the GC is healthy or not, and if the heap is reasonably sized.