### PR TITLE
Support env memory overrides to start-tc-server

### DIFF
--- a/terracotta-kit/src/assemble/server/bin/start-tc-server.bat
+++ b/terracotta-kit/src/assemble/server/bin/start-tc-server.bat
@@ -54,6 +54,10 @@ if not defined JAVA_HOME (
   exit /b 1
 )
 
+if not defined JAVA_MEMORY_OPTS (
+ set JAVA_MEMORY_OPTS=-Xms256m -Xmx2g
+)
+
 for %%C in ("-d64 -server -XX:MaxDirectMemorySize=1048576g" ^
 			"-server -XX:MaxDirectMemorySize=1048576g" ^
 			"-d64 -client  -XX:MaxDirectMemorySize=1048576g" ^
@@ -74,7 +78,7 @@ exit /b 1
 
 :setJavaOptsAndClasspath
 
-set OPTS=%SERVER_OPT% -Xms256m -Xmx2g -XX:+HeapDumpOnOutOfMemoryError
+set OPTS=%SERVER_OPT% %JAVA_MEMORY_OPTS% -XX:+HeapDumpOnOutOfMemoryError
 set OPTS=%OPTS% "-Dtc.install-root=%TC_SERVER_DIR%"
 set JAVA_OPTS=%OPTS% %JAVA_OPTS%
 

--- a/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
+++ b/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
@@ -18,6 +18,9 @@
 #
 #
 
+# the solaris 64-bit JVM has a bug that makes it fail to allocate more than 2GB of offheap when
+# the max heap is <= 2G, hence we set the heap size to a bit more than 2GB
+JAVA_MEMORY_OPTS=${JAVA_MEMORY_OPTS:-"-Xms256m -Xmx2049m"}
 TC_SERVER_DIR=$(dirname "$(cd "$(dirname "$0")";pwd)")
 
 # this will only happen if using sag installer
@@ -41,6 +44,7 @@ do
     # accept the first one that works
     "${JAVA_HOME}/bin/java" $JAVA_COMMAND_ARGS -version > /dev/null 2>&1 && break
 done
+JAVA_COMMAND_ARGS="${JAVA_COMMAND_ARGS} ${JAVA_MEMORY_OPTS}"
 
 #rmi.dgc.server.gcInterval is set an year to avoid system gc in case authentication is enabled
 #users may change it accordingly


### PR DESCRIPTION
FYI I did this as a daggy but looking at branches this may not be needed.  Let me know and I can rebase on the tip of master and maybe make it simpler.