### PR TITLE
More data corruption

### DIFF
--- a/common/src/main/java/com/tc/net/basic/BasicConnectionManager.java
+++ b/common/src/main/java/com/tc/net/basic/BasicConnectionManager.java
@@ -70,15 +70,15 @@ public class BasicConnectionManager implements TCConnectionManager {
   }
 
   @Override
-  public void asynchCloseAllConnections() {
-    new Thread(()->closeAllConnections(1000)).start();
+  public void closeAllConnections() {
+    Arrays.asList(getAllConnections()).forEach(c->c.close());
   }
 
   @Override
-  public void closeAllConnections(long timeout) {
-    Arrays.asList(getAllConnections()).forEach(c->c.close(timeout));
+  public void asynchCloseAllConnections() {
+    Arrays.asList(getAllConnections()).forEach(c->c.asynchClose());
   }
-
+  
   @Override
   public void closeAllListeners() {
     throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
@@ -86,7 +86,7 @@ public class BasicConnectionManager implements TCConnectionManager {
 
   @Override
   public void shutdown() {
-    closeAllConnections(1000);
+    asynchCloseAllConnections();
   }
 
   @Override

--- a/common/src/main/java/com/tc/net/core/TCConnectionManager.java
+++ b/common/src/main/java/com/tc/net/core/TCConnectionManager.java
@@ -66,7 +66,7 @@ public interface TCConnectionManager extends PrettyPrintable {
    */
   public void asynchCloseAllConnections();
 
-  public void closeAllConnections(long timeout);
+  public void closeAllConnections();
 
   /**
    * Close all listeners created through this connection manager instance

--- a/common/src/main/java/com/tc/net/core/TCConnectionManagerImpl.java
+++ b/common/src/main/java/com/tc/net/core/TCConnectionManagerImpl.java
@@ -44,6 +44,7 @@ import com.tc.net.protocol.TCProtocolAdaptor;
 import com.tc.properties.TCPropertiesConsts;
 import com.tc.properties.TCPropertiesImpl;
 import com.tc.text.PrettyPrintable;
+import java.util.concurrent.Future;
 
 /**
  * The {@link TCConnectionManager} implementation.
@@ -176,25 +177,24 @@ public class TCConnectionManagerImpl implements TCConnectionManager {
   }
 
   @Override
-  public void closeAllConnections(long timeout) {
-    closeAllConnections(false, timeout);
+  public void closeAllConnections() {
+    closeAllConnections(false);
   }
-
+  
   @Override
   public void asynchCloseAllConnections() {
-    closeAllConnections(true, 0);
+    closeAllConnections(true);
   }
 
-  private void closeAllConnections(boolean async, long timeout) {
+  private void closeAllConnections(boolean async) {
     TCConnection[] conns = getAllConnections();
 
     logger.info("closing {} connection/s for {}", conns.length, this.comm.toString());
     for (TCConnection conn : conns) {
       try {
-        if (async) {
-          conn.asynchClose();
-        } else {
-          conn.close(timeout);
+        Future<Void> c = conn.asynchClose();
+        if (!async) {
+          c.get();
         }
       } catch (Exception e) {
         logger.error("Exception trying to close " + conn, e);

--- a/common/src/main/java/com/tc/net/protocol/tcm/NetworkListenerImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/NetworkListenerImpl.java
@@ -18,7 +18,6 @@
  */
 package com.tc.net.protocol.tcm;
 
-import com.tc.net.TCSocketAddress;
 import com.tc.net.core.TCListener;
 import com.tc.net.protocol.transport.ConnectionID;
 import com.tc.net.protocol.transport.ConnectionIDFactory;

--- a/common/src/main/java/com/tc/net/protocol/tcm/TCMessageParser.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/TCMessageParser.java
@@ -67,8 +67,8 @@ class TCMessageParser {
     if (type == null) {
       throw new RuntimeException("Can't find message type for type: " + msgType);
     }
-
-    TCAction converted = factory.createMessage(source, type, hdr, new TCByteBufferInputStream(msgData));
+    
+    TCAction converted = factory.createMessage(source, type, hdr, new TCByteBufferInputStream(msgData, msg.stealCompleteAction()));
     
     return converted;
   }

--- a/common/src/main/java/com/tc/net/protocol/transport/ClientMessageTransport.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ClientMessageTransport.java
@@ -140,7 +140,7 @@ public class ClientMessageTransport extends MessageTransportBase {
     } catch (CommStackMismatchException | IOException | MaxConnectionsExceededException | TCTimeoutException | RuntimeException e) {
       finishOpenWithException(e);
       if (connection != null) {
-        connection.close(1000);
+        connection.close();
       }
       throw e;
     }
@@ -162,10 +162,10 @@ public class ClientMessageTransport extends MessageTransportBase {
     try {
       connection.connect(sa, this.timeout);
     } catch (IOException e) {
-      connection.close(100);
+      connection.close();
       throw e;
     } catch (TCTimeoutException e) {
-      connection.close(100);
+      connection.close();
       throw e;
     }
     return connection;

--- a/common/src/main/java/com/tc/net/protocol/transport/MessageTransportBase.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/MessageTransportBase.java
@@ -342,7 +342,7 @@ abstract class MessageTransportBase extends AbstractMessageTransport implements 
   protected void clearConnection() {
     TCConnection conn;
     if ((conn = getConnection()) != null) {
-      conn.close(10000);
+      conn.close();
       conn.removeListener(this);
       this.connection = null;
       resetIfNotEnd();

--- a/common/src/test/java/com/tc/net/basic/BasicConnectionTest.java
+++ b/common/src/test/java/com/tc/net/basic/BasicConnectionTest.java
@@ -102,7 +102,7 @@ public class BasicConnectionTest {
         assertEquals(expResult, instance.getConnectTime());
         instance.connect(new InetSocketAddress(server.getLocalPort()), 0);
         assertNotEquals(expResult, instance.getConnectTime());
-        instance.close(0);
+        instance.close();
       }
     }
   }
@@ -131,7 +131,7 @@ public class BasicConnectionTest {
         when(msg.getEntireMessageData()).thenReturn(new TCByteBuffer[] { mock(TCByteBuffer.class) });
         instance.putMessage(msg);
         assertTrue(idleTime > instance.getIdleTime());
-        instance.close(0);
+        instance.close();
       } catch (Exception e) {
         e.printStackTrace();
       }
@@ -155,7 +155,7 @@ public class BasicConnectionTest {
         long idleTime = instance.getIdleTime();
         Thread.sleep(1000);
         assertNotEquals(idleTime, instance.getIdleTime());
-        instance.close(0);
+        instance.close();
       }
     }
   }
@@ -176,7 +176,7 @@ public class BasicConnectionTest {
         TCConnectionEventListener listener = mock(TCConnectionEventListener.class);
         instance.addListener(listener);
         instance.connect(new InetSocketAddress(server.getLocalPort()), 0);
-        instance.close(0);
+        instance.close();
         verify(listener).closeEvent(any(TCConnectionEvent.class));
         verify(listener).connectEvent(any(TCConnectionEvent.class));
       }

--- a/common/src/test/java/com/tc/net/core/NoReconnectThreadTest.java
+++ b/common/src/test/java/com/tc/net/core/NoReconnectThreadTest.java
@@ -144,7 +144,7 @@ public class NoReconnectThreadTest extends TCTestCase implements ChannelEventLis
 
           // closing all connections from server side
           System.err.println("XXX closing all client connections");
-          serverCommsMgr.getConnectionManager().closeAllConnections(1000);
+          serverCommsMgr.getConnectionManager().closeAllConnections();
 
           while (connections.get() != 0) {
             ThreadUtil.reallySleep(2000);

--- a/common/src/test/java/com/tc/net/core/TCConnectionImplTest.java
+++ b/common/src/test/java/com/tc/net/core/TCConnectionImplTest.java
@@ -48,6 +48,7 @@ import java.net.InetSocketAddress;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.SelectableChannel;
 import static junit.framework.TestCase.assertTrue;
+import static org.mockito.Mockito.doAnswer;
 
 /**
  *
@@ -148,6 +149,10 @@ public class TCConnectionImplTest {
         TCProtocolAdaptor adaptor = mock(TCProtocolAdaptor.class);
         TCConnectionManagerImpl mgr = new TCConnectionManagerImpl();
         final CoreNIOServices nioServiceThread = mock(CoreNIOServices.class);
+        doAnswer(a->{
+          ((Runnable)a.getArgument(1)).run();
+          return null;
+        }).when(nioServiceThread).cleanupChannel(any(SocketChannel.class), any(Runnable.class));
         SocketParams socketParams = new SocketParams();
         BufferManagerFactory bufferManagerFactory = mock(BufferManagerFactory.class);
 
@@ -168,7 +173,7 @@ public class TCConnectionImplTest {
         InetSocketAddress addr = new InetSocketAddress("localhost", port);
         conn.connect(addr, 0);
 
-        conn.close(100);
+        conn.close();
 
         verify(bufferManager).close();
       }
@@ -325,6 +330,6 @@ public class TCConnectionImplTest {
     } catch (InterruptedException ie) {
       ie.printStackTrace();
     }
-    conn.close(100);
+    conn.close();
   }
 }

--- a/common/src/test/java/com/tc/net/core/TCConnectionManagerTest.java
+++ b/common/src/test/java/com/tc/net/core/TCConnectionManagerTest.java
@@ -72,21 +72,21 @@ public class TCConnectionManagerTest extends TestCase {
 
     assertTrue(Arrays.asList(conns).containsAll(Arrays.asList(new Object[] { conn1, conn2, conn3 })));
 
-    clientConnMgr.closeAllConnections(5000);
+    clientConnMgr.closeAllConnections();
 
     assertEquals(0, clientConnMgr.getAllConnections().length);
 
     conn1 = clientConnMgr.createConnection(new NullProtocolAdaptor());
     assertEquals(1, clientConnMgr.getAllConnections().length);
 
-    conn1.close(5000);
+    conn1.close();
     assertEquals(0, clientConnMgr.getAllConnections().length);
 
     conn1 = clientConnMgr.createConnection(new NullProtocolAdaptor());
     assertEquals(1, clientConnMgr.getAllConnections().length);
     conn1.connect(lsnr.getBindSocketAddress(), 3000);
     assertEquals(1, clientConnMgr.getAllConnections().length);
-    conn1.close(5000);
+    conn1.close();
     assertEquals(0, clientConnMgr.getAllConnections().length);
   }
 
@@ -149,7 +149,7 @@ public class TCConnectionManagerTest extends TestCase {
       ThreadUtil.reallySleep(500);
     }
 
-    clientConnMgr.closeAllConnections(5000);
+    clientConnMgr.closeAllConnections();
     assertEquals(0, clientConnMgr.getAllConnections().length);
 
     while (serverConnMgr.getAllConnections().length > 0) {
@@ -191,9 +191,9 @@ public class TCConnectionManagerTest extends TestCase {
     assertEquals(2, activeConns.length);
     assertTrue(Arrays.asList(activeConns).containsAll(Arrays.asList(new Object[] { conn1, conn2 })));
 
-    conn1.close(5000);
-    conn2.close(5000);
-
+    conn1.close();
+    conn2.close();
+    
     assertEquals(0, clientConnMgr.getAllConnections().length);
 
     while (serverConnMgr.getAllConnections().length > 0) {

--- a/common/src/test/java/com/tc/net/core/TCWorkerCommManagerTest.java
+++ b/common/src/test/java/com/tc/net/core/TCWorkerCommManagerTest.java
@@ -203,7 +203,7 @@ public class TCWorkerCommManagerTest extends TCTestCase {
     Assert.assertEquals(1, ((TCCommImpl) commsMgr.getConnectionManager().getTcComm()).getWeightForWorkerComm(1));
     Assert.assertEquals(1, ((TCCommImpl) commsMgr.getConnectionManager().getTcComm()).getWeightForWorkerComm(2));
 
-    commsMgr.getConnectionManager().closeAllConnections(1000);
+    commsMgr.getConnectionManager().closeAllConnections();
 
     waitForWeight(commsMgr, 0, 0);
     waitForWeight(commsMgr, 1, 0);
@@ -401,7 +401,7 @@ public class TCWorkerCommManagerTest extends TCTestCase {
 
             // case 4: closing all connections from server side
             System.out.println("XXX closing all client connections");
-            commsMgr.getConnectionManager().closeAllConnections(5000);
+            commsMgr.getConnectionManager().closeAllConnections();
 
             // all clients should reconnect and should be distributed fairly among the worker comms.
 

--- a/common/src/test/java/com/tc/net/protocol/tcm/MessageChannelTest.java
+++ b/common/src/test/java/com/tc/net/protocol/tcm/MessageChannelTest.java
@@ -402,8 +402,8 @@ try {
     int port = lsnr.getBindPort();
 
     lsnr.stop(WAIT);
-    serverComms.getConnectionManager().closeAllConnections(WAIT);
-    clientComms.getConnectionManager().closeAllConnections(WAIT);
+    serverComms.getConnectionManager().closeAllConnections();
+    clientComms.getConnectionManager().closeAllConnections();
 
     for (int i = 0; i < 10; i++) {
       try {
@@ -447,7 +447,7 @@ try {
     clientChannel.open(serverAddress);
     assertEquals(1, clientChannel.getConnectAttemptCount());
     assertEquals(1, clientChannel.getConnectCount());
-    clientComms.getConnectionManager().closeAllConnections(WAIT);
+    clientComms.getConnectionManager().closeAllConnections();
     ThreadUtil.reallySleep(5000);
     assertEquals(1, clientChannel.getConnectAttemptCount());
     assertEquals(1, clientChannel.getConnectCount());
@@ -467,7 +467,7 @@ try {
     lsnr.stop(WAIT);
     assertEquals(0, serverComms.getAllListeners().length);
 
-    clientComms.getConnectionManager().closeAllConnections(5000);
+    clientComms.getConnectionManager().closeAllConnections();
     int count = clientChannel.getConnectAttemptCount();
     ThreadUtil.reallySleep(WAIT * 4);
     assertTrue(clientChannel.getConnectAttemptCount() + " vs " + count, clientChannel.getConnectAttemptCount() > count);
@@ -600,10 +600,10 @@ try {
             try {
               if (serverClose) {
                 logger.info("Initiating close on the SERVER side...");
-                serverComms.getConnectionManager().asynchCloseAllConnections();
+                serverComms.getConnectionManager().closeAllConnections();
               } else {
                 logger.info("Initiating close on the CLIENT side...");
-                clientComms.getConnectionManager().asynchCloseAllConnections();
+                clientComms.getConnectionManager().closeAllConnections();
               }
             } catch (Throwable t) {
               setError(t);

--- a/galvan-support/src/test/java/org/terracotta/testing/rules/DynamicPassiveRemovalIT.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/rules/DynamicPassiveRemovalIT.java
@@ -18,6 +18,7 @@
  */
 package org.terracotta.testing.rules;
 
+import java.net.InetSocketAddress;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.terracotta.connection.Connection;
@@ -29,8 +30,8 @@ import org.terracotta.connection.entity.EntityRef;
 
 import java.net.URI;
 import java.util.Properties;
-import java.util.concurrent.TimeoutException;
 import org.terracotta.connection.Diagnostics;
+import org.terracotta.connection.DiagnosticsFactory;
 
 
 public class DynamicPassiveRemovalIT {
@@ -79,14 +80,14 @@ public class DynamicPassiveRemovalIT {
     for (String hostPort: hostPorts) {
       Properties properties = new Properties();
       properties.setProperty(ConnectionPropertyNames.CONNECTION_TIMEOUT, "10000");
-      try (Connection connection = ConnectionFactory.connect(URI.create( "diagnostic://" + hostPort), properties)) {
+      String[] split = hostPort.split(":");
+      try (Diagnostics connection = DiagnosticsFactory.connect(InetSocketAddress.createUnresolved(split[0], Integer.parseInt(split[1])), properties)) {
+        System.out.println(hostPort + " -- " + connection.getState());
       } catch (ConnectionException exception) {
-        if (exception.getCause() instanceof TimeoutException) {
-          return hostPort;
-        }
+        return hostPort;
       }
     }
-
+    
     return null;
   }
 }

--- a/tc-messaging/src/main/java/com/tc/io/TCByteBufferInput.java
+++ b/tc-messaging/src/main/java/com/tc/io/TCByteBufferInput.java
@@ -45,8 +45,6 @@ public interface TCByteBufferInput extends TCDataInput {
 
   public void close();
 
-  public void mark(int readlimit);
-
   /**
    * This is a TC special version of mark() to be used in conjunction with tcReset()...We should eventually implement
    * the general purpose mark(int) method as specified by InputStream. NOTE: It has some unusual semantics that make it
@@ -61,8 +59,6 @@ public interface TCByteBufferInput extends TCDataInput {
   public TCByteBuffer read(int len);
 
   public int read();
-
-  public void reset();
 
   /**
    * Reset this input stream to the position recorded by the mark that is passed an input parameter.

--- a/tc-messaging/src/main/java/com/tc/net/core/TCConnection.java
+++ b/tc-messaging/src/main/java/com/tc/net/core/TCConnection.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.Map;
+import java.util.concurrent.Future;
 
 /**
  * Common interface for TC network connections
@@ -69,14 +70,14 @@ public interface TCConnection extends NetworkMessageSink {
   /**
    * Close this connection. The actual close happens asynchronously to this call.
    */
-  public void asynchClose();
+  public Future<Void> asynchClose();
 
   /**
    * Close this connection, blocking for at most the given timeout value
    * 
    * @return true/false whether the connection closed in time
    */
-  public boolean close(long timeout);
+  public void close();
 
   /**
    * Connect synchronously to a given destination. If this call fails, connect called be called again. However once a

--- a/tc-messaging/src/main/java/com/tc/net/protocol/TCNetworkMessage.java
+++ b/tc-messaging/src/main/java/com/tc/net/protocol/TCNetworkMessage.java
@@ -40,4 +40,6 @@ public interface TCNetworkMessage {
   public void complete();
 
   void addCompleteCallback(Runnable r);
+  
+  Runnable stealCompleteAction();
 }

--- a/tc-messaging/src/main/java/com/tc/net/protocol/tcm/TCActionImpl.java
+++ b/tc-messaging/src/main/java/com/tc/net/protocol/tcm/TCActionImpl.java
@@ -147,7 +147,7 @@ public abstract class TCActionImpl implements TCAction {
           }
         }
       } finally {
-        this.bbis.reset();
+        this.bbis.close();
         this.bbis = null;
       }
       monitor.newIncomingMessage(this);

--- a/tc-server/src/main/java/com/tc/objectserver/impl/DiagnosticsHandler.java
+++ b/tc-server/src/main/java/com/tc/objectserver/impl/DiagnosticsHandler.java
@@ -71,6 +71,7 @@ public class DiagnosticsHandler extends AbstractEventHandler<TCAction> {
       message.hydrate();
     } catch (Exception e) {
       logger.warn("trouble with diagnostics", e);
+      return;
     }
     DiagnosticMessage msg = (DiagnosticMessage)message;
     TCByteBuffer data = msg.getExtendedData();

--- a/tc-server/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/tc-server/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -873,7 +873,7 @@ public class DistributedObjectServer {
       this.l2Coordinator.shutdown();
       this.groupCommManager.shutdown();
       this.communicationsManager.shutdown();
-      this.communicationsManager.getConnectionManager().closeAllConnections(6000);
+      this.communicationsManager.getConnectionManager().closeAllConnections();
       this.persistor.shutdown();
       this.context.shutdown();
       this.entityManager.shutdown();

--- a/tc-server/src/test/java/com/tc/net/groups/TCGroupMessageWrapperTest.java
+++ b/tc-server/src/test/java/com/tc/net/groups/TCGroupMessageWrapperTest.java
@@ -103,7 +103,7 @@ public class TCGroupMessageWrapperTest extends TestCase {
   protected void tearDown() throws Exception {
     super.tearDown();
     try {
-      clientComms.getConnectionManager().closeAllConnections(5000);
+      clientComms.getConnectionManager().closeAllConnections();
 
       for (int i = 0; i < 30; i++) {
         if (channelManager.getChannels().length == 0) {


### PR DESCRIPTION
This prevents data corruption when reading from the network by delaying buffer recycle until after hydrate of a TCAction has occurred.