### PR TITLE
simplify pom via parent, correct licenses, back to surefire

### DIFF
--- a/checkstyle-toolkit/suppressions.xml
+++ b/checkstyle-toolkit/suppressions.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
-  ~
-  ~  The contents of this file are subject to the Terracotta Public License Version
-  ~  2.0 (the "License"); You may not use this file except in compliance with the
-  ~  License. You may obtain a copy of the License at
-  ~
-  ~  http://terracotta.org/legal/terracotta-public-license.
-  ~
-  ~  Software distributed under the License is distributed on an "AS IS" basis,
-  ~  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~  the specific language governing rights and limitations under the License.
-  ~
-  ~  The Covered Software is Terracotta Core.
-  ~
-  ~  The Initial Developer of the Covered Software is
-  ~  Terracotta, Inc., a Software AG company
-  ~
-  -->
 
+
+     The contents of this file are subject to the Terracotta Public License Version
+     2.0 (the "License"); You may not use this file except in compliance with the
+     License. You may obtain a copy of the License at
+
+     http://terracotta.org/legal/terracotta-public-license.
+
+     Software distributed under the License is distributed on an "AS IS" basis,
+     WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+     the specific language governing rights and limitations under the License.
+
+     The Covered Software is Terracotta Core.
+
+     The Initial Developer of the Covered Software is
+     Terracotta, Inc., a Software AG company
+
+
+-->
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
     "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
-  ~
-  ~  The contents of this file are subject to the Terracotta Public License Version
-  ~  2.0 (the "License"); You may not use this file except in compliance with the
-  ~  License. You may obtain a copy of the License at
-  ~
-  ~  http://terracotta.org/legal/terracotta-public-license.
-  ~
-  ~  Software distributed under the License is distributed on an "AS IS" basis,
-  ~  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~  the specific language governing rights and limitations under the License.
-  ~
-  ~  The Covered Software is Terracotta Core.
-  ~
-  ~  The Initial Developer of the Covered Software is
-  ~  Terracotta, Inc., a Software AG company
-  ~
-  -->
 
+
+     The contents of this file are subject to the Terracotta Public License Version
+     2.0 (the "License"); You may not use this file except in compliance with the
+     License. You may obtain a copy of the License at
+
+     http://terracotta.org/legal/terracotta-public-license.
+
+     Software distributed under the License is distributed on an "AS IS" basis,
+     WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+     the specific language governing rights and limitations under the License.
+
+     The Covered Software is Terracotta Core.
+
+     The Initial Developer of the Covered Software is
+     Terracotta, Inc., a Software AG company
+
+
+-->
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
     "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">

--- a/common-spi/src/main/java/com/tc/net/core/AbstractBufferManager.java
+++ b/common-spi/src/main/java/com/tc/net/core/AbstractBufferManager.java
@@ -10,7 +10,7 @@
  *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
  *  the specific language governing rights and limitations under the License.
  *
- *  The Covered Software is common SPI.
+ *  The Covered Software is Terracotta Core.
  *
  *  The Initial Developer of the Covered Software is
  *  Terracotta, Inc., a Software AG company

--- a/common-spi/src/main/java/com/tc/net/core/BufferManager.java
+++ b/common-spi/src/main/java/com/tc/net/core/BufferManager.java
@@ -10,7 +10,7 @@
  *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
  *  the specific language governing rights and limitations under the License.
  *
- *  The Covered Software is common SPI.
+ *  The Covered Software is Terracotta Core.
  *
  *  The Initial Developer of the Covered Software is
  *  Terracotta, Inc., a Software AG company

--- a/common-spi/src/main/java/com/tc/net/core/BufferManagerFactory.java
+++ b/common-spi/src/main/java/com/tc/net/core/BufferManagerFactory.java
@@ -10,7 +10,7 @@
  *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
  *  the specific language governing rights and limitations under the License.
  *
- *  The Covered Software is common SPI.
+ *  The Covered Software is Terracotta Core.
  *
  *  The Initial Developer of the Covered Software is
  *  Terracotta, Inc., a Software AG company

--- a/common-spi/src/main/java/com/tc/net/core/BufferManagerFactorySupplier.java
+++ b/common-spi/src/main/java/com/tc/net/core/BufferManagerFactorySupplier.java
@@ -10,7 +10,7 @@
  *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
  *  the specific language governing rights and limitations under the License.
  *
