### PR TITLE
DRAFT : Trying to grok reconnect interrupt handling

### DIFF
--- a/common/src/main/java/com/tc/net/protocol/transport/ClientConnectionEstablisher.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ClientConnectionEstablisher.java
@@ -294,7 +294,7 @@ public class ClientConnectionEstablisher {
       try {
         Thread.sleep(CONNECT_RETRY_INTERVAL);
       } catch (InterruptedException e1) {
-        Thread.currentThread().interrupt();
+        LOGGER.info("Async reconnect thread woken by interrupt " + transport);
       }
     }
   }
@@ -442,6 +442,7 @@ public class ClientConnectionEstablisher {
     }
 
     public boolean putConnectionRequest(ConnectionRequest request) {
+      //TODO I'm worried about this code-path... it's signalling for a stop... but it's not setting any conditions.
       if (!isStopped() && waitForThread(getConnectionThread(), true)) {
         if (!transport.isConnected()) {
           startThreadIfNecessary(request);


### PR DESCRIPTION
I think the reasserting here is wrong... and I think this is causing the occasional infinite reconnect loop. I wonder if the in to that loop is the line I've added a comment to where we interrupt and wait for termination, but don't flip any termination conditions. I'm thinking if this code path got called during a reconnect it could trigger one of these loops.