### PR TITLE
Add a kill switch 

### DIFF
--- a/connection-loader/src/main/java/com/terracotta/connection/TerracottaInternalClientImpl.java
+++ b/connection-loader/src/main/java/com/terracotta/connection/TerracottaInternalClientImpl.java
@@ -68,7 +68,7 @@ public class TerracottaInternalClientImpl implements TerracottaInternalClient {
     errorListener.attachCollector();
     try {
       try {
-        client = clientCreator.create();
+        client = clientCreator.create(this::shutdown);
       } catch (Exception e){
         throw new DetailedConnectionException(new Exception(DetailedConnectionException.getDetailedMessage(errorListener.getErrors()), e), errorListener.getErrors());
       }

--- a/dso-l1/src/main/java/com/tc/object/DistributedObjectClientFactory.java
+++ b/dso-l1/src/main/java/com/tc/object/DistributedObjectClientFactory.java
@@ -56,11 +56,12 @@ public class DistributedObjectClientFactory {
     TCPropertiesImpl.getProperties().overwriteTcPropertiesFromConfig(props);
   }
 
-  public DistributedObjectClient create() throws InterruptedException, ConfigurationSetupException {
+  public DistributedObjectClient create(Runnable killSwitch) throws InterruptedException, ConfigurationSetupException {
     L1ThrowableHandler throwableHandler = new L1ThrowableHandler(LoggerFactory.getLogger(DistributedObjectClient.class),
                                                                  new Callable<Void>() {
                                                                    @Override
                                                                    public Void call() throws Exception {
+                                                                     killSwitch.run();
                                                                      return null;
                                                                    }
                                                                  });


### PR DESCRIPTION
An uncaught exception on a terracotta thread should result in connection closure.