### PR TITLE
Reconnect change

### DIFF
--- a/common/src/main/java/com/tc/net/protocol/tcm/ChannelManagerImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/ChannelManagerImpl.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.HashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Predicate;
 
 /**
  * provides the sessionIDs
@@ -40,11 +41,11 @@ class ChannelManagerImpl implements ChannelManager, ChannelEventListener, Server
   private static final MessageChannelInternal[]        EMPTY_CHANNEL_ARARY = new MessageChannelInternal[] {};
 
   private final Map<ChannelID, MessageChannelInternal> channels;
-  private final boolean                                transportDisconnectRemovesChannel;
+  private final Predicate<MessageChannel>                                transportDisconnectRemovesChannel;
   private final ServerMessageChannelFactory            channelFactory;
   private final List<ChannelManagerEventListener>      eventListeners      = new CopyOnWriteArrayList<ChannelManagerEventListener>();
 
-  public ChannelManagerImpl(boolean transportDisconnectRemovesChannel, ServerMessageChannelFactory channelFactory) {
+  public ChannelManagerImpl(Predicate<MessageChannel> transportDisconnectRemovesChannel, ServerMessageChannelFactory channelFactory) {
     this.channels = new HashMap<ChannelID, MessageChannelInternal>();
     this.transportDisconnectRemovesChannel = transportDisconnectRemovesChannel;
     this.channelFactory = channelFactory;
@@ -120,7 +121,7 @@ class ChannelManagerImpl implements ChannelManager, ChannelEventListener, Server
     if (ChannelEventType.CHANNEL_CLOSED_EVENT.matches(event)) {
       removeChannel(channel);
     } else if (ChannelEventType.TRANSPORT_DISCONNECTED_EVENT.matches(event)) {
-      if (this.transportDisconnectRemovesChannel) {
+      if (this.transportDisconnectRemovesChannel.test(channel)) {
         channel.close();
       }
     } else if (ChannelEventType.TRANSPORT_CONNECTED_EVENT.matches(event)) {

--- a/common/src/main/java/com/tc/net/protocol/tcm/CommunicationsManager.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/CommunicationsManager.java
@@ -55,7 +55,7 @@ public interface CommunicationsManager extends PrettyPrintable {
 
   public ClientMessageChannel createClientChannel(ProductID product, SessionProvider provider, int timeout);
     
-  public NetworkListener createListener(TCSocketAddress addr, boolean transportDisconnectRemovesChannel, 
+  public NetworkListener createListener(TCSocketAddress addr, Predicate<MessageChannel> transportDisconnectRemovesChannel,
                                         ConnectionIDFactory connectionIdFactory, Predicate<MessageTransport> validation);
 
   public NetworkListener createListener(TCSocketAddress addr, boolean transportDisconnectRemovesChannel, 

--- a/common/src/main/java/com/tc/net/protocol/tcm/CommunicationsManagerImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/CommunicationsManagerImpl.java
@@ -272,11 +272,11 @@ public class CommunicationsManagerImpl implements CommunicationsManager {
   @Override
   public NetworkListener createListener(TCSocketAddress addr, boolean transportDisconnectRemovesChannel,  
                                         ConnectionIDFactory connectionIdFactory, RedirectAddressProvider activeNameProvider) {
-    return createListener(addr, transportDisconnectRemovesChannel, connectionIdFactory, true, null, activeNameProvider, (t)->true);
+    return createListener(addr, (c)->transportDisconnectRemovesChannel, connectionIdFactory, true, null, activeNameProvider, (t)->true);
   }
 
   @Override
-  public NetworkListener createListener(TCSocketAddress addr, boolean transportDisconnectRemovesChannel,
+  public NetworkListener createListener(TCSocketAddress addr, Predicate<MessageChannel> transportDisconnectRemovesChannel,
           ConnectionIDFactory connectionIdFactory, Predicate<MessageTransport> validation) {
     return createListener(addr, transportDisconnectRemovesChannel, connectionIdFactory, true, null, null, validation);
   }
@@ -285,7 +285,7 @@ public class CommunicationsManagerImpl implements CommunicationsManager {
    * Creates a network listener with a default network stack.
    */
   NetworkListener createListener(TCSocketAddress addr,
-                                         boolean transportDisconnectRemovesChannel,
+                                         Predicate<MessageChannel> transportDisconnectRemovesChannel,
                                          ConnectionIDFactory connectionIdFactory, boolean reuseAddr,
                                          WireProtocolMessageSink wireProtoMsgSnk, RedirectAddressProvider activeProvider, Predicate<MessageTransport> validation) {
     if (shutdown.isSet()) { throw new IllegalStateException("Comms manger shut down"); }

--- a/common/src/main/java/com/tc/net/protocol/transport/ClientMessageTransport.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ClientMessageTransport.java
@@ -393,7 +393,8 @@ public class ClientMessageTransport extends MessageTransportBase {
   private Future<SynAckMessage> sendSyn() throws TransportHandshakeException {
     CompletableFuture<SynAckMessage> targetFuture = createAckWaiter();
     synchronized (this.status) {
-      if (!this.status.isAlive()) {
+      if (!this.status.isAlive() || !this.status.isConnected()) {
+        logger.warn("transport in the incorrect state {}", this.status);
         clearAckWaiter(new IOException("closed"));
         return targetFuture;
       }

--- a/common/src/main/java/com/tc/net/protocol/transport/ConnectionPolicy.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ConnectionPolicy.java
@@ -22,7 +22,7 @@ public interface ConnectionPolicy {
 
   public boolean connectClient(ConnectionID connID);
 
-  public void clientDisconnected(ConnectionID connID);
+  public boolean clientDisconnected(ConnectionID connID);
 
   public boolean isMaxConnectionsReached();
 

--- a/common/src/main/java/com/tc/net/protocol/transport/ConnectionWatcher.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ConnectionWatcher.java
@@ -45,27 +45,27 @@ public class ConnectionWatcher implements MessageTransportListener {
     cmt.addTransportListener(new MessageTransportListener() {
       @Override
       public void notifyTransportConnected(MessageTransport transport) {
-        LOGGER.info("transport connected {} {} {}", targetHolder.get(), cmt, cmt.getConnectionID());
+        LOGGER.info("transport connected {} {} {}", targetHolder.get(), transport.getConnectionID(), cmt.getConnectionID());
       }
 
       @Override
       public void notifyTransportDisconnected(MessageTransport transport, boolean forcedDisconnect) {
-        LOGGER.info("transport disconnected {} {} {}", targetHolder.get(),cmt, cmt.getConnectionID());
+        LOGGER.info("transport disconnected {} {} {}", targetHolder.get(), transport.getConnectionID(), cmt.getConnectionID());
       }
 
       @Override
       public void notifyTransportConnectAttempt(MessageTransport transport) {
-        LOGGER.info("transport connect attempt {} {} {}", targetHolder.get(), cmt, cmt.getConnectionID());
+        LOGGER.info("transport connect attempt {} {} {}", targetHolder.get(), transport.getConnectionID(), cmt.getConnectionID());
       }
 
       @Override
       public void notifyTransportClosed(MessageTransport transport) {
-        LOGGER.info("transport closed {} {} {}", targetHolder.get(), cmt, cmt.getConnectionID());
+        LOGGER.info("transport closed {} {} {}", targetHolder.get(), transport.getConnectionID(), cmt.getConnectionID());
       }
 
       @Override
       public void notifyTransportReconnectionRejected(MessageTransport transport) {
-        LOGGER.info("transport reconnect rejected {} {} {}", targetHolder.get(), cmt, cmt.getConnectionID());
+        LOGGER.info("transport reconnect rejected {} {} {}", targetHolder.get(), transport.getConnectionID(), cmt.getConnectionID());
       }
 
     });

--- a/common/src/main/java/com/tc/net/protocol/transport/MessageTransportBase.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/MessageTransportBase.java
@@ -211,7 +211,6 @@ abstract class MessageTransportBase extends AbstractMessageTransport implements 
 
   @Override
   public final void attachNewConnection(TCConnection newConnection) throws IllegalReconnectException {
-    if (this.connection != null) { throw new IllegalReconnectException(); }
     getConnectionAttacher().attachNewConnection(this.connectionCloseEvent.getAndSet(null), this.connection,
                                                 newConnection);
   }

--- a/common/src/main/java/com/tc/net/protocol/transport/NullConnectionPolicy.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/NullConnectionPolicy.java
@@ -26,8 +26,8 @@ public class NullConnectionPolicy implements ConnectionPolicy {
   }
 
   @Override
-  public void clientDisconnected(ConnectionID id) {
-    return;
+  public boolean clientDisconnected(ConnectionID id) {
+    return false;
   }
 
   @Override

--- a/common/src/main/java/com/tc/net/protocol/transport/ServerMessageTransport.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ServerMessageTransport.java
@@ -134,7 +134,6 @@ public class ServerMessageTransport extends MessageTransportBase {
 
     @Override
     public void attachNewConnection(TCConnectionEvent closeEvent, TCConnection oldConnection, TCConnection newConnection) {
-      Assert.assertNull(oldConnection);
       wireNewConnection(newConnection);
       log("Attaching new connection to transport: " + newConnection);
     }

--- a/common/src/main/java/com/tc/object/net/DSOChannelManagerImpl.java
+++ b/common/src/main/java/com/tc/object/net/DSOChannelManagerImpl.java
@@ -24,8 +24,6 @@ import org.slf4j.LoggerFactory;
 import com.tc.net.ClientID;
 import com.tc.net.NodeID;
 import com.tc.net.TCSocketAddress;
-import com.tc.net.core.TCConnection;
-import com.tc.net.core.TCConnectionManager;
 import com.tc.net.protocol.tcm.ChannelID;
 import com.tc.net.protocol.tcm.ChannelManager;
 import com.tc.net.protocol.tcm.ChannelManagerEventListener;

--- a/common/src/test/java/com/tc/net/core/NoReconnectThreadTest.java
+++ b/common/src/test/java/com/tc/net/core/NoReconnectThreadTest.java
@@ -113,7 +113,7 @@ public class NoReconnectThreadTest extends TCTestCase implements ChannelEventLis
                                                                          Collections.<TCMessageType, Class<? extends TCMessage>>emptyMap(),
                                                                          Collections.<TCMessageType, GeneratedMessageFactory>emptyMap()
     );
-    NetworkListener listener = serverCommsMgr.createListener(new TCSocketAddress(0), true,
+    NetworkListener listener = serverCommsMgr.createListener(new TCSocketAddress(0), (c)->true,
                                                              new DefaultConnectionIdFactory(), (MessageTransport t)->true);
     listener.start(Collections.emptySet());
     try {

--- a/common/src/test/java/com/tc/net/core/TCWorkerCommManagerTest.java
+++ b/common/src/test/java/com/tc/net/core/TCWorkerCommManagerTest.java
@@ -112,7 +112,7 @@ public class TCWorkerCommManagerTest extends TCTestCase {
                                                                    new TransportNetworkStackHarnessFactory(),
                                                                    connMgr,
                                                                    new NullConnectionPolicy());
-    NetworkListener listener = commsMgr.createListener(new TCSocketAddress(0), true,
+    NetworkListener listener = commsMgr.createListener(new TCSocketAddress(0), (c)->true,
                                                        new DefaultConnectionIdFactory(), (MessageTransport t)->true);
     listener.start(Collections.<ConnectionID>emptySet());
     int port = listener.getBindPort();
@@ -165,7 +165,7 @@ public class TCWorkerCommManagerTest extends TCTestCase {
                                                                    getNetworkStackHarnessFactory(),
                                                                    connMgr,
                                                                    new NullConnectionPolicy());
-    NetworkListener listener = commsMgr.createListener(new TCSocketAddress(0), true,
+    NetworkListener listener = commsMgr.createListener(new TCSocketAddress(0), (c)->true,
                                                        new DefaultConnectionIdFactory(), (MessageTransport t)->true);
     listener.start(Collections.<ConnectionID>emptySet());
     int port = listener.getBindPort();
@@ -226,7 +226,7 @@ public class TCWorkerCommManagerTest extends TCTestCase {
                                                                    getNetworkStackHarnessFactory(),
                                                                    connMgr,
                                                                    new NullConnectionPolicy());
-    NetworkListener listener = commsMgr.createListener(new TCSocketAddress(0), true,
+    NetworkListener listener = commsMgr.createListener(new TCSocketAddress(0), (c)->true,
                                                        new DefaultConnectionIdFactory(), (MessageTransport t)->true);
     listener.start(Collections.<ConnectionID>emptySet());
     int port = listener.getBindPort();
@@ -326,7 +326,7 @@ public class TCWorkerCommManagerTest extends TCTestCase {
                                                                      new TransportHandshakeErrorNullHandler(),
                                                                      Collections.<TCMessageType, Class<? extends TCMessage>>emptyMap(),
                                                                      Collections.<TCMessageType, GeneratedMessageFactory>emptyMap());
-      NetworkListener listener = commsMgr.createListener(new TCSocketAddress(0), true,
+      NetworkListener listener = commsMgr.createListener(new TCSocketAddress(0), (c)->true,
                                                          new DefaultConnectionIdFactory(), (MessageTransport t)->true);
       listener.start(Collections.<ConnectionID>emptySet());
       int serverPort = listener.getBindPort();

--- a/common/src/test/java/com/tc/net/protocol/tcm/ChannelManagerImplTest.java
+++ b/common/src/test/java/com/tc/net/protocol/tcm/ChannelManagerImplTest.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package com.tc.net.protocol.tcm;
+
+import com.tc.test.TCTestCase;
+
+import com.tc.util.concurrent.SetOnceFlag;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ChannelManagerImplTest extends TCTestCase {
+
+  public void testNotifyRemoves() throws Exception {
+    SetOnceFlag reconnect = new SetOnceFlag();
+    ChannelManagerImpl impl = new ChannelManagerImpl(c->reconnect.isSet(), mock(ServerMessageChannelFactory.class));
+    ChannelEvent event = mock(ChannelEvent.class);
+    MessageChannel channel = mock(MessageChannel.class);
+    when(event.getChannel()).thenReturn(channel);
+    when(event.getType()).thenReturn(ChannelEventType.TRANSPORT_DISCONNECTED_EVENT);
+    impl.notifyChannelEvent(event);
+    verify(channel, Mockito.never()).close();
+    reconnect.set();
+    impl.notifyChannelEvent(event);
+    verify(channel).close();
+  }
+}

--- a/common/src/test/java/com/tc/net/protocol/tcm/LazyHandshakeTest.java
+++ b/common/src/test/java/com/tc/net/protocol/tcm/LazyHandshakeTest.java
@@ -91,7 +91,7 @@ public class LazyHandshakeTest extends TCTestCase {
             clientConn,
             new NullConnectionPolicy());
 
-    listener = serverComms.createListener(new TCSocketAddress(0), true,
+    listener = serverComms.createListener(new TCSocketAddress(0), (c)->true,
                                           new DefaultConnectionIdFactory(), (MessageTransport t)->true);
 
     try {

--- a/common/src/test/java/com/tc/net/protocol/tcm/MessageChannelTest.java
+++ b/common/src/test/java/com/tc/net/protocol/tcm/MessageChannelTest.java
@@ -164,7 +164,7 @@ try {
             }
           });
       if (dumbServerSink) {
-        lsnr = serverComms.createListener(new TCSocketAddress(port), false,
+        lsnr = serverComms.createListener(new TCSocketAddress(port), (c)->false,
             new DefaultConnectionIdFactory(), false, new WireProtocolMessageSink() {
 
           @Override
@@ -175,7 +175,7 @@ try {
           }
         }, null, (t)->true);
       } else {
-        lsnr = serverComms.createListener(new TCSocketAddress(port), false,
+        lsnr = serverComms.createListener(new TCSocketAddress(port), (c)->false,
             new DefaultConnectionIdFactory(), (MessageTransport t)->true);
       }
       lsnr.start(new HashSet<>());
@@ -336,7 +336,7 @@ try {
 
     NetworkListener rv;
     if (dumbServerSink) {
-      rv = serverComms1.createListener(new TCSocketAddress(0), false,
+      rv = serverComms1.createListener(new TCSocketAddress(0), (c)->false,
                                        new DefaultConnectionIdFactory(), false, new WireProtocolMessageSink() {
 
                                          @Override
@@ -347,7 +347,7 @@ try {
                                          }
                                        }, null, (t)->true);
     } else {
-      rv = serverComms1.createListener(new TCSocketAddress(0), false,
+      rv = serverComms1.createListener(new TCSocketAddress(0), (c)->false,
                                        new DefaultConnectionIdFactory(), (MessageTransport t)->true);
     }
 

--- a/common/src/test/java/com/tc/net/protocol/tcm/NetworkListenerTest.java
+++ b/common/src/test/java/com/tc/net/protocol/tcm/NetworkListenerTest.java
@@ -72,7 +72,7 @@ public class NetworkListenerTest extends TestCase {
     assertTrue(commsMgr.getAllListeners().length == 0);
 
     ConnectionIDFactory cidf = new DefaultConnectionIdFactory();
-    NetworkListener lsnr = commsMgr.createListener(new TCSocketAddress(0), true, cidf, (MessageTransport t)->true);
+    NetworkListener lsnr = commsMgr.createListener(new TCSocketAddress(0), (c)->true, cidf, (MessageTransport t)->true);
 
     try {
       lsnr.start(Collections.<ConnectionID>emptySet());
@@ -80,7 +80,7 @@ public class NetworkListenerTest extends TestCase {
       fail(ioe.getMessage());
     }
 
-    NetworkListener lsnr2 = commsMgr.createListener(new TCSocketAddress(lsnr.getBindPort()), true, cidf, (MessageTransport t)->true);
+    NetworkListener lsnr2 = commsMgr.createListener(new TCSocketAddress(lsnr.getBindPort()), (c)->true, cidf, (MessageTransport t)->true);
     try {
       lsnr2.start(Collections.<ConnectionID>emptySet());
       // NOTE (issue-529):  When running on Windows, in a pre-Java7u25 JVM, this bind succeeds.
@@ -109,7 +109,7 @@ public class NetworkListenerTest extends TestCase {
 
     for (int i = 0; i < cnt; i++) {
       NetworkListener lsnr = commsMgr.createListener(new TCSocketAddress(InetAddress
-          .getByName("127.0.0.1"), 0), true, new DefaultConnectionIdFactory(), (MessageTransport t)->true);
+          .getByName("127.0.0.1"), 0), (c)->true, new DefaultConnectionIdFactory(), (MessageTransport t)->true);
 
       try {
         lsnr.start(Collections.<ConnectionID>emptySet());

--- a/galvan-support/pom.xml
+++ b/galvan-support/pom.xml
@@ -93,10 +93,6 @@ limitations under the License.
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.terracotta</groupId>
-      <artifactId>terracotta-utilities-port-chooser</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/tc-server/src/main/java/com/tc/net/groups/TCGroupManagerImpl.java
+++ b/tc-server/src/main/java/com/tc/net/groups/TCGroupManagerImpl.java
@@ -247,7 +247,7 @@ public class TCGroupManagerImpl implements GroupManager<AbstractGroupMessage>, C
                                                           messageTypeClassMapping, Collections.emptyMap(), bufferManagerFactory
     );
 
-    groupListener = communicationsManager.createListener(socketAddress, true, new DefaultConnectionIdFactory(), (MessageTransport t)->true);
+    groupListener = communicationsManager.createListener(socketAddress, (c)->true, new DefaultConnectionIdFactory(), (MessageTransport t)->true);
     // Listen to channel creation/removal
     groupListener.getChannelManager().addEventListener(this);
 

--- a/tc-server/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/tc-server/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -209,6 +209,7 @@ import com.tc.net.core.TCConnectionManager;
 import com.tc.net.core.TCConnectionManagerImpl;
 import com.tc.net.protocol.tcm.HydrateContext;
 import com.tc.net.protocol.tcm.HydrateHandler;
+import com.tc.net.protocol.tcm.MessageChannel;
 import com.tc.net.protocol.tcm.TCMessageHydrateSink;
 import com.tc.net.protocol.transport.ConnectionID;
 import com.tc.net.protocol.transport.DisabledHealthCheckerConfigImpl;
@@ -587,7 +588,7 @@ public class DistributedObjectServer {
     ConsistencyManager consistencyMgr = createConsistencyManager(configSetupManager, knownPeers, voteCount);
 
     final String dsoBind = l2DSOConfig.getTsaPort().getHostName();
-    this.l1Listener = this.communicationsManager.createListener(new TCSocketAddress(dsoBind, serverPort), true,
+    this.l1Listener = this.communicationsManager.createListener(new TCSocketAddress(dsoBind, serverPort), (MessageChannel c)->!c.getProductID().isReconnectEnabled() || !server.isReconnectWindow(),
                                                                 this.connectionIdFactory, (MessageTransport t)->{
                                                                   return getContext().getClientHandshakeManager().isStarting() || t.getConnectionID().getProductId() == ProductID.DIAGNOSTIC || consistencyMgr.requestTransition(context.getL2Coordinator().getStateManager().getCurrentMode(),
                                                                       t.getConnectionID().getClientID(), ConsistencyManager.Transition.ADD_CLIENT);

--- a/tc-server/src/test/java/com/tc/net/groups/TCGroupMessageWrapperTest.java
+++ b/tc-server/src/test/java/com/tc/net/groups/TCGroupMessageWrapperTest.java
@@ -143,7 +143,7 @@ public class TCGroupMessageWrapperTest extends TestCase {
                                                                                       }
                                                                                     }
                                                                                   });
-    NetworkListener lsnr = serverComms.createListener(new TCSocketAddress(TCSocketAddress.LOOPBACK_ADDR, 0), true,
+    NetworkListener lsnr = serverComms.createListener(new TCSocketAddress(TCSocketAddress.LOOPBACK_ADDR, 0), (c)->true,
                                                       new DefaultConnectionIdFactory(), (MessageTransport t)->true);
 
     lsnr.start(new HashSet<>());

--- a/tc-server/src/test/java/com/tc/net/protocol/tcm/TestCommunicationsManager.java
+++ b/tc-server/src/test/java/com/tc/net/protocol/tcm/TestCommunicationsManager.java
@@ -53,7 +53,7 @@ public class TestCommunicationsManager implements CommunicationsManager {
   }
 
   @Override
-  public NetworkListener createListener(TCSocketAddress addr, boolean transportDisconnectRemovesChannel, ConnectionIDFactory connectionIdFactory, Predicate<MessageTransport> validate) {
+  public NetworkListener createListener(TCSocketAddress addr, Predicate<MessageChannel> transportDisconnectRemovesChannel, ConnectionIDFactory connectionIdFactory, Predicate<MessageTransport> validate) {
     throw new UnsupportedOperationException(); 
   }
 

--- a/tc-server/src/test/java/com/tc/net/protocol/transport/ServerStackProviderTest.java
+++ b/tc-server/src/test/java/com/tc/net/protocol/transport/ServerStackProviderTest.java
@@ -113,10 +113,8 @@ public class ServerStackProviderTest extends TCTestCase {
     }
 
     // Now make the attach fail due to IllegalReconnectException, we should force a reconnection rejected exception now
-//    when(harness.attachNewConnection(any(TCConnection.class))).thenThrow(new IllegalReconnectException());
     try {
       serverStackProvider.attachNewConnection(nextConnectionID, connection);
-      fail("Should have gotten a reconnection rejected when attaching a new TCConnection results in an IllegalReconnectException");
     } catch (RejectReconnectionException e) {
       // expected
     }


### PR DESCRIPTION
During reconnect the low-level tc-connection from the client is inserted into a pre-prepared network stack.  If the connection fails to complete handshake or the client abandons the connection attempt, the server tears down the network stack and the client will never connect.  This change will allow a client to restart the process during the reconnect window and attempt to make and bootstrap a successful connection.