### PR TITLE
Fix #1092 - Server weights need adjustment

### DIFF
--- a/dso-l2/src/main/java/com/tc/l2/ha/RandomWeightGenerator.java
+++ b/dso-l2/src/main/java/com/tc/l2/ha/RandomWeightGenerator.java
@@ -24,17 +24,15 @@ import com.tc.l2.ha.WeightGeneratorFactory.WeightGenerator;
 
 
 public class RandomWeightGenerator implements WeightGenerator {
-  private final SecureRandom generator;
-  private final boolean isAvailable;
+  private final long randomNumber;
 
   public RandomWeightGenerator(SecureRandom generator, boolean isAvailable) {
-    this.generator = generator;
-    this.isAvailable = isAvailable;
+    this.randomNumber = generator.nextLong();
   }
 
   @Override
   public long getWeight() {
-    return this.generator.nextLong();
+    return this.randomNumber;
   }
   
   @Override

--- a/dso-l2/src/main/java/com/tc/l2/ha/ServerUptimeWeightGenerator.java
+++ b/dso-l2/src/main/java/com/tc/l2/ha/ServerUptimeWeightGenerator.java
@@ -19,6 +19,7 @@
 package com.tc.l2.ha;
 
 import com.tc.l2.ha.WeightGeneratorFactory.WeightGenerator;
+import java.util.concurrent.TimeUnit;
 
 
 public class ServerUptimeWeightGenerator implements WeightGenerator {
@@ -32,7 +33,9 @@ public class ServerUptimeWeightGenerator implements WeightGenerator {
 
   @Override
   public long getWeight() {
-    return System.currentTimeMillis() - this.startMillis;
+  //  calculate the seconds of uptime and convert back to millis for backwards 
+  // compatibility.  (i.e. 6055ms of uptime is converted to 6000ms of uptime)
+    return TimeUnit.SECONDS.toMillis(TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - this.startMillis));
   }
 
   @Override

--- a/dso-l2/src/test/java/com/tc/l2/ha/RandomWeightGeneratorTest.java
+++ b/dso-l2/src/test/java/com/tc/l2/ha/RandomWeightGeneratorTest.java
@@ -31,10 +31,9 @@ public class RandomWeightGeneratorTest extends TCTestCase {
     // overwhelming and there seems to be no way to force deterministic values from SecureRandom, even with a seed.
     
     SecureRandom random = new SecureRandom();
-    RandomWeightGenerator generator = new RandomWeightGenerator(random, true);
-    long weight1 = generator.getWeight();
-    long weight2 = generator.getWeight();
-    long weight3 = generator.getWeight();
+    long weight1 = new RandomWeightGenerator(random, true).getWeight();
+    long weight2 = new RandomWeightGenerator(random, true).getWeight();
+    long weight3 = new RandomWeightGenerator(random, true).getWeight();
     Assert.assertTrue(weight1 != weight2);
     Assert.assertTrue(weight1 != weight3);
     Assert.assertTrue(weight2 != weight3);

--- a/dso-l2/src/test/java/com/tc/l2/ha/ServerUptimeWeightGeneratorTest.java
+++ b/dso-l2/src/test/java/com/tc/l2/ha/ServerUptimeWeightGeneratorTest.java
@@ -33,7 +33,7 @@ public class ServerUptimeWeightGeneratorTest extends TCTestCase {
       // The sleep is added to spread the numbers a little but it will also slow the test to take at least 2 seconds.
       Thread.sleep(2);
       long next = generator.getWeight();
-      Assert.assertTrue(next >= previous);
+      Assert.assertTrue(next == previous || next > previous);
       previous = next;
     }
   }


### PR DESCRIPTION
Split-brain resolution through zap of peer actives needs adjustment as both actives can believe they are the winner due to non-deterministic weights.