### PR TITLE
remove an assert that is not longer valid.  

### DIFF
--- a/tc-messaging/src/main/java/com/tc/net/protocol/transport/WireProtocolAdaptorImpl.java
+++ b/tc-messaging/src/main/java/com/tc/net/protocol/transport/WireProtocolAdaptorImpl.java
@@ -64,8 +64,6 @@ public class WireProtocolAdaptorImpl extends AbstractTCProtocolAdaptor implement
         }
         if (msg.getWireProtocolHeader().isMessagesGrouped()) {
           WireProtocolGroupMessage wpmg = (WireProtocolGroupMessage) msg;
-          int msgCount = wpmg.getWireProtocolHeader().getMessageCount();
-          Assert.eval(msgCount > 1);
 
           for (Iterator<TCNetworkMessage> i = wpmg.getMessageIterator(); i.hasNext();) {
             WireProtocolMessage wpm = (WireProtocolMessage) i.next();


### PR DESCRIPTION
with the added message recall feature, it is possible for a message group to start with multiple messages and get reduced to one message because all others have been recalled.  remove assert as this is a completely valid case