### PR TITLE
Fixing bug in version compatibility check

### DIFF
--- a/common/src/main/java/com/tc/util/version/Version.java
+++ b/common/src/main/java/com/tc/util/version/Version.java
@@ -118,6 +118,32 @@ public class Version implements Comparable<Version> {
   }
 
   /**
+   * Tests if this Version is newer than Version 'v' up to a maximum 'depth' of digits.
+   * @param v Version to compare against
+   * @param depth Maximum number of digits in version string to compare
+   * @return TRUE if this Version is newer than Version 'v' up to 'depth' digits comparison, FALSE otherwise
+   */
+  public boolean isNewer(Version v, int depth) {
+    if (v == null) { throw new NullPointerException(); }
+    if (depth < 1 || depth > 5) {throw new IndexOutOfBoundsException(); }
+    int[] v1 = {major, minor, micro, patch, build};
+    int[] v2 = {v.major, v.minor, v.micro, v.patch, v.build};
+    int i = 0;
+    while (i < depth) {
+      if (v1[i] > v2[i]) {
+        return true;
+      }
+      if (v1[i] != v2[i]) {
+        return false;
+      }
+      i++;
+    }
+    return false;
+  }
+
+
+
+  /**
    * May be null
    */
   public String qualifier() {

--- a/common/src/main/java/com/tc/util/version/VersionCompatibility.java
+++ b/common/src/main/java/com/tc/util/version/VersionCompatibility.java
@@ -47,18 +47,9 @@ public class VersionCompatibility {
     return ((v1.major() == v2.major()) && (v1.minor() == v2.minor()));
   }
 
-  public static boolean isNewer(Version v1, Version v2) {
+  public static boolean isNewer(Version v1, Version v2, int depth) {
     if (v1 == null || v2 == null) { throw new NullPointerException(); }
-    if (v1.major() > v2.major()) {
-      return true;
-    }
-    if (v1.minor() > v2.minor()) {
-      return true;
-    }
-    if (v1.micro() > v2.micro()) {
-      return true;
-    }
-    return false;
+    return v1.isNewer(v2, depth);
   }
 
   public Version getMinimumCompatiblePersistence() {

--- a/common/src/test/java/com/tc/util/version/VersionTest.java
+++ b/common/src/test/java/com/tc/util/version/VersionTest.java
@@ -111,4 +111,64 @@ public class VersionTest extends TestCase {
     Collections.sort(stuff);
     assertEquals("[1.0.0.0.0, 1.1.0.0.0_preview, 1.1.0.0.0-SNAPSHOT, 1.1.0.0.0, 1.2.0.0.0, 2.1.0.0.0-SNAPSHOT, 2.1.0.0.0]", stuff.toString());
   }
+
+  public void testIsNewer() {
+    try {
+      helpTestIsNewer ("1", "1", 0);
+      fail("depth must be >= 1 and <= 5");
+    } catch(IndexOutOfBoundsException e) {
+      // expected
+    }
+    try {
+      helpTestIsNewer ("1", "1", 6);
+      fail("depth must be >= 1 and <= 5");
+    } catch(IndexOutOfBoundsException e) {
+      // expected
+    }
+
+    assertTrue(helpTestIsNewer("11", "10", 1));
+    assertTrue(helpTestIsNewer("11", "10", 2));
+    assertTrue(helpTestIsNewer("11", "10", 3));
+    assertTrue(helpTestIsNewer("11", "10", 4));
+    assertTrue(helpTestIsNewer("11", "10", 5));
+
+    assertFalse(helpTestIsNewer("11.1", "11.0", 1));
+    assertTrue(helpTestIsNewer ("11.2", "11.1", 2));
+    assertTrue(helpTestIsNewer ("11.3", "11.2", 3));
+    assertTrue(helpTestIsNewer ("11.4", "11.3", 4));
+    assertTrue(helpTestIsNewer ("11.5", "11.4", 5));
+
+    assertFalse(helpTestIsNewer("11.0.1", "11.0.0", 1));
+    assertFalse(helpTestIsNewer("11.0.2", "11.0.1", 2));
+    assertTrue(helpTestIsNewer ("11.0.3", "11.0.2", 3));
+    assertTrue(helpTestIsNewer ("11.0.4", "11.0.3", 4));
+    assertTrue(helpTestIsNewer ("11.0.5", "11.0.4", 5));
+
+    assertFalse(helpTestIsNewer("11.0.0.1", "11.0.0.0", 1));
+    assertFalse(helpTestIsNewer("11.0.0.2", "11.0.0.1", 2));
+    assertFalse(helpTestIsNewer("11.0.0.3", "11.0.0.2", 3));
+    assertTrue(helpTestIsNewer ("11.0.0.4", "11.0.0.3", 4));
+    assertTrue(helpTestIsNewer ("11.0.0.5", "11.0.0.4", 5));
+
+    assertFalse(helpTestIsNewer("11.0.0.0.1", "11.0.0.0.0", 1));
+    assertFalse(helpTestIsNewer("11.0.0.0.2", "11.0.0.0.1", 2));
+    assertFalse(helpTestIsNewer("11.0.0.0.3", "11.0.0.0.2", 3));
+    assertFalse(helpTestIsNewer("11.0.0.0.4", "11.0.0.0.3", 4));
+    assertTrue(helpTestIsNewer ("11.0.0.0.5", "11.0.0.0.4", 5));
+
+    assertFalse(helpTestIsNewer("1.1.1.1.1", "10.10.10.10.10", 1));
+    assertFalse(helpTestIsNewer("1.1.1.1.1", "10.10.10.10.10", 2));
+    assertFalse(helpTestIsNewer("1.1.1.1.1", "10.10.10.10.10", 3));
+    assertFalse(helpTestIsNewer("1.1.1.1.1", "10.10.10.10.10", 4));
+    assertFalse(helpTestIsNewer("1.1.1.1.1", "10.10.10.10.10", 5));
+
+    assertTrue(helpTestIsNewer("10.7.0", "10.3.1.4.11", 3));
+    assertFalse(helpTestIsNewer("10.3.1.4.11", "10.7.0", 3));
+  }
+
+  private boolean helpTestIsNewer(String s1, String s2, int depth) {
+    Version v1 = new Version(s1);
+    Version v2 = new Version(s2);
+    return v1.isNewer(v2, depth);
+  }
 }

--- a/tc-server/src/main/java/com/tc/objectserver/handler/ClientHandshakeHandler.java
+++ b/tc-server/src/main/java/com/tc/objectserver/handler/ClientHandshakeHandler.java
@@ -58,7 +58,7 @@ public class ClientHandshakeHandler extends AbstractEventHandler<ClientHandshake
     try {
       if (!GuardianContext.validate(Guardian.Op.CONNECT_CLIENT, cid, clientMsg.getChannel())) {
         this.handshakeManager.notifyClientRefused(clientMsg, "new connections not allowed");
-      } else if (VersionCompatibility.isNewer(client, serverVersion)) {
+      } else if (VersionCompatibility.isNewer(client, serverVersion, 3)) {
         this.handshakeManager.notifyClientRefused(clientMsg, "client version is newer than the server");
       } else if (clientMsg.getChannel().getProductID() == ProductID.DIAGNOSTIC) {
         this.handshakeManager.notifyDiagnosticClient(clientMsg);


### PR DESCRIPTION
Noticed that VersionCompatibility contained a bug when comparing against an older version that possesses a greater minor or micro value.  For Example: 10.3.1.4.11 was identified as being greater than 10.7.0.