### PR TITLE
Correct intermittent failure of ClientLeakIT.testConnectionMakerDiesWithNoRef

### DIFF
--- a/galvan-support/pom.xml
+++ b/galvan-support/pom.xml
@@ -114,6 +114,7 @@ limitations under the License.
           </execution>
         </executions>
         <configuration>
+          <reuseForks>false</reuseForks>
           <systemPropertyVariables>
             <kitInstallationPath>${kitUnzipLocation}/terracotta-${project.version}</kitInstallationPath>
             <kitTestDirectory>${project.build.testOutputDirectory}/testing_directory</kitTestDirectory>


### PR DESCRIPTION
Fixes Issue #1100 by running preventing JVM reuse for integration tests in the galvan-support module.