- *  The Covered Software is common SPI.
+ *  The Covered Software is Terracotta Core.
  *
  *  The Initial Developer of the Covered Software is
  *  Terracotta, Inc., a Software AG company

--- a/common-spi/src/main/java/com/tc/text/PrettyPrintable.java
+++ b/common-spi/src/main/java/com/tc/text/PrettyPrintable.java
@@ -10,7 +10,7 @@
  *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
  *  the specific language governing rights and limitations under the License.
  *
- *  The Covered Software is common SPI.
+ *  The Covered Software is Terracotta Core.
  *
  *  The Initial Developer of the Covered Software is
  *  Terracotta, Inc., a Software AG company

--- a/common-spi/src/main/java/com/tc/text/PrettyPrinter.java
+++ b/common-spi/src/main/java/com/tc/text/PrettyPrinter.java
@@ -10,7 +10,7 @@
  *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
  *  the specific language governing rights and limitations under the License.
  *
- *  The Covered Software is common SPI.
+ *  The Covered Software is Terracotta Core.
  *
  *  The Initial Developer of the Covered Software is
  *  Terracotta, Inc., a Software AG company

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -106,8 +106,7 @@ Apache Ivy version: 2.2.0 20100923230623
   <build>
     <plugins>
       <plugin>
-        <groupId>org.terracotta</groupId>
-        <artifactId>maven-forge-plugin</artifactId>
+        <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
             <forkCount>0.5C</forkCount>
             <reuseForks>false</reuseForks>

--- a/default-configuration/src/assemble/distribution.xml
+++ b/default-configuration/src/assemble/distribution.xml
@@ -1,21 +1,23 @@
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
-  ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
-  ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
-  ~
-  ~ The Covered Software is Terracotta Configuration.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
-  ~
-  -->
 
+
+     The contents of this file are subject to the Terracotta Public License Version
+     2.0 (the "License"); You may not use this file except in compliance with the
+     License. You may obtain a copy of the License at
+
+     http://terracotta.org/legal/terracotta-public-license.
+
+     Software distributed under the License is distributed on an "AS IS" basis,
+     WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+     the specific language governing rights and limitations under the License.
+
+     The Covered Software is Terracotta Core.
+
+     The Initial Developer of the Covered Software is
+     Terracotta, Inc., a Software AG company
+
+
+-->
 <assembly>
   <id>distribution</id>
   <formats>

--- a/dso-l2/pom.xml
+++ b/dso-l2/pom.xml
@@ -136,8 +136,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.terracotta</groupId>
-        <artifactId>maven-forge-plugin</artifactId>
+        <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
             <forkCount>0.5C</forkCount>
             <reuseForks>false</reuseForks>
@@ -157,8 +156,7 @@
       <build>
     <plugins>
       <plugin>
-        <groupId>org.terracotta</groupId>
-        <artifactId>maven-forge-plugin</artifactId>
+        <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
             <debugForkedProcess>true</debugForkedProcess>
         </configuration>

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/Topology.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/Topology.java
@@ -1,3 +1,21 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
 package com.tc.objectserver.impl;
 
 import java.util.Collections;

