### PR TITLE
Use version range for logging components & terracotta-utilities

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -42,8 +42,10 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <slf4j.version>1.7.32</slf4j.version>
-    <logback.version>1.2.11</logback.version>
+    <slf4j.base.version>1.7.32</slf4j.base.version>
+    <slf4j.range.version>[${slf4j.base.version},1.7.9999)</slf4j.range.version>
+    <logback.base.version>1.2.11</logback.base.version>
+    <logback.range.version>[${logback.base.version},1.2.9999)</logback.range.version>
     <management-core-version>2.0.8</management-core-version>
 
     <gmaven-plugin.version>1.4</gmaven-plugin.version>
@@ -130,17 +132,23 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
+        <version>${slf4j.range.version}</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
-        <version>${logback.version}</version>
+        <version>${logback.range.version}</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>${logback.version}</version>
+        <version>${logback.range.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.terracotta</groupId>
@@ -214,7 +222,7 @@
       <dependency>
         <groupId>org.terracotta</groupId>
         <artifactId>terracotta-utilities-port-chooser</artifactId>
-        <version>${terracotta-utilities.version}</version>
+        <version>${terracotta-utilities.range.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -52,6 +52,12 @@ Apache Ivy version: 2.2.0 20100923230623
     <dependency>
       <groupId>org.terracotta.internal</groupId>
       <artifactId>tc-messaging</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.terracotta.internal</groupId>

--- a/galvan-support/pom.xml
+++ b/galvan-support/pom.xml
@@ -57,6 +57,12 @@ limitations under the License.
       <groupId>org.terracotta</groupId>
       <artifactId>galvan</artifactId>
       <version>${galvan.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.terracotta</groupId>
+          <artifactId>terracotta-utilities-port-chooser</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.terracotta</groupId>
@@ -66,6 +72,12 @@ limitations under the License.
       <groupId>org.terracotta.internal</groupId>
       <artifactId>tc-server</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.terracotta</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,10 +42,11 @@
     <exclude-spotbugs-dependency>true</exclude-spotbugs-dependency>
 
     <terracotta-apis.version>1.8.2</terracotta-apis.version>
-    <terracotta-configuration.version>10.7.2</terracotta-configuration.version>
-    <galvan.version>1.6.4</galvan.version>
-    <tc-tripwire.version>1.0.3</tc-tripwire.version>
-    <terracotta-utilities.version>0.0.13</terracotta-utilities.version>
+    <terracotta-configuration.version>10.7.3</terracotta-configuration.version>
+    <galvan.version>1.6.5</galvan.version>
+    <tc-tripwire.version>1.0.4</tc-tripwire.version>
+    <terracotta-utilities.base.version>0.0.14</terracotta-utilities.base.version>
+    <terracotta-utilities.range.version>[${terracotta-utilities.base.version},)</terracotta-utilities.range.version>
   </properties>
 
   <modules>

--- a/tc-client/pom.xml
+++ b/tc-client/pom.xml
@@ -43,6 +43,10 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
     <!-- entity API needs to be loaded in app class loader layer as entities too fall into it -->
     <dependency>
       <groupId>org.terracotta</groupId>

--- a/terracotta-kit/pom.xml
+++ b/terracotta-kit/pom.xml
@@ -38,6 +38,12 @@
           <classifier>jar-with-dependencies</classifier>
           <version>${project.version}</version>
           <scope>runtime</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
         <dependency>
           <groupId>org.terracotta.test</groupId>


### PR DESCRIPTION
This commit introduces version ranges for Logback and SLF4J.

This commit also introduces a version range for terracotta-utilities
and bumps the base version.  The upper bound is left open.

To prevent depdendency convergence conflicts, several exclusions
(mostly for SLF4J) are also included.