### PR TITLE
Add client revision to handshake info and TCServerInfo mbean.

### DIFF
--- a/common/src/main/java/com/tc/object/msg/TestClientHandshakeMessage.java
+++ b/common/src/main/java/com/tc/object/msg/TestClientHandshakeMessage.java
@@ -52,6 +52,7 @@ public class TestClientHandshakeMessage extends TestTCMessage implements ClientH
   private String                uuid;
   private String                name;
   private String                clientVersion;
+  private String                clientRevision;
   private int                   pid;
   private final Set<ClientEntityReferenceContext> reconnectReferenceSet = new HashSet<ClientEntityReferenceContext>();
   private final Set<ResendVoltronEntityMessage> resendMessageSet = new HashSet<ResendVoltronEntityMessage>();
@@ -106,6 +107,11 @@ public class TestClientHandshakeMessage extends TestTCMessage implements ClientH
   }
 
   @Override
+  public String getClientRevision() {
+    return this.clientRevision;
+  }
+
+  @Override
   public void setClientPID(int pid) {
     this.pid = pid;
   }
@@ -118,6 +124,11 @@ public class TestClientHandshakeMessage extends TestTCMessage implements ClientH
   @Override
   public void setClientVersion(String v) {
     this.clientVersion = v;
+  }
+
+  @Override
+  public void setClientRevision(String v) {
+    this.clientRevision = v;
   }
 
   @Override

--- a/management/src/main/java/com/tc/management/beans/TCServerInfoMBean.java
+++ b/management/src/main/java/com/tc/management/beans/TCServerInfoMBean.java
@@ -21,6 +21,7 @@ package com.tc.management.beans;
 import com.tc.management.RuntimeStatisticConstants;
 import com.tc.management.TerracottaMBean;
 
+import java.io.IOException;
 import java.util.Map;
 
 public interface TCServerInfoMBean extends TerracottaMBean, RuntimeStatisticConstants {
@@ -102,4 +103,6 @@ public interface TCServerInfoMBean extends TerracottaMBean, RuntimeStatisticCons
   void setPipelineMonitoring(boolean monitor);
   
   String getClusterState(boolean shortForm);
+
+  String getConnectedClients() throws IOException;
 }

--- a/tc-client/src/main/java/com/tc/object/ClientBuilder.java
+++ b/tc-client/src/main/java/com/tc/object/ClientBuilder.java
@@ -63,6 +63,7 @@ public interface ClientBuilder {
                                                       String uuid,
                                                       String name,
                                                       String clientVersion,
+                                                      String clientRevision,
                                                       ClientEntityManager entity);
 
   ClientEntityManager createClientEntityManager(ClientMessageChannel channel, StageManager stages);

