### PR TITLE
Remove POM repositories elements & bump terracotta-utilities version

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -287,36 +287,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <repository>
-      <id>terracotta-snapshots</id>
-      <url>https://www.terracotta.org/download/reflector/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>terracotta-releases</id>
-      <url>https://www.terracotta.org/download/reflector/releases</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>https://www.terracotta.org/download/reflector/snapshots</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>https://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>
-  </pluginRepositories>
 </project>

--- a/connection-impl/pom.xml
+++ b/connection-impl/pom.xml
@@ -43,7 +43,7 @@
       <artifactId>tc-client</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
-    </dependency> 
+    </dependency>
     <dependency>
       <groupId>org.terracotta.internal</groupId>
       <artifactId>common-spi</artifactId>
@@ -108,17 +108,4 @@
       </plugin>
     </plugins>
   </reporting>
-
-  <repositories>
-    <repository>
-      <id>terracotta-repository</id>
-      <url>https://www.terracotta.org/download/reflector/releases</url>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-repository</id>
-      <url>https://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>
-  </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>terracotta-parent</artifactId>
-    <version>5.19</version>
+    <version>5.21</version>
     <relativePath/>
   </parent>
 
@@ -41,11 +41,11 @@
     <spotbugs.skip>true</spotbugs.skip>
     <exclude-spotbugs-dependency>true</exclude-spotbugs-dependency>
 
-    <terracotta-apis.version>1.8.1</terracotta-apis.version>
-    <terracotta-configuration.version>10.7.1</terracotta-configuration.version>
-    <galvan.version>1.6.3</galvan.version>
-    <tc-tripwire.version>1.0.2</tc-tripwire.version>
-    <terracotta-utilities.version>0.0.9</terracotta-utilities.version>
+    <terracotta-apis.version>1.8.2</terracotta-apis.version>
+    <terracotta-configuration.version>10.7.2</terracotta-configuration.version>
+    <galvan.version>1.6.4</galvan.version>
+    <tc-tripwire.version>1.0.3</tc-tripwire.version>
+    <terracotta-utilities.version>0.0.13</terracotta-utilities.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
In addition to bumping the version of terracotta-utilities used,
this commit reduces the repositories and pluginRepositories elements
to those required to locate the direct dependencies of this project.
More specifically, the SNAPSHOT repositories are removed -- inclusion
of SNAPSHOT repositories interferes with the use of range-based version
specifications.  Should a developer want to include a SNAPSHOT release
in a build, local addition of the SNAPSHOT repositories can be employed.