### PR TITLE
small stability items

### DIFF
--- a/dso-l1/src/main/java/com/tc/object/StandardClientBuilderFactory.java
+++ b/dso-l1/src/main/java/com/tc/object/StandardClientBuilderFactory.java
@@ -18,6 +18,7 @@
  */
 package com.tc.object;
 
+import com.tc.net.core.BufferManagerFactory;
 import com.tc.net.core.BufferManagerFactorySupplier;
 import com.tc.net.core.ClearTextBufferManagerFactory;
 import com.terracotta.diagnostic.DiagnosticClientBuilder;
@@ -30,11 +31,18 @@ public class StandardClientBuilderFactory implements ClientBuilderFactory {
   private final BufferManagerFactorySupplier supplier;
 
   public StandardClientBuilderFactory() {
-    BufferManagerFactorySupplier s = ClientBuilderFactory.get(BufferManagerFactorySupplier.class);
-    if (s == null) {
-      s = (p)->new ClearTextBufferManagerFactory();
+    BufferManagerFactorySupplier base = ClientBuilderFactory.get(BufferManagerFactorySupplier.class);
+    if (base == null) {
+      supplier = (p)->new ClearTextBufferManagerFactory();
+    } else {
+       supplier = p -> {
+        BufferManagerFactory factory = base.createBufferManagerFactory(p);
+        if (factory == null) {
+          return new ClearTextBufferManagerFactory();
+        }
+        return factory;
+      };
     }
-    supplier = s;
   }
   
   @Override

--- a/voter/src/main/java/org/terracotta/voter/ActiveVoter.java
+++ b/voter/src/main/java/org/terracotta/voter/ActiveVoter.java
@@ -290,7 +290,8 @@ public class ActiveVoter implements AutoCloseable {
             voterManager.close();            
           } catch (RuntimeException run) {
             LOGGER.warn("Heart-beating with {} not connected", voterManager.getTargetHostPort());
-            voterManager.close(); 
+            voterManager.close();
+            sleepFor10();  // sleep for 10 here because the cause of the error is unknown
           }
           owner = voteOwner.get();
           LOGGER.info("owner is " + owner);

--- a/voter/src/main/java/org/terracotta/voter/ClientVoterManagerImpl.java
+++ b/voter/src/main/java/org/terracotta/voter/ClientVoterManagerImpl.java
@@ -78,8 +78,12 @@ public class ClientVoterManagerImpl implements ClientVoterManager {
   @Override
   public long registerVoter(String id) throws TimeoutException {
     String result = processInvocation(diagnostics.invokeWithArg(MBEAN_NAME, "registerVoter", id));
-    long nr = Long.parseLong(result);
-    return nr;
+    try {
+      return Long.parseLong(result);
+    } catch (NumberFormatException ne) {
+      LOGGER.info("unexpected value returned for register voter", result);
+      throw new RuntimeException("register voter error");
+    }
   }
 
   @Override

--- a/voter/src/test/java/org/terracotta/voter/ActiveVoterTest.java
+++ b/voter/src/test/java/org/terracotta/voter/ActiveVoterTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import org.mockito.Mockito;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
@@ -278,7 +279,7 @@ public class ActiveVoterTest {
         Thread.sleep(500);
         return false;
       });
-      when(manager.registerVoter(VOTER_ID)).thenReturn(-1L);
+      Mockito.doReturn(-1L).when(manager).registerVoter(VOTER_ID);
     }
   }
 


### PR DESCRIPTION
Voter need to be tolerant of errors in registration 
BufferManagerFactorySupplier should always supply at least a ClearTextBufferManager