### PR TITLE
BUGFIX: logback-ext.xml was not considered due to a wrong classpath entry in tc-server.jar

### DIFF
--- a/tc-server/pom.xml
+++ b/tc-server/pom.xml
@@ -167,6 +167,9 @@
                 <manifest>
                   <addClasspath>true</addClasspath>
                 </manifest>
+                <manifestEntries>
+                  <Class-Path>.</Class-Path>
+                </manifestEntries>
               </archive>
           </configuration>
         </plugin>


### PR DESCRIPTION
### Description of the issue

The `logback.ext.xml` file in server/lib has the following doc:

```
  You are free to define and use your own appenders and loggers here.
  You can also use predefined TC appenders.
  Use the appender name "TC_BASE" to refer to the Terracotta base appender that logs to the terracotta-server.log file.
  Use the appender name "STDOUT" to refer to the Terracotta console appender.
  -->

  <!--
    You can change the Terracotta root log level by uncommenting the following block and changing the level.
  -->
  <!--<root level="DEBUG">
    <appender-ref ref="TC_BASE" />
  </root>-->

  <!--
    You can customize log levels for specific loggers by defining config blocks as follows:
  -->
  <!--<logger name="some.specific.logger.name" level="DEBUG">
    <appender-ref ref="TC_BASE" />
  </logger>-->
```

While implementing Json logging, I saw that this does not work at all.

Tried also:

```xml
<included>
  <logger name="org.terracotta.console" level="TRACE">
    <appender-ref ref="STDOUT"/>
  </logger>
  <root level="TRACE">
    <appender-ref ref="STDOUT"/>
  </root>
</included>
```

and

```xml
<included>
  <logger name="org.terracotta.console" level="TRACE">
    <appender-ref ref="TC_BASE"/>
  </logger>
  <root level="TRACE">
    <appender-ref ref="TC_BASE"/>
  </root>
</included>
```

and

```xml
<included>

  <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
    <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
      <layout class="com.terracottatech.cloud.logging.json.TerracottaJsonLayout">
        <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter"/>
        <timestampFormat>yyyy-MM-dd' 'HH:mm:ss.SSS</timestampFormat>
        <appendLineSeparator>true</appendLineSeparator>
        <file>server.log</file>
        <product>Terracotta DB</product>
      </layout>
    </encoder>
  </appender>

  <logger name="org.terracotta.console" level="INFO">
    <appender-ref ref="JSON"/>
  </logger>

  <root level="INFO">
    <appender-ref ref="JSON"/>
  </root>
</included>
```

The problem is caused by how classpath are defined. When using manifest entries, Classpath attributes prevails and in this case the `tc-server.,jar` does not declare the lib folder as being part of the classpath.

Here is the classpath entry:

`Class-Path: slf4j-api-1.7.25.jar configuration-provider-5.9.2.jar logbac
 k-classic-1.2.3.jar logback-core-1.2.3.jar build-data-5.9.2.jar server-
 spi-5.9.2.jar common-spi-5.9.2.jar tc-tripwire-appenders-1.0.2.jar enti
 ty-server-api-1.8.1.jar entity-common-api-1.8.1.jar monitoring-support-
 1.8.1.jar packaging-support-1.8.1.jar common-5.9.2.jar tc-messaging-5.9
 .2.jar tc-tripwire-plugin-1.0.2.jar management-5.9.2.jar`

It should end with a `.` at the end so that the `logback-ext` file and its content get considered in the classpath.

`Class-Path: slf4j-api-1.7.25.jar configuration-provider-5.9.2.jar logbac
 k-classic-1.2.3.jar logback-core-1.2.3.jar build-data-5.9.2.jar server-
 spi-5.9.2.jar common-spi-5.9.2.jar tc-tripwire-appenders-1.0.2.jar enti
 ty-server-api-1.8.1.jar entity-common-api-1.8.1.jar monitoring-support-
 1.8.1.jar packaging-support-1.8.1.jar common-5.9.2.jar tc-messaging-5.9
 .2.jar tc-tripwire-plugin-1.0.2.jar management-5.9.2.jar .`

Tested this patch that locally and it works fine.