### PR TITLE
Added console logging for server restart event

### DIFF
--- a/dso-l2/src/main/java/com/tc/server/TCServerImpl.java
+++ b/dso-l2/src/main/java/com/tc/server/TCServerImpl.java
@@ -144,6 +144,7 @@ public class TCServerImpl extends SEDA implements TCServer {
 
   @Override
   public void stop(RestartMode restartMode) {
+    TCLogging.getConsoleLogger().info("Stopping server with restartMode: {}", restartMode);
     dsoServer.getContext().getL2Coordinator().getStateManager().moveToStopState();
     if (restartMode == RestartMode.STOP_ONLY) {
       exitWithStatus(0);


### PR DESCRIPTION
When a server is shut down or restarted programmatically, all we log is `L2 Exiting...`, which doesn't make it clear if the shutdown was intentional or not. The logging statement added here helps the users, and test frameworks to ascertain that the server was shut down.