### PR TITLE
Correct Galvan-based test failures on Windows

### DIFF
--- a/galvan-support/src/main/java/org/terracotta/testing/config/DefaultStartupCommandBuilder.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/config/DefaultStartupCommandBuilder.java
@@ -89,8 +89,8 @@ public class DefaultStartupCommandBuilder implements StartupCommandBuilder {
     if (builtCommand == null) {
       try {
         installServer();
-        Path basePath = kitDir.resolve("server").resolve("bin").resolve("start-tc-server");
-        String startScript = isWindows() ? basePath + ".bat" : basePath + ".sh";
+        Path basePath = serverWorkingDir.resolve(kitDir).resolve("server").resolve("bin").resolve("start-tc-server").toAbsolutePath().normalize();
+        String startScript = isWindows() ? "\"" + basePath + ".bat\"" : basePath + ".sh";
         if (consistentStartup) {
           builtCommand = new String[]{startScript, "-c", "-f", tcConfig.toString(), "-n", serverName};
         } else {


### PR DESCRIPTION
Galvan-based tests are failing on Windows -- unable to start the server because the start-tc-server.bat command cannot be found.  The cause is need in Windows for a normalized, absolute path to the script.  This update both resolves the script path against the server working directory and normalizes it, and then quotes the path to avoid issues with interesting path characters.