### PR TITLE
Handle UnsupportedOperationException from Files.setPosixFilePermissions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 
 # Batch scripts should have Windows endings
 *.bat eol=crlf
+*.cmd eol=crlf

--- a/test-common/src/main/java/com/tc/test/BaseScriptTest.java
+++ b/test-common/src/main/java/com/tc/test/BaseScriptTest.java
@@ -382,7 +382,10 @@ public abstract class BaseScriptTest {
             PosixFilePermission.OWNER_WRITE
             );
     Path f = Files.copy(scriptPath, binPath.resolve(scriptPath.getFileName()), StandardCopyOption.COPY_ATTRIBUTES);
-    Files.setPosixFilePermissions(f, perms);
+    try {
+      Files.setPosixFilePermissions(f, perms);
+    } catch (UnsupportedOperationException ignored) {
+    }
     return f;
   }
 


### PR DESCRIPTION
Restores successful Windows builds