### PR TITLE
IPv6 fix

### DIFF
--- a/tc-server/src/main/java/com/tc/net/groups/Node.java
+++ b/tc-server/src/main/java/com/tc/net/groups/Node.java
@@ -86,7 +86,9 @@ public class Node {
   }
 
   private String getName() {
-    return host + DELIMITER + port;
+    // The node name is passed when constructing a new ServerID()
+    // Other callers of new ServerID() are using getStringForm#getStringForm()
+    return (host.contains(":") ? ("[" + host + "]") : host) + DELIMITER + port;
   }
 
   private static String getHost(String hostPort) {


### PR DESCRIPTION
Implementors of `NetworkTranslator` can receive a badly formed host:port in case host in an IPv6 address.

See the ugly hack we had to do in DC a the moment to work around that: 

https://github.com/Terracotta-OSS/terracotta-platform/blob/master/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DynamicConfigNetworkTranslator.java#L70-L79