### PR TITLE
Fix build on mac

### DIFF
--- a/default-configuration/pom.xml
+++ b/default-configuration/pom.xml
@@ -115,6 +115,7 @@
                     <goal>single</goal>
                   </goals>
                   <configuration>
+                    <tarLongFileMode>posix</tarLongFileMode>
                     <descriptorRefs>
                       <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>

--- a/terracotta-kit/pom.xml
+++ b/terracotta-kit/pom.xml
@@ -134,7 +134,7 @@
                     <finalName>terracotta-${project.version}</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                     <attach>true</attach>
-                    <tarLongFileMode>gnu</tarLongFileMode>
+                    <tarLongFileMode>posix</tarLongFileMode>
                     <descriptors>
                         <descriptor>${basedir}/src/assemble/distribution.xml</descriptor>
                     </descriptors>


### PR DESCRIPTION
Build is failing on my mac with below error 

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:3.2.0:single (create-distribution) on project default-configuration: Execution create-distribution of goal org.apache.maven.plugins:maven-assembly-plugin:3.2.0:single failed: group id '1978728554' is too big ( > 2097151 ). Use STAR or POSIX extensions to overcome this limit -> [Help 1]
[ERROR] 

Build is fine with the changes in this PR