### PR TITLE
fix canDelete logic when creating entities

### DIFF
--- a/tc-server/src/main/java/com/tc/objectserver/api/EntityManager.java
+++ b/tc-server/src/main/java/com/tc/objectserver/api/EntityManager.java
@@ -45,10 +45,9 @@ public interface EntityManager extends MessageCodecSupplier, PrettyPrintable {
    * @param id id of the entity to create
    * @param version the version of the entity on the calling client
    * @param consumerID the unique consumerID this entity uses when interacting with services
-   * @param canDelete True if this is an entity which can be deleted, false if it is permanent.
    * @return an uninitialized ManagedEntity
    */
-  ManagedEntity createEntity(EntityID id, long version, long consumerID, boolean canDelete) throws ServerException;
+  ManagedEntity createEntity(EntityID id, long version, long consumerID) throws ServerException;
  
   /**
    * Once a ManagedEntity is destroyed it must be removed from the EntityManager manually. 
@@ -80,6 +79,8 @@ public interface EntityManager extends MessageCodecSupplier, PrettyPrintable {
   void loadExisting(EntityID entityID, long recordedVersion, long consumerID, boolean canDelete, byte[] configuration) throws ServerException;
   
   void resetReferences();
+
+  boolean canDelete(EntityID entityID);
 
   /**
    * Gets a snapshot of the entity list, sorted by order in which they were initially instantiated, under lock.

--- a/tc-server/src/main/java/com/tc/objectserver/api/ManagedEntity.java
+++ b/tc-server/src/main/java/com/tc/objectserver/api/ManagedEntity.java
@@ -76,6 +76,8 @@ public interface ManagedEntity {
   boolean isActive();
   
   boolean isRemoveable();
+
+  boolean canDelete();
   
   boolean clearQueue();
   

--- a/tc-server/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/tc-server/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -691,6 +691,9 @@ public class ManagedEntityImpl implements ManagedEntity {
     return this.isDestroyed && runnables.isEmpty() && runnables.deferCleared;
   }
 
+  @Override
+  public boolean canDelete() { return this.canDelete; }
+
   private void destroyEntity(ServerEntityRequest request, ResultCapture response) throws ConfigurationException {
     CommonServerEntity<EntityMessage, EntityResponse> commonServerEntity = this.isInActiveState
         ? activeServerEntity

--- a/tc-server/src/main/java/com/tc/objectserver/entity/PlatformEntity.java
+++ b/tc-server/src/main/java/com/tc/objectserver/entity/PlatformEntity.java
@@ -84,6 +84,9 @@ public class PlatformEntity implements ManagedEntity {
   }
 
   @Override
+  public boolean canDelete() { return false; }
+
+  @Override
   public void sync(SessionID passive) {
   //  never sync
   }

--- a/tc-server/src/main/java/com/tc/objectserver/handler/EntityExistenceHelpers.java
+++ b/tc-server/src/main/java/com/tc/objectserver/handler/EntityExistenceHelpers.java
@@ -31,7 +31,7 @@ import com.tc.util.Assert;
  * ReplicatedTransactionHandler.
  */
 public class EntityExistenceHelpers {
-  public static boolean createEntityReturnWasCached(EntityPersistor entityPersistor, EntityManager entityManager, ClientID clientID, TransactionID transactionIDObject, TransactionID oldestTransactionOnClientObject, EntityID entityID, long version, long consumerID, byte[] configuration, boolean canDelete) throws ServerException {
+  public static boolean createEntityReturnWasCached(EntityPersistor entityPersistor, EntityManager entityManager, ClientID clientID, TransactionID transactionIDObject, TransactionID oldestTransactionOnClientObject, EntityID entityID, long version, long consumerID, byte[] configuration) throws ServerException {
     boolean resultWasCached = false;
     // We can't have a null client, transaction, or oldest transaction when an entity is created - even synthetic clients shouldn't do this as they will disrupt clients.
     Assert.assertNotNull(clientID);
@@ -45,7 +45,7 @@ public class EntityExistenceHelpers {
       resultWasCached = true;
     } else {
       // There is no record of this, so give it a try.
-      entityManager.createEntity(entityID, version, consumerID, canDelete);
+      entityManager.createEntity(entityID, version, consumerID);
     }
     return resultWasCached;
   }

--- a/tc-server/src/test/java/com/tc/objectserver/entity/EntityManagerImplTest.java
+++ b/tc-server/src/test/java/com/tc/objectserver/entity/EntityManagerImplTest.java
@@ -99,7 +99,7 @@ public class EntityManagerImplTest {
   @Test
   public void testCreateEntity() throws Exception {
     try {
-      entityManager.createEntity(id, version, consumerID, true);
+      entityManager.createEntity(id, version, consumerID);
     } catch (Exception e) {
       e.printStackTrace();
       throw e;
@@ -109,8 +109,8 @@ public class EntityManagerImplTest {
 
   @Test
   public void testCreateExistingEntity() throws Exception {
-    ManagedEntity entity = entityManager.createEntity(id, version, consumerID, true);
-    ManagedEntity second = entityManager.createEntity(id, version, consumerID, true);
+    ManagedEntity entity = entityManager.createEntity(id, version, consumerID);
+    ManagedEntity second = entityManager.createEntity(id, version, consumerID);
     Assert.assertEquals(entity, second);
   }
   
@@ -118,7 +118,7 @@ public class EntityManagerImplTest {
   public void testNullEntityChecks() throws Exception {
     Optional<ManagedEntity> check = entityManager.getEntity(EntityDescriptor.createDescriptorForLifecycle(EntityID.NULL_ID, version));
     Assert.assertFalse(check.isPresent());
-    ManagedEntity entity = entityManager.createEntity(id, version, consumerID, true);
+    ManagedEntity entity = entityManager.createEntity(id, version, consumerID);
     Assert.assertNotNull(entity);
     check = entityManager.getEntity(EntityDescriptor.createDescriptorForLifecycle(id, version));
     Assert.assertTrue(check.isPresent());
@@ -133,7 +133,7 @@ public class EntityManagerImplTest {
   @Test
   public void testDestroyEntity() throws Exception {
     entityManager.enterActiveState();
-    ManagedEntity entity = entityManager.createEntity(id, version, consumerID, true);
+    ManagedEntity entity = entityManager.createEntity(id, version, consumerID);
     Thread.currentThread().setName(ServerConfigurationContext.VOLTRON_MESSAGE_STAGE);
     ServerEntityRequest req = new ServerEntityRequest() {
       @Override

--- a/tc-server/src/test/java/com/tc/objectserver/handler/EntityExistenceHelpersTest.java
+++ b/tc-server/src/test/java/com/tc/objectserver/handler/EntityExistenceHelpersTest.java
@@ -70,15 +70,15 @@ public class EntityExistenceHelpersTest {
     TransactionID tid = mock(TransactionID.class);
     EntityID eid = new EntityID("test", "test");
     when(cid.isNull()).thenReturn(Boolean.FALSE);
-    boolean result = EntityExistenceHelpers.createEntityReturnWasCached(persistor, manager, cid, tid, TransactionID.NULL_ID, eid, 1, 1, configuration, true);
+    boolean result = EntityExistenceHelpers.createEntityReturnWasCached(persistor, manager, cid, tid, TransactionID.NULL_ID, eid, 1, 1, configuration);
 // first run through should be false
     Assert.assertFalse(result);
     when(persistor.wasEntityCreatedInJournal(any(), any(), anyLong())).thenReturn(Boolean.TRUE);
-    result = EntityExistenceHelpers.createEntityReturnWasCached(persistor, manager, cid, tid, TransactionID.NULL_ID, eid, 1, 1, configuration, true);
+    result = EntityExistenceHelpers.createEntityReturnWasCached(persistor, manager, cid, tid, TransactionID.NULL_ID, eid, 1, 1, configuration);
 // if the persistor thinks the entity was created, the entity return was cached
     Assert.assertTrue(result);
     when(cid.isNull()).thenReturn(Boolean.TRUE);
-    result = EntityExistenceHelpers.createEntityReturnWasCached(persistor, manager, cid, tid, TransactionID.NULL_ID, eid, 1, 1, configuration, true);
+    result = EntityExistenceHelpers.createEntityReturnWasCached(persistor, manager, cid, tid, TransactionID.NULL_ID, eid, 1, 1, configuration);
 // if the client id is null then the transaction was generated on the server and the return is never cached and the create never resent
     Assert.assertFalse(result);
   }

--- a/tc-server/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
+++ b/tc-server/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
@@ -67,7 +67,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.Mockito;
@@ -167,8 +166,9 @@ public class ReplicatedTransactionHandlerTest {
     when(msg.messageFrom()).thenReturn(sid);
     when(msg.getActivities()).thenReturn(Collections.singletonList(activity));
     when(entity.getCodec()).thenReturn(mock(MessageCodec.class));
+    when(entity.canDelete()).thenReturn(true);
     when(this.entityManager.getEntity(any())).thenReturn(Optional.empty());
-    when(this.entityManager.createEntity(any(), anyLong(), anyLong(), anyBoolean())).then((invoke)->{
+    when(this.entityManager.createEntity(any(), anyLong(), anyLong())).then((invoke)->{
       when(this.entityManager.getEntity(any())).thenReturn(Optional.of(entity));
       return entity;
     });
@@ -259,7 +259,7 @@ public class ReplicatedTransactionHandlerTest {
       ((ResultCapture)in.getArguments()[2]).complete(new byte[0]);
       return null;
     }).when(entity).addRequestMessage(any(), any(), any());
-    when(entityManager.createEntity(any(), anyLong(), anyLong(), anyBoolean())).thenReturn(entity);
+    when(entityManager.createEntity(any(), anyLong(), anyLong())).thenReturn(entity);
     when(entityManager.getEntity(EntityDescriptor.NULL_ID)).thenReturn(Optional.empty());
     this.rth.getEventHandler().handleEvent(start);
     this.rth.getEventHandler().handleEvent(end);
@@ -291,7 +291,7 @@ public class ReplicatedTransactionHandlerTest {
       }
     });
     
-    when(this.entityManager.createEntity(Mockito.eq(entityID), Mockito.anyLong(), anyLong(), anyBoolean())).thenReturn(entity);
+    when(this.entityManager.createEntity(Mockito.eq(entityID), Mockito.anyLong(), anyLong())).thenReturn(entity);
     this.rth.getEventHandler().handleEvent(ReplicationMessage.createLocalContainer(SyncReplicationActivity.createStartSyncMessage(new SyncReplicationActivity.EntityCreationTuple[0])));
     ByteArrayOutputStream bout = new ByteArrayOutputStream();
     ObjectOutputStream out = new ObjectOutputStream(bout);
@@ -316,12 +316,13 @@ public class ReplicatedTransactionHandlerTest {
     ManagedEntity entity = mock(ManagedEntity.class);
     MessageCodec codec = mock(MessageCodec.class);
     when(this.entityManager.getEntity(any())).thenReturn(Optional.empty());
-    when(this.entityManager.createEntity(any(), anyLong(), anyLong(), anyBoolean())).then((invoke)->{
+    when(this.entityManager.createEntity(any(), anyLong(), anyLong())).then((invoke)->{
       when(this.entityManager.getEntity(any())).thenReturn(Optional.of(entity));
       return entity;
     });
     when(this.entityManager.getMessageCodec(any())).thenReturn(codec);
     when(entity.getCodec()).thenReturn(codec);
+    when(entity.canDelete()).thenReturn(true);
     
     Mockito.doAnswer(invocation->{
       ServerEntityRequest req = (ServerEntityRequest)invocation.getArguments()[0];


### PR DESCRIPTION
For this change, the logic for determining if an entity can be deleted is based on whether or not the entity is a PermanentEntity.  The previous approach determined an entity's deletion status based on whether or not the entity creation requestor was a client.  That approach did not work for dynamic scaling whereby entities can be created by non-clients (i.e. the server itself).