--- a/dso-l2/src/main/java/com/tc/objectserver/impl/TopologyListener.java
+++ b/dso-l2/src/main/java/com/tc/objectserver/impl/TopologyListener.java
@@ -1,3 +1,21 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
 package com.tc.objectserver.impl;
 
 public interface TopologyListener {

--- a/galvan-support/pom.xml
+++ b/galvan-support/pom.xml
@@ -103,10 +103,8 @@ limitations under the License.
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.terracotta</groupId>
-        <artifactId>maven-forge-plugin</artifactId>
+        <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <reuseForks>false</reuseForks>
           <systemPropertyVariables>
             <kitInstallationPath>${kitUnzipLocation}/terracotta-${project.version}</kitInstallationPath>
             <kitTestDirectory>${project.build.testOutputDirectory}/testing_directory</kitTestDirectory>

--- a/galvan-support/src/main/java/org/terracotta/testing/config/TcConfigBuilder.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/config/TcConfigBuilder.java
@@ -1,17 +1,20 @@
 /*
- * Copyright Terracotta, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *  http://terracotta.org/legal/terracotta-public-license.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
  */
 package org.terracotta.testing.config;
 

--- a/galvan-support/src/test/java/org/terracotta/testing/rules/CorruptConfigWithClassRuleIT.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/rules/CorruptConfigWithClassRuleIT.java
@@ -57,7 +57,9 @@ public class CorruptConfigWithClassRuleIT {
 
   @Test(expected=ConnectionException.class)
   public void testConnectionViaURI() throws Exception {
-    Connection connection = ConnectionFactory.connect(CLUSTER.getConnectionURI(), new Properties());
+    Properties connectionProps = new Properties();
+    connectionProps.put("connection.timeout", "10000");
+    Connection connection = ConnectionFactory.connect(CLUSTER.getConnectionURI(), new Properties(connectionProps));
     try {
       //do nothing
     } finally {

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>terracotta-parent</artifactId>
-    <version>5.17</version>
+    <version>5.18</version>
     <relativePath/>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>terracotta-parent</artifactId>
-    <version>5.10</version>
+    <version>5.17</version>
     <relativePath/>
   </parent>
 
@@ -38,7 +38,7 @@
   <properties>
     <build.edition>opensource</build.edition>
     <tc-shader.version>1.2</tc-shader.version>
-    <skip.deploy>false</skip.deploy>
+    <spotbugs.skip>true</spotbugs.skip>
 
     <terracotta-apis.version>1.7.0-pre3</terracotta-apis.version>
     <terracotta-configuration.version>10.7.0-pre2</terracotta-configuration.version>
@@ -68,56 +68,23 @@
     <module>default-configuration</module>
   </modules>
 
+  <repositories>
+    <repository>
+      <id>terracotta-releases</id>
+      <url>http://www.terracotta.org/download/reflector/releases</url>
+    </repository>
+  </repositories>
+
   <build>
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.6.1</version>
-          <extensions>true</extensions>
-          <configuration>
-            <!-- The Base URL of Nexus instance where we want to stage -->
-            <nexusUrl>http://nexus.terracotta.eur.ad.sag</nexusUrl>
-            <!-- The server "id" element from settings to use authentication from -->
-            <serverId>terracotta-nexus-staging</serverId>
-            <skipNexusStagingDeployMojo>${skip.deploy}</skipNexusStagingDeployMojo>
-          </configuration>
-        </plugin>
-        <plugin>
-          <inherited>false</inherited>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>3.0.rc1</version>
           <configuration>
-            <keywords>
-              <keyword>License</keyword>
-            </keywords>
             <aggregate>true</aggregate>
             <header>header.txt</header>
-            <mapping>
-              <java>SLASHSTAR_STYLE</java>
-            </mapping>
-            <excludes>
-              <exclude>**/README</exclude>
-              <exclude>**/LICENSE</exclude>
-              <exclude>src/test/resources/**</exclude>
-              <exclude>src/main/resources/**</exclude>
-              <!-- if you only import management in your ide, it will generate its metadata under management/ -->
-              <exclude>**/.idea/**</exclude>
-              <exclude>**/*.html</exclude>
-              <exclude>**/*.txt</exclude>
-              <exclude>**/*.yml</exclude>
-              <exclude>**/*.properties</exclude>
-              <exclude>**/*.xsd</exclude>
-              <exclude>**/*.sh</exclude>
-              <exclude>**/*.bat</exclude>
-              <exclude>**/nbproject/**</exclude>
-              <exclude>**/*.adoc</exclude>
-              <exclude>**/*.xml</exclude>
-              <exclude>mvnw</exclude>
-              <exclude>mvnw.cmd</exclude>
-            </excludes>
+            <inlineHeader combine.self="override"></inlineHeader>
           </configuration>
         </plugin>
       </plugins>
@@ -142,42 +109,6 @@
       </plugin>
     </plugins>
   </build>
-
-  <distributionManagement>
-    <repository>
-      <id>terracotta-os-releases</id>
-      <name>Terracotta OS Releases Repository</name>
-      <url>https://nexus.terracotta.eur.ad.sag/content/repositories/terracotta-os-releases</url>
-    </repository>
-    <snapshotRepository>
-      <id>terracotta-os-snapshots</id>
-      <uniqueVersion>false</uniqueVersion>
-      <name>Terracotta OS Snapshots Repository</name>
-      <url>https://nexus.terracotta.eur.ad.sag/content/repositories/terracotta-os-snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
-
-  <repositories>
-    <repository>
-      <id>terracotta-snapshots</id>
-      <url>https://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>
-    <repository>
-      <id>terracotta-releases</id>
-      <url>https://www.terracotta.org/download/reflector/releases</url>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>https://www.terracotta.org/download/reflector/snapshots</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>https://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <scm>
     <connection>scm:git:https://github.com/Terracotta-OSS/terracotta-core.git</connection>

--- a/server-spi/src/main/java/com/tc/spi/Guardian.java
+++ b/server-spi/src/main/java/com/tc/spi/Guardian.java
@@ -10,7 +10,7 @@
  *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
  *  the specific language governing rights and limitations under the License.
  *
- *  The Covered Software is Terracotta API.
+ *  The Covered Software is Terracotta Core.
  *
  *  The Initial Developer of the Covered Software is
  *  Terracotta, Inc., a Software AG company

--- a/terracotta-kit/pom.xml
+++ b/terracotta-kit/pom.xml
@@ -107,8 +107,7 @@
             </plugin>
 
             <plugin>
-              <groupId>org.terracotta</groupId>
-              <artifactId>maven-forge-plugin</artifactId>
+              <artifactId>maven-surefire-plugin</artifactId>
               <executions>
                 <execution>
                   <id>test-scripts</id>

--- a/terracotta-kit/src/assemble/client/logging/impl/logback.xml
+++ b/terracotta-kit/src/assemble/client/logging/impl/logback.xml
@@ -1,5 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
 
+
+     The contents of this file are subject to the Terracotta Public License Version
+     2.0 (the "License"); You may not use this file except in compliance with the
+     License. You may obtain a copy of the License at
+
+     http://terracotta.org/legal/terracotta-public-license.
+
+     Software distributed under the License is distributed on an "AS IS" basis,
+     WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+     the specific language governing rights and limitations under the License.
+
+     The Covered Software is Terracotta Core.
+
+     The Initial Developer of the Covered Software is
+     Terracotta, Inc., a Software AG company
+
+
+-->
 <configuration>
 
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">

--- a/terracotta-kit/src/assemble/distribution.xml
+++ b/terracotta-kit/src/assemble/distribution.xml
@@ -1,4 +1,23 @@
+<!--
 
+
+     The contents of this file are subject to the Terracotta Public License Version
+     2.0 (the "License"); You may not use this file except in compliance with the
+     License. You may obtain a copy of the License at
+
+     http://terracotta.org/legal/terracotta-public-license.
+
+     Software distributed under the License is distributed on an "AS IS" basis,
+     WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+     the specific language governing rights and limitations under the License.
+
+     The Covered Software is Terracotta Core.
+
+     The Initial Developer of the Covered Software is
+     Terracotta, Inc., a Software AG company
+
+
+-->
 <!--
 The contents of this file are subject to the Terracotta Public License Version
 2.0 (the "License"); You may not use this file except in compliance with the

--- a/terracotta-kit/src/assemble/init/sysv/terracotta.properties
+++ b/terracotta-kit/src/assemble/init/sysv/terracotta.properties
@@ -1,3 +1,22 @@
+#
+#
+#  The contents of this file are subject to the Terracotta Public License Version
+#  2.0 (the "License"); You may not use this file except in compliance with the
+#  License. You may obtain a copy of the License at
+#
+#  http://terracotta.org/legal/terracotta-public-license.
+#
+#  Software distributed under the License is distributed on an "AS IS" basis,
+#  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+#  the specific language governing rights and limitations under the License.
+#
+#  The Covered Software is Terracotta Core.
+#
+#  The Initial Developer of the Covered Software is
+#  Terracotta, Inc., a Software AG company
+#
+#
+
 # Configuration file for the Terracotta SysV init script
 # Intended to be placed into /etc/default/terracotta
 # or /etc/default/X if using multiple copies (name should match the name of the init script)

--- a/terracotta-kit/src/assemble/init/sysv/terracotta.sh
+++ b/terracotta-kit/src/assemble/init/sysv/terracotta.sh
@@ -1,4 +1,23 @@
 #!/bin/sh -e
+#
+#
+#  The contents of this file are subject to the Terracotta Public License Version
+#  2.0 (the "License"); You may not use this file except in compliance with the
+#  License. You may obtain a copy of the License at
+#
+#  http://terracotta.org/legal/terracotta-public-license.
+#
+#  Software distributed under the License is distributed on an "AS IS" basis,
+#  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+#  the specific language governing rights and limitations under the License.
+#
+#  The Covered Software is Terracotta Core.
+#
+#  The Initial Developer of the Covered Software is
+#  Terracotta, Inc., a Software AG company
+#
+#
+
 # Terracotta Server startup script
 #chkconfig: 2345 80 05
 #description: Terracotta Server

--- a/terracotta-kit/src/assemble/server/bin/start-tc-server.bat
+++ b/terracotta-kit/src/assemble/server/bin/start-tc-server.bat
@@ -1,3 +1,22 @@
+@REM
+@REM
+@REM  The contents of this file are subject to the Terracotta Public License Version
+@REM  2.0 (the "License"); You may not use this file except in compliance with the
+@REM  License. You may obtain a copy of the License at
+@REM
+@REM  http://terracotta.org/legal/terracotta-public-license.
+@REM
+@REM  Software distributed under the License is distributed on an "AS IS" basis,
+@REM  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+@REM  the specific language governing rights and limitations under the License.
+@REM
+@REM  The Covered Software is Terracotta Core.
+@REM
+@REM  The Initial Developer of the Covered Software is
+@REM  Terracotta, Inc., a Software AG company
+@REM
+@REM
+
 @echo off
 
 REM

--- a/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
+++ b/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
@@ -1,20 +1,21 @@
 #!/bin/sh
-
-# 
-# The contents of this file are subject to the Terracotta Public License Version
-# 2.0 (the "License"); You may not use this file except in compliance with the
-# License. You may obtain a copy of the License at 
-# 
-#      http://terracotta.org/legal/terracotta-public-license.
-# 
-# Software distributed under the License is distributed on an "AS IS" basis,
-# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-# the specific language governing rights and limitations under the License.
-# 
-# The Covered Software is Terracotta Platform.
-# 
-# The Initial Developer of the Covered Software is 
-#     Terracotta, Inc., a Software AG company
+#
+#
+#  The contents of this file are subject to the Terracotta Public License Version
+#  2.0 (the "License"); You may not use this file except in compliance with the
+#  License. You may obtain a copy of the License at
+#
+#  http://terracotta.org/legal/terracotta-public-license.
+#
+#  Software distributed under the License is distributed on an "AS IS" basis,
+#  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+#  the specific language governing rights and limitations under the License.
+#
+#  The Covered Software is Terracotta Core.
+#
+#  The Initial Developer of the Covered Software is
+#  Terracotta, Inc., a Software AG company
+#
 #
 
 TC_SERVER_DIR=$(dirname "$(cd "$(dirname "$0")";pwd)")

--- a/terracotta-kit/src/assemble/server/conf/tc-config.xml
+++ b/terracotta-kit/src/assemble/server/conf/tc-config.xml
@@ -1,23 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-  ~
-  ~  The contents of this file are subject to the Terracotta Public License Version
-  ~  2.0 (the "License"); You may not use this file except in compliance with the
-  ~  License. You may obtain a copy of the License at
-  ~
-  ~  http://terracotta.org/legal/terracotta-public-license.
-  ~
-  ~  Software distributed under the License is distributed on an "AS IS" basis,
-  ~  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~  the specific language governing rights and limitations under the License.
-  ~
-  ~  The Covered Software is Terracotta Core.
-  ~
-  ~  The Initial Developer of the Covered Software is
-  ~  Terracotta, Inc., a Software AG company
-  ~
-  -->
 
+
+     The contents of this file are subject to the Terracotta Public License Version
+     2.0 (the "License"); You may not use this file except in compliance with the
+     License. You may obtain a copy of the License at
+
+     http://terracotta.org/legal/terracotta-public-license.
+
+     Software distributed under the License is distributed on an "AS IS" basis,
+     WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+     the specific language governing rights and limitations under the License.
+
+     The Covered Software is Terracotta Core.
+
+     The Initial Developer of the Covered Software is
+     Terracotta, Inc., a Software AG company
+
+
+-->
 <!-- This config file is used by the server and bootjar tool when none is specified. -->
 
 <tc-config xmlns="http://www.terracotta.org/config">

--- a/terracotta-kit/src/assemble/server/lib/logback-ext.xml
+++ b/terracotta-kit/src/assemble/server/lib/logback-ext.xml
@@ -1,3 +1,23 @@
+<!--
+
+
+     The contents of this file are subject to the Terracotta Public License Version
+     2.0 (the "License"); You may not use this file except in compliance with the
+     License. You may obtain a copy of the License at
+
+     http://terracotta.org/legal/terracotta-public-license.
+
+     Software distributed under the License is distributed on an "AS IS" basis,
+     WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+     the specific language governing rights and limitations under the License.
+
+     The Covered Software is Terracotta Core.
+
+     The Initial Developer of the Covered Software is
+     Terracotta, Inc., a Software AG company
+
+
+-->
 <included>
   <!--
   This is an extension point for TC server logging configuration.

--- a/terracotta-kit/src/assemble/voter/bin/start-tc-voter.bat
+++ b/terracotta-kit/src/assemble/voter/bin/start-tc-voter.bat
@@ -1,3 +1,22 @@
+@REM
+@REM
+@REM  The contents of this file are subject to the Terracotta Public License Version
+@REM  2.0 (the "License"); You may not use this file except in compliance with the
+@REM  License. You may obtain a copy of the License at
+@REM
+@REM  http://terracotta.org/legal/terracotta-public-license.
+@REM
+@REM  Software distributed under the License is distributed on an "AS IS" basis,
+@REM  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+@REM  the specific language governing rights and limitations under the License.
+@REM
+@REM  The Covered Software is Terracotta Core.
+@REM
+@REM  The Initial Developer of the Covered Software is
+@REM  Terracotta, Inc., a Software AG company
+@REM
+@REM
+
 @echo off
 
 REM

--- a/terracotta-kit/src/assemble/voter/bin/start-tc-voter.sh
+++ b/terracotta-kit/src/assemble/voter/bin/start-tc-voter.sh
@@ -1,19 +1,21 @@
 #!/bin/sh
 #
-# The contents of this file are subject to the Terracotta Public License Version
-# 2.0 (the "License"); You may not use this file except in compliance with the
-# License. You may obtain a copy of the License at
 #
-#      http://terracotta.org/legal/terracotta-public-license.
+#  The contents of this file are subject to the Terracotta Public License Version
+#  2.0 (the "License"); You may not use this file except in compliance with the
+#  License. You may obtain a copy of the License at
 #
-# Software distributed under the License is distributed on an "AS IS" basis,
-# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-# the specific language governing rights and limitations under the License.
+#  http://terracotta.org/legal/terracotta-public-license.
 #
-# The Covered Software is Terracotta Platform.
+#  Software distributed under the License is distributed on an "AS IS" basis,
+#  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+#  the specific language governing rights and limitations under the License.
 #
-# The Initial Developer of the Covered Software is
-#     Terracotta, Inc., a Software AG company
+#  The Covered Software is Terracotta Core.
+#
+#  The Initial Developer of the Covered Software is
+#  Terracotta, Inc., a Software AG company
+#
 #
 
 

--- a/terracotta-kit/src/test/java/com/tc/server/bin/StartTcServerScriptTest.java
+++ b/terracotta-kit/src/test/java/com/tc/server/bin/StartTcServerScriptTest.java
@@ -1,18 +1,20 @@
 /*
- * The contents of this file are subject to the Terracotta Public License Version
- * 2.0 (the "License"); You may not use this file except in compliance with the
- * License. You may obtain a copy of the License at
  *
- * http://terracotta.org/legal/terracotta-public-license.
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
  *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- * the specific language governing rights and limitations under the License.
+ *  http://terracotta.org/legal/terracotta-public-license.
  *
- * The Covered Software is Terracotta Core.
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
  *
- * The Initial Developer of the Covered Software is
- * Terracotta, Inc., a Software AG company
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
  */
 package com.tc.server.bin;
 

--- a/terracotta-kit/src/test/java/org/terracotta/voter/bin/StartTcVoterScriptTest.java
+++ b/terracotta-kit/src/test/java/org/terracotta/voter/bin/StartTcVoterScriptTest.java
@@ -1,18 +1,20 @@
 /*
- * The contents of this file are subject to the Terracotta Public License Version
- * 2.0 (the "License"); You may not use this file except in compliance with the
- * License. You may obtain a copy of the License at
  *
- * http://terracotta.org/legal/terracotta-public-license.
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
  *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- * the specific language governing rights and limitations under the License.
+ *  http://terracotta.org/legal/terracotta-public-license.
  *
- * The Covered Software is Terracotta Core.
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
  *
- * The Initial Developer of the Covered Software is
- * Terracotta, Inc., a Software AG company
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
  */
 package org.terracotta.voter.bin;
 

--- a/terracotta/pom.xml
+++ b/terracotta/pom.xml
@@ -31,21 +31,21 @@
             <plugin>
                 <groupId>org.terracotta</groupId>
                 <artifactId>maven-forge-plugin</artifactId>
-                <configuration>
-                    <rootPath>${basedir}/..</rootPath>
-                    <addClasspath>true</addClasspath>
-                    <excludeGroupIds>${excludeGroupIdsForClasspath}</excludeGroupIds>
-                    <manifestEntries>
-                        <Main-Class>com.tc.cli.CommandLineMain</Main-Class>
-                        <Class-Path>resources/</Class-Path>
-                    </manifestEntries>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>manifest</goal>
                         </goals>
                         <phase>compile</phase>
+                        <configuration>
+                            <rootPath>${basedir}/..</rootPath>
+                            <addClasspath>true</addClasspath>
+                            <excludeGroupIds>${excludeGroupIdsForClasspath}</excludeGroupIds>
+                            <manifestEntries>
+                                <Main-Class>com.tc.cli.CommandLineMain</Main-Class>
+                                <Class-Path>resources/</Class-Path>
+                            </manifestEntries>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/test-common/src/main/java/com/tc/test/BaseScriptTest.java
+++ b/test-common/src/main/java/com/tc/test/BaseScriptTest.java
@@ -1,18 +1,20 @@
 /*
- * The contents of this file are subject to the Terracotta Public License Version
- * 2.0 (the "License"); You may not use this file except in compliance with the
- * License. You may obtain a copy of the License at
  *
- * http://terracotta.org/legal/terracotta-public-license.
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
  *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- * the specific language governing rights and limitations under the License.
+ *  http://terracotta.org/legal/terracotta-public-license.
  *
- * The Covered Software is Terracotta Core.
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
  *
- * The Initial Developer of the Covered Software is
- * Terracotta, Inc., a Software AG company
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
  */
 package com.tc.test;
 

--- a/test-common/src/main/java/com/tc/test/ScriptTestUtil.java
+++ b/test-common/src/main/java/com/tc/test/ScriptTestUtil.java
@@ -1,18 +1,20 @@
 /*
- * The contents of this file are subject to the Terracotta Public License Version
- * 2.0 (the "License"); You may not use this file except in compliance with the
- * License. You may obtain a copy of the License at
  *
- * http://terracotta.org/legal/terracotta-public-license.
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
  *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- * the specific language governing rights and limitations under the License.
+ *  http://terracotta.org/legal/terracotta-public-license.
  *
- * The Covered Software is Terracotta Core.
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
  *
- * The Initial Developer of the Covered Software is
- * Terracotta, Inc., a Software AG company
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
  */
 package com.tc.test;
 

--- a/test-common/src/main/java/com/tc/test/SurrogateMain.java
+++ b/test-common/src/main/java/com/tc/test/SurrogateMain.java
@@ -1,18 +1,20 @@
 /*
- * The contents of this file are subject to the Terracotta Public License Version
- * 2.0 (the "License"); You may not use this file except in compliance with the
- * License. You may obtain a copy of the License at
  *
- * http://terracotta.org/legal/terracotta-public-license.
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
  *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- * the specific language governing rights and limitations under the License.
+ *  http://terracotta.org/legal/terracotta-public-license.
  *
- * The Covered Software is Terracotta Core.
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
  *
- * The Initial Developer of the Covered Software is
- * Terracotta, Inc., a Software AG company
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
  */
 package com.tc.test;
 

--- a/voter/src/test/java/org/terracotta/voter/ActiveVoterTest.java
+++ b/voter/src/test/java/org/terracotta/voter/ActiveVoterTest.java
@@ -1,3 +1,21 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
 package org.terracotta.voter;
 
 import org.junit.Rule;


### PR DESCRIPTION
* Removes redundant stuff from pom (everything that is already in parent)
* Corrects all licenses via license plugin automation (Latest parent enables license check)
* Moving back to surefire/failsafe (forge-plugin is no longer needed in all but one submodule)
* Turns off **spotbugs** since it fails.  (On by default in parent)
* Fixes a timeout issue in a test which somehow didn't happen in old version of failsafe.