--- a/tc-client/src/main/java/com/tc/object/DistributedObjectClient.java
+++ b/tc-client/src/main/java/com/tc/object/DistributedObjectClient.java
@@ -293,11 +293,12 @@ public class DistributedObjectClient {
     
     final ProductInfo pInfo = ProductInfo.getInstance(getClass().getClassLoader());
     
-    ClientHandshakeMessageFactory chmf = (u, n, c)->{
+    ClientHandshakeMessageFactory chmf = (u, n, c, r)->{
       ClientMessageChannel cmc = getClientMessageChannel();
       if (cmc != null) {
         final ClientHandshakeMessage rv = (ClientHandshakeMessage)cmc.createMessage(TCMessageType.CLIENT_HANDSHAKE_MESSAGE);
         rv.setClientVersion(c);
+        rv.setClientRevision(r);
         rv.setClientPID(getPID());
         rv.setUUID(u);
         rv.setName(n);
@@ -310,7 +311,7 @@ public class DistributedObjectClient {
     this.clientHandshakeManager = this.clientBuilder
         .createClientHandshakeManager(new ClientIDLogger(clientChannel, LoggerFactory
                                           .getLogger(ClientHandshakeManagerImpl.class)), chmf, sessionManager,
-                                          this.uuid, this.name, pInfo.version(), clientEntityManager);
+                                          this.uuid, this.name, pInfo.version(), pInfo.buildRevision(), clientEntityManager);
 
     ClientChannelEventController.connectChannelEventListener(clientChannel, clientHandshakeManager);
     final ClientConfigurationContext cc = new ClientConfigurationContext(clientChannel.getClientID().toString(), this.communicationStageManager);

--- a/tc-client/src/main/java/com/tc/object/StandardClientBuilder.java
+++ b/tc-client/src/main/java/com/tc/object/StandardClientBuilder.java
@@ -90,8 +90,9 @@ public class StandardClientBuilder implements ClientBuilder {
                                                              String uuid, 
                                                              String name, 
                                                              String clientVersion,
+                                                             String clientRevision,
                                                              ClientEntityManager entity) {
-    return new ClientHandshakeManagerImpl(logger, chmf, sessionManager, uuid, name, clientVersion, entity);
+    return new ClientHandshakeManagerImpl(logger, chmf, sessionManager, uuid, name, clientVersion, clientRevision, entity);
   }
 
   @Override

--- a/tc-client/src/main/java/com/tc/object/handshakemanager/ClientHandshakeManagerImpl.java
+++ b/tc-client/src/main/java/com/tc/object/handshakemanager/ClientHandshakeManagerImpl.java
@@ -54,8 +54,9 @@ public class ClientHandshakeManagerImpl implements ClientHandshakeManager {
   private final Logger logger;
   private final SessionManager sessionManager;
   private final String clientVersion;
+  private final String clientRevision;
   
-  private final String   uuid;
+  private final String uuid;
   private final String name;
 
   private State state;
@@ -64,7 +65,7 @@ public class ClientHandshakeManagerImpl implements ClientHandshakeManager {
 
   public ClientHandshakeManagerImpl(Logger logger, ClientHandshakeMessageFactory chmf,
                                     SessionManager sessionManager,
-                                    String uuid, String name, String clientVersion,
+                                    String uuid, String name, String clientVersion, String clientRevision,
                                     ClientHandshakeCallback entities) {
     this.logger = logger;
     this.chmf = chmf;
@@ -72,6 +73,7 @@ public class ClientHandshakeManagerImpl implements ClientHandshakeManager {
     this.uuid = uuid;
     this.name = name;
     this.clientVersion = clientVersion;
+    this.clientRevision = clientRevision;
     this.callBacks = entities;
     this.state = State.PAUSED;
     this.disconnected = true;
@@ -108,7 +110,7 @@ public class ClientHandshakeManagerImpl implements ClientHandshakeManager {
     ClientHandshakeMessage handshakeMessage;
 
     changeToStarting();
-    handshakeMessage = this.chmf.newClientHandshakeMessage(this.uuid, this.name, this.clientVersion);
+    handshakeMessage = this.chmf.newClientHandshakeMessage(this.uuid, this.name, this.clientVersion, this.clientRevision);
     if (handshakeMessage != null) {
       notifyCallbackOnHandshake(handshakeMessage);
 

--- a/tc-client/src/test/java/com/tc/object/handshakemanager/ClientHandshakeManagerTest.java
+++ b/tc-client/src/test/java/com/tc/object/handshakemanager/ClientHandshakeManagerTest.java
@@ -72,7 +72,7 @@ public class ClientHandshakeManagerTest {
 
   private void checkClientServerVersionCompatibility(String clientVersion, String serverVersion) {
     ClientHandshakeManagerImpl manager = new ClientHandshakeManagerImpl(logger, chmf, sessionManager,
-            UUID.getUUID().toString(), "name", clientVersion, entities);
+            UUID.getUUID().toString(), "name", clientVersion, "revision", entities);
     manager.checkClientServerVersionCompatibility(serverVersion);
   }
 

--- a/tc-messaging/src/main/java/com/tc/object/msg/ClientHandshakeMessage.java
+++ b/tc-messaging/src/main/java/com/tc/object/msg/ClientHandshakeMessage.java
@@ -38,6 +38,10 @@ public interface ClientHandshakeMessage extends TCMessage {
 
   String getClientVersion();
 
+  void setClientRevision(String v);
+
+  String getClientRevision();
+
   void setClientPID(int pid);
 
   int getClientPID();

--- a/tc-messaging/src/main/java/com/tc/object/msg/ClientHandshakeMessageFactory.java
+++ b/tc-messaging/src/main/java/com/tc/object/msg/ClientHandshakeMessageFactory.java
@@ -20,6 +20,6 @@ package com.tc.object.msg;
 
 public interface ClientHandshakeMessageFactory {
 
-  public ClientHandshakeMessage newClientHandshakeMessage(String uuid, String name, String clientVersion);
+  public ClientHandshakeMessage newClientHandshakeMessage(String uuid, String name, String clientVersion, String clientRevision);
 
 }

--- a/tc-messaging/src/main/java/com/tc/object/msg/ClientHandshakeMessageImpl.java
+++ b/tc-messaging/src/main/java/com/tc/object/msg/ClientHandshakeMessageImpl.java
@@ -47,11 +47,13 @@ public class ClientHandshakeMessageImpl extends DSOMessageBase implements Client
   private static final byte   CLIENT_UUID              = 8;
   private static final byte   CLIENT_NAME              = 9;
   private static final byte   CLIENT_ADDRESS           = 10;
+  private static final byte   CLIENT_REVISION          = 11;
 
   private long                currentLocalTimeMills    = System.currentTimeMillis();
-  private String                uuid                     = com.tc.util.UUID.NULL_ID.toString();
+  private String              uuid                     = com.tc.util.UUID.NULL_ID.toString();
   private String              name                     = "";
   private String              clientVersion            = "";
+  private String              clientRevision           = "";
   private String              clientAddress            = ""; 
   private int                 pid                      = -1;
   private final Set<ClientEntityReferenceContext> reconnectReferences = new HashSet<ClientEntityReferenceContext>();
@@ -79,6 +81,11 @@ public class ClientHandshakeMessageImpl extends DSOMessageBase implements Client
   @Override
   public String getClientVersion() {
     return this.clientVersion;
+  }
+
+  @Override
+  public String getClientRevision() {
+    return this.clientRevision;
   }
 
   @Override
@@ -117,6 +124,11 @@ public class ClientHandshakeMessageImpl extends DSOMessageBase implements Client
   }
 
   @Override
+  public void setClientRevision(String revision) {
+    this.clientRevision = revision;
+  }
+
+  @Override
   public long getLocalTimeMills() {
     return this.currentLocalTimeMills;
   }
@@ -142,6 +154,7 @@ public class ClientHandshakeMessageImpl extends DSOMessageBase implements Client
       putNVPair(RESEND_MESSAGES, resendMessage);
     }
     putNVPair(CLIENT_ADDRESS, this.clientAddress);
+    putNVPair(CLIENT_REVISION, this.clientRevision);
   }
 
   @Override
@@ -176,6 +189,9 @@ public class ClientHandshakeMessageImpl extends DSOMessageBase implements Client
         return true;
       case CLIENT_ADDRESS:
         this.clientAddress = getStringValue();
+        return true;
+      case CLIENT_REVISION:
+        this.clientRevision = getStringValue();
         return true;
       default:
         return false;

--- a/tc-server/src/main/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollector.java
+++ b/tc-server/src/main/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollector.java
@@ -148,6 +148,9 @@ public class ManagementTopologyEventCollector implements ITopologyEventCollector
       if (minfo.hasClientReportedAddress()) {
         this.serviceInterface.addNode(extrasPath, "clientReportedAddress", minfo.getClientReportedAddress());
       }
+      if (minfo.hasClientRevision()) {
+        this.serviceInterface.addNode(extrasPath, "clientRevision", minfo.getRevision());
+      }
       if (earlyFetches != null && !earlyFetches.isEmpty()) {
         for (ResolvedDescriptors ed : earlyFetches) {
           String fetchIdentifier = fetchIdentifierForService(client, ed.id, ed.consumerID, ed.instance);

--- a/tc-server/src/main/java/com/tc/objectserver/handshakemanager/ClientHandshakeMonitoringInfo.java
+++ b/tc-server/src/main/java/com/tc/objectserver/handshakemanager/ClientHandshakeMonitoringInfo.java
@@ -28,13 +28,15 @@ public class ClientHandshakeMonitoringInfo {
   private final String uuid;
   private final String name;
   private final String version;
+  private final String revision;
   private final String address;
 
-  public ClientHandshakeMonitoringInfo(int pid, String uuid, String name, String version, String address) {
+  public ClientHandshakeMonitoringInfo(int pid, String uuid, String name, String version, String revision, String address) {
     this.pid = pid;
     this.uuid = uuid;
     this.name = name;
     this.version = version;
+    this.revision = revision;
     this.address = address;
   }
 
@@ -51,6 +53,8 @@ public class ClientHandshakeMonitoringInfo {
   }
 
   public String getVersion() { return version; }
+
+  public String getRevision() { return revision; }
   
   public String getClientReportedAddress() {
     return this.address;
@@ -64,8 +68,12 @@ public class ClientHandshakeMonitoringInfo {
     return (this.version != null && this.version.length() > 0);
   }
 
+  public boolean hasClientRevision() {
+    return (this.revision != null && this.revision.length() > 0);
+  }
+
   @Override
   public String toString() {
-    return "ClientHandshakeInfo{" + "pid=" + pid + ", uuid=" + uuid + ", name=" + name + ", version=" + version + ", address=" + address + '}';
+    return "ClientHandshakeInfo{" + "pid=" + pid + ", uuid=" + uuid + ", name=" + name + ", version=" + version + ", revision=" + revision + ", address=" + address + '}';
   }
 }

--- a/tc-server/src/main/java/com/tc/objectserver/handshakemanager/ClientHandshakePrettyPrintable.java
+++ b/tc-server/src/main/java/com/tc/objectserver/handshakemanager/ClientHandshakePrettyPrintable.java
@@ -46,6 +46,7 @@ public class ClientHandshakePrettyPrintable implements PrettyPrintable {
             hs.put("pid", target.getPid());
             hs.put("uuid", target.getUuid());
             hs.put("version", target.getVersion());
+            hs.put("revision", target.getRevision());
             hs.put("clientReportedAddress", target.getClientReportedAddress());
             map.put(c.toString(), hs);
           }

--- a/tc-server/src/main/java/com/tc/objectserver/handshakemanager/ServerClientHandshakeManager.java
+++ b/tc-server/src/main/java/com/tc/objectserver/handshakemanager/ServerClientHandshakeManager.java
@@ -112,7 +112,7 @@ public class ServerClientHandshakeManager {
     synchronized (this) {
       this.logger.info("Handling client handshake for " + clientID);
       handshake.getChannel().addAttachment(ClientHandshakeMonitoringInfo.MONITORING_INFO_ATTACHMENT, 
-          new ClientHandshakeMonitoringInfo(handshake.getClientPID(), handshake.getUUID(), handshake.getName(), handshake.getClientVersion(), handshake.getClientAddress()), false);
+          new ClientHandshakeMonitoringInfo(handshake.getClientPID(), handshake.getUUID(), handshake.getName(), handshake.getClientVersion(), handshake.getClientRevision(), handshake.getClientAddress()), false);
       if (canAcceptStats(handshake.getClientVersion())) {
         handshake.getChannel().addAttachment("SendStats", true, true);
       }
@@ -175,7 +175,7 @@ public class ServerClientHandshakeManager {
   public void notifyDiagnosticClient(ClientHandshakeMessage clientMsg) {
     final ClientID clientID = (ClientID) clientMsg.getSourceNodeID();
     clientMsg.getChannel().addAttachment(ClientHandshakeMonitoringInfo.MONITORING_INFO_ATTACHMENT, 
-        new ClientHandshakeMonitoringInfo(clientMsg.getClientPID(), clientMsg.getUUID(), clientMsg.getName(), clientMsg.getClientVersion(), clientMsg.getClientAddress()), false);
+        new ClientHandshakeMonitoringInfo(clientMsg.getClientPID(), clientMsg.getUUID(), clientMsg.getName(), clientMsg.getClientVersion(), clientMsg.getClientRevision(), clientMsg.getClientAddress()), false);
     ClientHandshakeAckMessage ack = (ClientHandshakeAckMessage)clientMsg.getChannel().createMessage(TCMessageType.CLIENT_HANDSHAKE_ACK_MESSAGE);
     ack.initialize(Collections.emptySet(), clientID, productInfo.version());
     ack.send();

--- a/tc-server/src/main/java/com/tc/server/TCServer.java
+++ b/tc-server/src/main/java/com/tc/server/TCServer.java
@@ -18,6 +18,7 @@
  */
 package com.tc.server;
 
+import com.tc.stats.Client;
 import org.terracotta.monitoring.PlatformStopException;
 
 import com.tc.config.schema.setup.ConfigurationSetupException;
@@ -28,6 +29,7 @@ import com.tc.util.ProductInfo;
 import com.tc.util.State;
 import org.terracotta.server.StopAction;
 
+import java.util.List;
 
 public interface TCServer extends Pauseable {
   String[] processArguments();
@@ -87,4 +89,6 @@ public interface TCServer extends Pauseable {
   String getClusterState(PrettyPrinter form);
 
   ProductInfo productInfo();
+
+  List<Client> getConnectedClients();
 }

--- a/tc-server/src/main/java/com/tc/server/TCServerImpl.java
+++ b/tc-server/src/main/java/com/tc/server/TCServerImpl.java
@@ -19,6 +19,7 @@
 package com.tc.server;
 
 
+import com.tc.stats.Client;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.monitoring.PlatformStopException;
@@ -37,7 +38,6 @@ import com.tc.management.beans.L2MBeanNames;
 import com.tc.management.beans.TCServerInfo;
 import com.tc.net.protocol.transport.ConnectionPolicy;
 import com.tc.net.protocol.transport.ConnectionPolicyImpl;
-import com.tc.net.utils.L2Utils;
 import com.tc.objectserver.core.api.ServerConfigurationContext;
 import com.tc.objectserver.core.impl.GuardianContext;
 import com.tc.objectserver.core.impl.ServerManagementContext;
@@ -45,7 +45,6 @@ import com.tc.objectserver.impl.DistributedObjectServer;
 import com.tc.objectserver.impl.JMXSubsystem;
 import com.tc.spi.Guardian;
 import com.tc.stats.DSO;
-import com.tc.stats.api.DSOMBean;
 import com.tc.util.Assert;
 import com.tc.util.ProductInfo;
 import com.tc.util.State;
@@ -64,6 +63,7 @@ import javax.management.NotCompliantMBeanException;
 import com.tc.text.PrettyPrinter;
 import java.lang.management.ManagementFactory;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
@@ -89,6 +89,7 @@ public class TCServerImpl extends SEDA implements TCServer {
   private final CompletableFuture<Boolean>                      shutdownGate                        = new CompletableFuture<>();
 
   private final JMXSubsystem                subsystem;
+  private DSO dso;
   /**
    * This should only be used for tests.
    */
@@ -410,8 +411,8 @@ public class TCServerImpl extends SEDA implements TCServer {
   protected void registerDSOMBeans(ServerManagementContext mgmtContext, ServerConfigurationContext configContext, DistributedObjectServer tcDumper,
                                    MBeanServer mBeanServer) throws NotCompliantMBeanException,
       InstanceAlreadyExistsException, MBeanRegistrationException {
-    DSOMBean dso = new DSO(mgmtContext, configContext, mBeanServer);
-    mBeanServer.registerMBean(dso, L2MBeanNames.DSO);
+      dso = new DSO(mgmtContext, configContext, mBeanServer);
+      mBeanServer.registerMBean(dso, L2MBeanNames.DSO);
   }
 
   protected void unregisterDSOMBeans(MBeanServer mbs) throws MBeanRegistrationException, InstanceNotFoundException {
@@ -447,6 +448,12 @@ public class TCServerImpl extends SEDA implements TCServer {
   @Override
   public String getClusterState(PrettyPrinter form) {
     return new String(dsoServer.getClusterState(Charset.defaultCharset(), form), Charset.defaultCharset());
+  }
+
+  @Override
+  public List<Client> getConnectedClients()
+  {
+    return dso.getConnectedClients();
   }
 
   @Override

--- a/tc-server/src/main/java/com/tc/stats/Client.java
+++ b/tc-server/src/main/java/com/tc/stats/Client.java
@@ -128,6 +128,22 @@ public class Client extends AbstractTerracottaMBean implements ClientMBean, Noti
     }
     return "";
   }
+
+  @Override
+  public String getVersion() {
+    if (minfo !=null) {
+      return minfo.getVersion();
+    }
+    return "";
+  }
+
+  @Override
+  public String getRevision() {
+    if (minfo !=null) {
+      return minfo.getRevision();
+    }
+    return "";
+  }
  
   private void beanRegistered(ObjectName beanName) {
 

--- a/tc-server/src/main/java/com/tc/stats/DSO.java
+++ b/tc-server/src/main/java/com/tc/stats/DSO.java
@@ -122,6 +122,13 @@ public class DSO extends AbstractNotifyingMBean implements DSOMBean {
     }
   }
 
+  @Override
+  public List<Client> getConnectedClients() {
+    synchronized (clientMap) {
+      return new ArrayList<>(clientMap.values());
+    }
+  }
+
   private void setupClients() {
     MessageChannel[] channels = channelMgr.getActiveChannels();
     for (MessageChannel channel : channels) {

--- a/tc-server/src/main/java/com/tc/stats/api/ClientMBean.java
+++ b/tc-server/src/main/java/com/tc/stats/api/ClientMBean.java
@@ -39,4 +39,8 @@ public interface ClientMBean extends TerracottaMBean {
   String getRemoteName();
   
   String getRemoteUUID();
+
+  String getVersion();
+
+  String getRevision();
 }

--- a/tc-server/src/main/java/com/tc/stats/api/DSOMBean.java
+++ b/tc-server/src/main/java/com/tc/stats/api/DSOMBean.java
@@ -19,7 +19,9 @@
 package com.tc.stats.api;
 
 import com.tc.management.TerracottaMBean;
+import com.tc.stats.Client;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -37,6 +39,8 @@ public interface DSOMBean extends TerracottaMBean {
   static final String CLIENT_DETACHED = "dso.client.detached";
 
   ObjectName[] getClients();
+
+  List<Client> getConnectedClients();
 
   Map<ObjectName, Exception> setAttribute(Set<ObjectName> onSet, String attrName, Object attrValue);
 

--- a/tc-server/src/test/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollectorTest.java
+++ b/tc-server/src/test/java/com/tc/objectserver/core/impl/ManagementTopologyEventCollectorTest.java
@@ -262,11 +262,12 @@ public class ManagementTopologyEventCollectorTest {
     final String uuid = UUID.getUUID().toString();
     final String name = "TEST";
     final String version = "1.2.0";
+    final String revision = "b03ca894bb1d4072b8c8140aa6296ce4";
     final String address = "unknown";
 
     // prepare and call collector.clientDidConnect(...)
     MessageChannel channel = mock(MessageChannel.class);
-    ClientHandshakeMonitoringInfo info = new ClientHandshakeMonitoringInfo(TEST_CLIENT_PID, uuid, name, version, address);
+    ClientHandshakeMonitoringInfo info = new ClientHandshakeMonitoringInfo(TEST_CLIENT_PID, uuid, name, version, revision, address);
     when(channel.getAttachment(eq(ClientHandshakeMonitoringInfo.MONITORING_INFO_ATTACHMENT))).thenReturn(info);
     when(channel.getLocalAddress()).thenReturn(new TCSocketAddress("localhost", 1234));
     when(channel.getRemoteAddress()).thenReturn(new TCSocketAddress("localhost", 4567));


### PR DESCRIPTION
Connected client versioning information, (e.g. version and revision), needs to be retrievable by the Diagnostic Service.  The current changes include (1) ability for connecting clients to provide their build revision string as part of the connection handshake and (2) the client version details exposed via the existing DSO MBean.,