### PR TITLE
Fix listening timing hole

### DIFF
--- a/common/src/main/java/com/tc/net/protocol/tcm/NetworkListener.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/NetworkListener.java
@@ -36,5 +36,7 @@ public interface NetworkListener {
   public InetAddress getBindAddress();
 
   public int getBindPort();
+  
+  public boolean isStarted();
 
 }

--- a/common/src/main/java/com/tc/net/protocol/tcm/NetworkListenerImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/NetworkListenerImpl.java
@@ -143,7 +143,8 @@ class NetworkListenerImpl implements NetworkListener {
     return started;
   }
 
-  private boolean isStarted() {
+  @Override
+  public boolean isStarted() {
     Future<Boolean> startDone = null;
     synchronized (this) {
       if (started == null) {

--- a/common/src/main/java/com/tc/properties/TCPropertiesImpl.java
+++ b/common/src/main/java/com/tc/properties/TCPropertiesImpl.java
@@ -89,6 +89,7 @@ public class TCPropertiesImpl implements TCProperties {
     // this happens last -- system properties have highest precedence
     processSystemProperties();
 
+    printLocalProperties();
     warnForOldProperties();
   }
 
@@ -282,6 +283,12 @@ public class TCPropertiesImpl implements TCProperties {
       }
     }
     return sb.toString();
+  }
+  
+  private void printLocalProperties() {
+    if (!localTcProperties.isEmpty()) {
+      logger.info("using the following local tc properties = {" + sortedPropertiesToString() + " }");
+    }
   }
 
   @Override

--- a/common/src/main/java/com/tc/util/properties/TCPropertyStore.java
+++ b/common/src/main/java/com/tc/util/properties/TCPropertyStore.java
@@ -49,6 +49,10 @@ public class TCPropertyStore {
   public synchronized int size() {
     return props.size();
   }
+  
+  public boolean isEmpty() {
+    return props.isEmpty();
+  }
 
   public synchronized String[] keysArray() {
     String[] keys = new String[props.size()];

--- a/galvan-support/src/test/java/org/terracotta/functional/DirectConnectIT.java
+++ b/galvan-support/src/test/java/org/terracotta/functional/DirectConnectIT.java
@@ -1,0 +1,71 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.functional;
+
+import java.net.InetSocketAddress;
+import java.util.Properties;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terracotta.connection.ConnectionException;
+import org.terracotta.connection.ConnectionPropertyNames;
+import org.terracotta.connection.Diagnostics;
+import org.terracotta.connection.DiagnosticsFactory;
+import org.terracotta.exception.ConnectionClosedException;
+import org.terracotta.testing.rules.BasicExternalClusterBuilder;
+import org.terracotta.testing.rules.Cluster;
+
+/**
+ *
+ */
+public class DirectConnectIT {
+
+  Logger LOGGER = LoggerFactory.getLogger(DirectConnectIT.class);
+  
+  @ClassRule
+  public static final Cluster CLUSTER = BasicExternalClusterBuilder.newCluster(2)
+          .withFailoverPriorityVoterCount(0)
+//          .withSystemProperty("logback.debug", "true")
+          .withClientReconnectWindowTime(30)
+      .build();
+
+  @Test
+  public void testPassiveCrash() throws Exception {
+    LOGGER.info("starting test");
+    String[] clusterHostPorts = CLUSTER.getClusterHostPorts();
+    CLUSTER.expectCrashes(true);
+    CLUSTER.getClusterControl().waitForRunningPassivesInStandby();
+    CLUSTER.getClusterControl().terminateActive();
+    Properties prop = new Properties();
+    prop.setProperty(ConnectionPropertyNames.CONNECTION_TIMEOUT, "-1");
+    for (String hostPort: clusterHostPorts) {
+      String[] hp = hostPort.split("[:]");
+      InetSocketAddress inet = InetSocketAddress.createUnresolved(hp[0], Integer.parseInt(hp[1]));
+      try (Diagnostics d = DiagnosticsFactory.connect(inet, prop)) {
+        System.out.println(d.getState());
+      } catch (Exception to) {
+        to.printStackTrace();
+      }
+
+    }
+  }
+
+}

--- a/galvan-support/src/test/java/org/terracotta/testing/rules/BasicExternalClusterActivePassiveIT.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/rules/BasicExternalClusterActivePassiveIT.java
@@ -37,7 +37,7 @@ public class BasicExternalClusterActivePassiveIT {
 
   @Rule
   public final Cluster CLUSTER = BasicExternalClusterBuilder.newCluster(3).withClientReconnectWindowTime(30)
-      .withTcProperty("server.entity.processor.threads", "16")
+      .withTcProperty("server.entity.processor.threads", "16").inline(false)
       .build();
 
   @Test

--- a/tc-server/src/main/java/com/tc/l2/state/ConsistencyManager.java
+++ b/tc-server/src/main/java/com/tc/l2/state/ConsistencyManager.java
@@ -23,7 +23,6 @@ import com.tc.logging.TCLogging;
 import com.tc.net.NodeID;
 import com.tc.objectserver.impl.Topology;
 import org.terracotta.configuration.FailoverBehavior;
-import org.terracotta.configuration.ServerConfiguration;
 import org.slf4j.Logger;
 
 import java.util.Collection;

--- a/tc-server/src/main/java/com/tc/l2/state/ServerVoterManagerImpl.java
+++ b/tc-server/src/main/java/com/tc/l2/state/ServerVoterManagerImpl.java
@@ -88,6 +88,7 @@ public class ServerVoterManagerImpl extends AbstractTerracottaMBean implements S
 
   @Override
   public long heartbeat(String id) {
+    logger.debug("received heartbeat {}", id);
     Long val = voters.computeIfPresent(id, (key, timeStamp) -> {
       long currentTime = timeSource.currentTimeMillis();
       // make sure some crazy time lapse didn't happen since last heartbeat
@@ -186,7 +187,7 @@ public class ServerVoterManagerImpl extends AbstractTerracottaMBean implements S
 
   @Override
   public boolean deregisterVoter(String id) {
-    System.out.println("Deregister " + id);
+    logger.info("Deregister " + id);
     return !votingInProgress ? voters.remove(id) != null : false;
   }
 

--- a/tc-server/src/main/java/com/tc/l2/state/StateManagerImpl.java
+++ b/tc-server/src/main/java/com/tc/l2/state/StateManagerImpl.java
@@ -119,7 +119,7 @@ public class StateManagerImpl implements StateManager {
     return this.state;
   }
   
-  private synchronized Enrollment createVerificationEnrollment() {
+  private Enrollment createVerificationEnrollment() {
     return availabilityMgr.createVerificationEnrollment(syncedTo, weightsFactory);
   }
   

--- a/tc-server/src/main/java/com/tc/objectserver/impl/DiagnosticsHandler.java
+++ b/tc-server/src/main/java/com/tc/objectserver/impl/DiagnosticsHandler.java
@@ -77,6 +77,7 @@ public class DiagnosticsHandler extends AbstractEventHandler<TCAction> {
     String raw = new String(TCByteBufferFactory.unwrap(data), set);
     String[] cmd = raw.split(" ");
     byte[] result = null;
+    long startTime = System.currentTimeMillis();
     ChannelID channelID = message.getChannel().getChannelID();
     try {
       GuardianContext.setCurrentChannelID(channelID);
@@ -158,6 +159,11 @@ public class DiagnosticsHandler extends AbstractEventHandler<TCAction> {
       DiagnosticResponse resp = (DiagnosticResponse)channel.createMessage(TCMessageType.DIAGNOSTIC_RESPONSE);
       resp.setResponse(msg.getTransactionID(), result);
       resp.send();
+      long end = System.currentTimeMillis();
+      if (end - startTime > 500) {
+        logger.warn("command {} took {}ms", raw, end - startTime);
+      }
+      logger.debug("command {} took {}ms and returned {}", raw, end - startTime, new String(result, set));
     } catch (Throwable t) {
       logger.warn("caught exception while running diagnostic command: " + Arrays.toString(cmd), t);
       DiagnosticResponse resp = (DiagnosticResponse)channel.createMessage(TCMessageType.DIAGNOSTIC_RESPONSE);

--- a/tc-server/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/tc-server/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -1198,8 +1198,12 @@ public class DistributedObjectServer {
       }
     }
   }
+  
+  public boolean isL1Listening() {
+    return this.l1Listener.isStarted();
+  }
 
-  public void startL1Listener(Set<ConnectionID> existingConnections) {
+  private void startL1Listener(Set<ConnectionID> existingConnections) {
     while (!server.isStopped()) {
       try {
         this.l1Diagnostics.stop(1000L);
@@ -1234,7 +1238,7 @@ public class DistributedObjectServer {
                        + " successfully, and is now ready for work.");
   }
 
-  public void startDiagnosticListener() {
+  private void startDiagnosticListener() {
     try {
       this.l1Diagnostics.start(Collections.emptySet());
       consoleLogger.info("Terracotta Server instance has started diagnostic listening on  {}", this.l1Diagnostics);

--- a/tc-server/src/test/java/com/tc/l2/state/ConsistencyManagerImplTest.java
+++ b/tc-server/src/test/java/com/tc/l2/state/ConsistencyManagerImplTest.java
@@ -25,7 +25,6 @@ import com.tc.util.Assert;
 import org.terracotta.configuration.FailoverBehavior;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.AfterClass;

--- a/tc-server/src/test/java/com/tc/l2/state/SafeStartupManagerImplTest.java
+++ b/tc-server/src/test/java/com/tc/l2/state/SafeStartupManagerImplTest.java
@@ -28,12 +28,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class SafeStartupManagerImplTest {
 
   @Test
   public void requestStartToActiveTransitionWithPeersJoining() {
-    SafeStartupManagerImpl safeStartupManager = new SafeStartupManagerImpl(true, 2, mock(ConsistencyManager.class));
+    ConsistencyManager consistency = mock(ConsistencyManager.class);
+    when(consistency.requestTransition(any(ServerMode.class), any(NodeID.class), eq(null), any(ConsistencyManager.Transition.class))).thenReturn(Boolean.TRUE);
+    SafeStartupManagerImpl safeStartupManager = new SafeStartupManagerImpl(true, 2, consistency);
     assertThat(safeStartupManager.requestTransition(ServerMode.START, mock(NodeID.class), ConsistencyManager.Transition.MOVE_TO_ACTIVE), is(false));
 
     safeStartupManager.nodeJoined(mock(NodeID.class));  //First node joins
@@ -45,7 +48,9 @@ public class SafeStartupManagerImplTest {
 
   @Test
   public void requestStartToActiveTransitionWithExternalIntervention() {
-    SafeStartupManagerImpl safeStartupManager = new SafeStartupManagerImpl(true, 2, mock(ConsistencyManager.class));
+    ConsistencyManager consistency = mock(ConsistencyManager.class);
+    when(consistency.requestTransition(any(ServerMode.class), any(NodeID.class), eq(null), any(ConsistencyManager.Transition.class))).thenReturn(Boolean.TRUE);
+    SafeStartupManagerImpl safeStartupManager = new SafeStartupManagerImpl(true, 2, consistency);
     assertThat(safeStartupManager.requestTransition(ServerMode.START, mock(NodeID.class), ConsistencyManager.Transition.MOVE_TO_ACTIVE), is(false));
 
     safeStartupManager.nodeJoined(mock(NodeID.class));  //First node joins
@@ -62,7 +67,16 @@ public class SafeStartupManagerImplTest {
     safeStartupManager.requestTransition(ServerMode.PASSIVE, mock(NodeID.class), ConsistencyManager.Transition.MOVE_TO_ACTIVE);
     verify(consistencyManager).requestTransition(eq(ServerMode.PASSIVE), any(NodeID.class), any(), eq(ConsistencyManager.Transition.MOVE_TO_ACTIVE));
   }
-
+  
+  @Test
+  public void requestStartupTransisiton() {
+    ConsistencyManager consistency = mock(ConsistencyManager.class);
+    when(consistency.requestTransition(any(ServerMode.class), any(NodeID.class), eq(null), any(ConsistencyManager.Transition.class))).thenReturn(Boolean.TRUE); 
+    SafeStartupManagerImpl safeStartupManager = new SafeStartupManagerImpl(true, 2, consistency);
+    assertTrue(safeStartupManager.requestTransition(ServerMode.START, mock(NodeID.class), ConsistencyManager.Transition.CONNECT_TO_ACTIVE));
+    verify(consistency).requestTransition(eq(ServerMode.START), any(NodeID.class), any(), eq(ConsistencyManager.Transition.CONNECT_TO_ACTIVE));
+  }
+  
   @Test
   public void allowLastTransitionDelegationForNonStartupTransition() {
     ConsistencyManager consistencyManager = mock(ConsistencyManager.class);

--- a/voter/src/main/java/org/terracotta/voter/ClientVoterManagerImpl.java
+++ b/voter/src/main/java/org/terracotta/voter/ClientVoterManagerImpl.java
@@ -86,7 +86,9 @@ public class ClientVoterManagerImpl implements ClientVoterManager {
 
   @Override
   public long heartbeat(String id) throws TimeoutException {
+    long time = System.currentTimeMillis();
     String result = processInvocation(diagnostics.invokeWithArg(MBEAN_NAME, "heartbeat", id));
+    LOGGER.debug("voting result {} time {} id {} host {} thread {}", result, System.currentTimeMillis() - time, id, hostPort, Thread.currentThread().getName());
     long nr = Long.parseLong(result);
     if (nr <= 0) {
       voting = false;


### PR DESCRIPTION
The server can report that it is accepting clients when the listening port is not bound but the rest of the stack is built.  Only report that clients are being accepted once the TSA is bound to the socket listener.  

Also fixed is NPE errors when the server is checked for state before being started.