### PR TITLE
Fix permanent entity creation during rolling upgrades

### DIFF
--- a/dso-l2/src/main/java/com/tc/objectserver/api/EntityManager.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/api/EntityManager.java
@@ -29,6 +29,7 @@ import com.tc.text.PrettyPrintable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import org.terracotta.exception.EntityException;
@@ -99,4 +100,9 @@ public interface EntityManager extends MessageCodecSupplier, PrettyPrintable {
    * @return the classloader used to create all entities
    */
   ServerEntityFactory getEntityLoader();
+
+  /**
+   * @return existing {@link EntityID}s
+   */
+  Set<EntityID> getExistingEntities();
 }

--- a/dso-l2/src/main/java/com/tc/objectserver/entity/EntityManagerImpl.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/entity/EntityManagerImpl.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -338,6 +339,11 @@ public class EntityManagerImpl implements EntityManager {
     entityMap.put("entities", entities);
     entityIndex.values().forEach(entity->entities.add(entity.getState()));
     return entityMap;
+  }
+
+  @Override
+  public Set<EntityID> getExistingEntities() {
+    return Collections.unmodifiableSet(entities.keySet());
   }
 }
 


### PR DESCRIPTION
Looks like the server creates permanent entities only if its a fresh startup, if we add new permanent entities in the new version, they never get created unless we wipe the existing data