### PR TITLE
new parent, surefire/failsafe->forge

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -48,7 +48,6 @@
 
     <gmaven-plugin.version>1.4</gmaven-plugin.version>
     <copy-maven-plugin.version>0.2.3.8</copy-maven-plugin.version>
-    <surefire.version>2.15</surefire.version>
     <powermock.version>2.0.0</powermock.version>
     <hamcrest.version>1.3</hamcrest.version>
     <asm.version>7.2</asm.version>
@@ -260,11 +259,6 @@
               </configuration>
             </execution>
           </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>${surefire.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -101,9 +101,8 @@ Apache Ivy version: 2.2.0 20100923230623
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19</version>
+        <groupId>org.terracotta</groupId>
+        <artifactId>maven-forge-plugin</artifactId>
         <configuration>
             <forkCount>2C</forkCount>
             <reuseForks>false</reuseForks>

--- a/dso-l2/pom.xml
+++ b/dso-l2/pom.xml
@@ -131,9 +131,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
+        <groupId>org.terracotta</groupId>
+        <artifactId>maven-forge-plugin</artifactId>
         <configuration>
             <forkCount>1C</forkCount>
             <reuseForks>false</reuseForks>
@@ -153,9 +152,8 @@
       <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
+        <groupId>org.terracotta</groupId>
+        <artifactId>maven-forge-plugin</artifactId>
         <configuration>
             <debugForkedProcess>true</debugForkedProcess>
         </configuration>

--- a/galvan-support/pom.xml
+++ b/galvan-support/pom.xml
@@ -103,16 +103,8 @@ limitations under the License.
         </executions>
       </plugin>
       <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.19.1</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
+        <groupId>org.terracotta</groupId>
+        <artifactId>maven-forge-plugin</artifactId>
         <configuration>
           <reuseForks>false</reuseForks>
           <systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>terracotta-parent</artifactId>
-    <version>5.5.0</version>
+    <version>5.10</version>
     <relativePath/>
   </parent>
 
@@ -37,7 +37,6 @@
 
   <properties>
     <build.edition>opensource</build.edition>
-    <maven-forge-plugin.version>1.2.22</maven-forge-plugin.version>
     <tc-shader.version>1.2</tc-shader.version>
     <skip.deploy>false</skip.deploy>
 

--- a/terracotta-kit/pom.xml
+++ b/terracotta-kit/pom.xml
@@ -107,9 +107,8 @@
             </plugin>
 
             <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <version>${surefire.version}</version>
+              <groupId>org.terracotta</groupId>
+              <artifactId>maven-forge-plugin</artifactId>
               <executions>
                 <execution>
                   <id>test-scripts</id>

--- a/terracotta/pom.xml
+++ b/terracotta/pom.xml
@@ -31,7 +31,6 @@
             <plugin>
                 <groupId>org.terracotta</groupId>
                 <artifactId>maven-forge-plugin</artifactId>
-                <version>${maven-forge-plugin.version}</version>
                 <configuration>
                     <rootPath>${basedir}/..</rootPath>
                     <addClasspath>true</addClasspath>


### PR DESCRIPTION
latest terracotta-parent, using maven-forge-plugin for full test jvm from toolchains support.  All references for surefire and failsafe are removed (forge plugin is a superset of both).