### PR TITLE
Remove callback port useage

### DIFF
--- a/common/src/main/java/com/tc/net/protocol/tcm/CommunicationsManagerImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/CommunicationsManagerImpl.java
@@ -99,7 +99,6 @@ public class CommunicationsManagerImpl implements CommunicationsManager {
 
   private final ConnectionHealthChecker                                              connectionHealthChecker;
   private ServerID                                                             serverID                  = ServerID.NULL_ID;
-  private int                                                                  callbackPort              = TransportHandshakeMessage.NO_CALLBACK_PORT;
   private final TransportHandshakeErrorHandler                                 handshakeErrHandler;
 
   /**
@@ -276,7 +275,7 @@ public class CommunicationsManagerImpl implements CommunicationsManager {
                                                                                      connectionHealthChecker,
                                                                                      connectionManager,
                                                                                      timeout,
-                                                                                     callbackPort, handshakeErrHandler,
+                                                                                     handshakeErrHandler,
                                                                                      reconnectionRejectedHandler
     );
     NetworkStackHarness stackHarness = this.stackHarnessFactory.createClientHarness(transportFactory, rv,
@@ -327,13 +326,6 @@ public class CommunicationsManagerImpl implements CommunicationsManager {
         return new ServerMessageChannelImpl(id, messageRouter, msgFactory, serverID);
       }
     };
-
-    // XXX: since we don't create multiple listeners per commsMgr, its OK to set
-    // L2's callbackPort here. Otherwise, have interface method and set after starting
-    // commsMgr listener.
-    if (!this.healthCheckerConfig.isCallbackPortListenerNeeded()) {
-      this.callbackPort = addr.getPort();
-    }
 
     final ChannelManagerImpl channelManager = new ChannelManagerImpl(transportDisconnectRemovesChannel, channelFactory);
     return new NetworkListenerImpl(addr, this, channelManager, msgFactory, reuseAddr,

--- a/common/src/main/java/com/tc/net/protocol/tcm/MessageTransportFactoryImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/MessageTransportFactoryImpl.java
@@ -27,6 +27,7 @@ import com.tc.net.protocol.transport.MessageTransportListener;
 import com.tc.net.protocol.transport.ReconnectionRejectedHandler;
 import com.tc.net.protocol.transport.ServerMessageTransport;
 import com.tc.net.protocol.transport.TransportHandshakeErrorHandler;
+import com.tc.net.protocol.transport.TransportHandshakeMessage;
 import com.tc.net.protocol.transport.TransportHandshakeMessageFactory;
 import com.tc.net.protocol.transport.WireProtocolAdaptorFactory;
 import com.tc.net.protocol.transport.WireProtocolAdaptorFactoryImpl;
@@ -38,21 +39,19 @@ public class MessageTransportFactoryImpl implements MessageTransportFactory {
   private final ConnectionHealthChecker          connectionHealthChecker;
   private final TCConnectionManager              connectionMgr;
   private final int                              timeout;
-  private final int                              callbackport;
   private final TransportHandshakeErrorHandler   defaultHandshakeErrorHandler;
   private final ReconnectionRejectedHandler      reconnectionRejectedHandler;
 
   public MessageTransportFactoryImpl(TransportHandshakeMessageFactory transportMessageFactory,
                                      ConnectionHealthChecker connectionHealthChecker,
                                      TCConnectionManager connectionManager,
-                                     int timeout, int callbackPort,
+                                     int timeout, 
                                      TransportHandshakeErrorHandler defaultHandshakeErrorHandler,
                                      ReconnectionRejectedHandler reconnectionRejectedBehaviour) {
     this.transportMessageFactory = transportMessageFactory;
     this.connectionHealthChecker = connectionHealthChecker;
     this.connectionMgr = connectionManager;
     this.timeout = timeout;
-    this.callbackport = callbackPort;
     this.defaultHandshakeErrorHandler = defaultHandshakeErrorHandler;
     this.reconnectionRejectedHandler = reconnectionRejectedBehaviour;
   }
@@ -61,17 +60,16 @@ public class MessageTransportFactoryImpl implements MessageTransportFactory {
   public ClientMessageTransport createNewTransport() {
     ClientMessageTransport cmt = createClientMessageTransport(
                                                               defaultHandshakeErrorHandler, transportMessageFactory,
-                                                              new WireProtocolAdaptorFactoryImpl(), callbackport);
+                                                              new WireProtocolAdaptorFactoryImpl());
     cmt.addTransportListener(connectionHealthChecker);
     return cmt;
   }
 
   protected ClientMessageTransport createClientMessageTransport(TransportHandshakeErrorHandler handshakeErrorHandler,
                                                                 TransportHandshakeMessageFactory messageFactory,
-                                                                WireProtocolAdaptorFactory wireProtocolAdaptorFactory,
-                                                                int callbackPortNum) {
+                                                                WireProtocolAdaptorFactory wireProtocolAdaptorFactory) {
     return new ClientMessageTransport(this.connectionMgr, handshakeErrorHandler, transportMessageFactory,
-                                      wireProtocolAdaptorFactory, callbackPortNum, this.timeout, reconnectionRejectedHandler);
+                                      wireProtocolAdaptorFactory, this.timeout, reconnectionRejectedHandler);
   }
 
   @Override

--- a/common/src/main/java/com/tc/net/protocol/transport/ClientMessageTransport.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ClientMessageTransport.java
@@ -59,15 +59,14 @@ public class ClientMessageTransport extends MessageTransportBase {
   private CompletableFuture<NetworkStackID>                         opener;
   private CompletableFuture<SynAckMessage>                          waitForSynAckResult;
   private final WireProtocolAdaptorFactory  wireProtocolAdaptorFactory;
-  private final int                         callbackPort;
   private final int                         timeout;
   private final ReconnectionRejectedHandler reconnectionRejectedHandler;
 
   public ClientMessageTransport(TCConnectionManager clientConnectionEstablisher,
                                 TransportHandshakeErrorHandler handshakeErrorHandler,
                                 TransportHandshakeMessageFactory messageFactory,
-                                WireProtocolAdaptorFactory wireProtocolAdaptorFactory, int callbackPort, int timeout) {
-    this(clientConnectionEstablisher, handshakeErrorHandler, messageFactory, wireProtocolAdaptorFactory, callbackPort, timeout,
+                                WireProtocolAdaptorFactory wireProtocolAdaptorFactory, int timeout) {
+    this(clientConnectionEstablisher, handshakeErrorHandler, messageFactory, wireProtocolAdaptorFactory, timeout,
          ReconnectionRejectedHandlerL1.SINGLETON);
   }
 
@@ -78,13 +77,12 @@ public class ClientMessageTransport extends MessageTransportBase {
   public ClientMessageTransport(TCConnectionManager connectionManager,
                                 TransportHandshakeErrorHandler handshakeErrorHandler,
                                 TransportHandshakeMessageFactory messageFactory,
-                                WireProtocolAdaptorFactory wireProtocolAdaptorFactory, int callbackPort, int timeout,
+                                WireProtocolAdaptorFactory wireProtocolAdaptorFactory, int timeout,
                                 ReconnectionRejectedHandler reconnectionRejectedHandler) {
 
     super(MessageTransportState.STATE_START, handshakeErrorHandler, messageFactory, LoggerFactory.getLogger(ClientMessageTransport.class));
     this.wireProtocolAdaptorFactory = wireProtocolAdaptorFactory;
     this.connectionManager = connectionManager;
-    this.callbackPort = callbackPort;
     this.timeout = timeout;
     this.reconnectionRejectedHandler = reconnectionRejectedHandler;
   }
@@ -309,7 +307,6 @@ public class ClientMessageTransport extends MessageTransportBase {
       }
       getConnection().setTransportEstablished();
       setSynAckResult(synAck);
-      setRemoteCallbackPort(synAck.getCallbackPort());
     }
   }
 
@@ -400,7 +397,7 @@ public class ClientMessageTransport extends MessageTransportBase {
       // get the stack layer list and pass it in
       short stackLayerFlags = getCommunicationStackFlags(this);
       TransportHandshakeMessage syn = this.messageFactory.createSyn(getConnectionID(), getConnection(),
-                                                                    stackLayerFlags, this.callbackPort);
+                                                                    stackLayerFlags);
       // send syn message
       try {
         this.sendToConnection(syn);

--- a/common/src/main/java/com/tc/net/protocol/transport/DisabledHealthCheckerConfigImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/DisabledHealthCheckerConfigImpl.java
@@ -66,11 +66,6 @@ public class DisabledHealthCheckerConfigImpl implements HealthCheckerConfig {
   }
 
   @Override
-  public boolean isCallbackPortListenerNeeded() {
-    return false;
-  }
-
-  @Override
   public boolean isCheckTimeEnabled() {
     throw new AssertionError("Disabled HealthChecker");
   }

--- a/common/src/main/java/com/tc/net/protocol/transport/HealthCheckerConfig.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/HealthCheckerConfig.java
@@ -53,10 +53,6 @@ public interface HealthCheckerConfig {
   int getSocketConnectTimeout();
 
   /**
-   * RMP-343: L2 SocketConnect L1
-   */
-  boolean isCallbackPortListenerNeeded();
-  /**
    * Checking time difference between hosts enabled/disabled.
    */
   boolean isCheckTimeEnabled();

--- a/common/src/main/java/com/tc/net/protocol/transport/HealthCheckerConfigClientImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/HealthCheckerConfigClientImpl.java
@@ -31,13 +31,8 @@ public class HealthCheckerConfigClientImpl extends HealthCheckerConfigImpl {
     super(name);
   }
 
-  public HealthCheckerConfigClientImpl(long idle, long interval, int probes, String name, boolean extraCheck,
+  public HealthCheckerConfigClientImpl(long idle, long interval, int probes, String name,
                                        int socketConnectMaxCount, int socketConnectTimeout) {
-    super(idle, interval, probes, name, extraCheck, socketConnectMaxCount, socketConnectTimeout);
-  }
-
-  @Override
-  public boolean isCallbackPortListenerNeeded() {
-    return true;
+    super(idle, interval, probes, name, false, socketConnectMaxCount, socketConnectTimeout);
   }
 }

--- a/common/src/main/java/com/tc/net/protocol/transport/HealthCheckerConfigImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/HealthCheckerConfigImpl.java
@@ -140,11 +140,6 @@ public class HealthCheckerConfigImpl implements HealthCheckerConfig {
   }
 
   @Override
-  public boolean isCallbackPortListenerNeeded() {
-    return false;
-  }
-
-  @Override
   public boolean isCheckTimeEnabled() {
     return this.checkTimeEnabled;
   }

--- a/common/src/main/java/com/tc/net/protocol/transport/MessageTransport.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/MessageTransport.java
@@ -50,9 +50,5 @@ public interface MessageTransport extends NetworkLayer, PrettyPrintable {
 
   public String getCommunicationStackNames(NetworkLayer parentLayer);
 
-  public void setRemoteCallbackPort(int callbackPort);
-
-  public int getRemoteCallbackPort();
-
   public void initConnectionID(ConnectionID cid);
 }

--- a/common/src/main/java/com/tc/net/protocol/transport/MessageTransportBase.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/MessageTransportBase.java
@@ -55,7 +55,6 @@ abstract class MessageTransportBase extends AbstractMessageTransport implements 
 
   private final AtomicReference<TCConnectionEvent> connectionCloseEvent   = new AtomicReference<>();
   private volatile ConnectionHealthCheckerContext  healthCheckerContext   = new ConnectionHealthCheckerContextDummyImpl();
-  private int                                      remoteCallbackPort     = TransportHandshakeMessage.NO_CALLBACK_PORT;
 
   protected MessageTransportBase(MessageTransportState initialState,
                                  TransportHandshakeErrorHandler handshakeErrorHandler,
@@ -384,16 +383,6 @@ abstract class MessageTransportBase extends AbstractMessageTransport implements 
   public String getStackLayerName() {
     // this is the transport layer
     return NAME_TRANSPORT_LAYER;
-  }
-
-  @Override
-  public synchronized int getRemoteCallbackPort() {
-    return this.remoteCallbackPort;
-  }
-
-  @Override
-  public synchronized void setRemoteCallbackPort(int remoteCallbackPort) {
-    this.remoteCallbackPort = remoteCallbackPort;
   }
 
   @Override

--- a/common/src/main/java/com/tc/net/protocol/transport/ServerStackProvider.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ServerStackProvider.java
@@ -353,7 +353,6 @@ public class ServerStackProvider implements NetworkStackProvider, MessageTranspo
       }
 
       connectionId = transport.getConnectionID();
-      this.transport.setRemoteCallbackPort(syn.getCallbackPort());
       // now check that the client side stack and server side stack are both in sync
       short clientStackLayerFlags = syn.getStackLayerFlags();
       short serverStackLayerFlags = this.transport.getCommunicationStackFlags(this.transport);
@@ -417,8 +416,7 @@ public class ServerStackProvider implements NetworkStackProvider, MessageTranspo
                 source, isMaxConnectionsReached, maxConnections);
         }
       } else {
-        int callbackPort = source.getLocalAddress().getPort();
-        synAck = handshakeMessageFactory.createSynAck(connectionId, source, isMaxConnectionsReached, maxConnections, callbackPort);
+        synAck = handshakeMessageFactory.createSynAck(connectionId, source, isMaxConnectionsReached, maxConnections);
         source.setTransportEstablished();
       }
       sendMessage(synAck);

--- a/common/src/test/java/com/tc/net/core/TCWorkerCommManagerTest.java
+++ b/common/src/test/java/com/tc/net/core/TCWorkerCommManagerTest.java
@@ -84,7 +84,7 @@ public class TCWorkerCommManagerTest extends TCTestCase {
                                                                    new NullConnectionPolicy());
 
     ClientMessageTransport cmt = new ClientMessageTransport(commsMgr.getConnectionManager(), createHandshakeErrorHandler(), new TransportMessageFactoryImpl(),
-                                      new WireProtocolAdaptorFactoryImpl(), TransportHandshakeMessage.NO_CALLBACK_PORT, 1000);
+                                      new WireProtocolAdaptorFactoryImpl(), 1000);
     transports.add(cmt);
     return cmt;
   }

--- a/common/src/test/java/com/tc/net/protocol/transport/CallbackPortRangeTest.java
+++ b/common/src/test/java/com/tc/net/protocol/transport/CallbackPortRangeTest.java
@@ -76,10 +76,6 @@ public class CallbackPortRangeTest extends TestCase {
     } catch (NumberFormatException nfe) {
       // expected
     }
-
-    ports = CallbackPortRange.expandRange(String.valueOf(TransportHandshakeMessage.NO_CALLBACK_PORT));
-    assertEquals(1, ports.size());
-    assertEquals(TransportHandshakeMessage.NO_CALLBACK_PORT, ports.iterator().next().intValue());
   }
 
 }

--- a/common/src/test/java/com/tc/net/protocol/transport/ClientConnectionEstablisherTest.java
+++ b/common/src/test/java/com/tc/net/protocol/transport/ClientConnectionEstablisherTest.java
@@ -78,7 +78,7 @@ public class ClientConnectionEstablisherTest {
   public void setup() throws Exception {
     MockitoAnnotations.initMocks(this);
     try {
-      cmt = spy(new ClientMessageTransport(connManager, mock(TransportHandshakeErrorHandler.class), mock(TransportHandshakeMessageFactory.class), mock(WireProtocolAdaptorFactory.class), TransportHandshakeMessage.NO_CALLBACK_PORT, 0));
+      cmt = spy(new ClientMessageTransport(connManager, mock(TransportHandshakeErrorHandler.class), mock(TransportHandshakeMessageFactory.class), mock(WireProtocolAdaptorFactory.class), 0));
       doNothing().when(cmt).sendToConnection(any(TCNetworkMessage.class));
       doNothing().when(cmt).reconnect(any(InetSocketAddress.class));
       doReturn(new NetworkStackID(0)).when(cmt).open(any(InetSocketAddress.class));

--- a/common/src/test/java/com/tc/net/protocol/transport/ClientMessageTransportTest.java
+++ b/common/src/test/java/com/tc/net/protocol/transport/ClientMessageTransportTest.java
@@ -61,7 +61,7 @@ public class ClientMessageTransportTest {
       }
       
     };
-    client = new ClientMessageTransport(cce, eh, factory, wiref, 0, 0);
+    client = new ClientMessageTransport(cce, eh, factory, wiref, 0);
   }
 
   @Test

--- a/tc-messaging/src/main/java/com/tc/net/protocol/transport/TransportHandshakeMessageFactory.java
+++ b/tc-messaging/src/main/java/com/tc/net/protocol/transport/TransportHandshakeMessageFactory.java
@@ -22,12 +22,12 @@ import com.tc.net.core.TCConnection;
 
 public interface TransportHandshakeMessageFactory {
 
-  public TransportHandshakeMessage createSyn(ConnectionID connectionId, TCConnection source, short stackLayerFlags, int callbackPort);
+  public TransportHandshakeMessage createSyn(ConnectionID connectionId, TCConnection source, short stackLayerFlags);
 
   public TransportHandshakeMessage createAck(ConnectionID connectionId, TCConnection source);
 
   public TransportHandshakeMessage createSynAck(ConnectionID connectionId, TCConnection source,
-                                                boolean isMaxConnectionsExceeded, int maxConnections, int callbackPort);
+                                                boolean isMaxConnectionsExceeded, int maxConnections);
 
   public TransportHandshakeMessage createSynAck(ConnectionID connectionId, TransportHandshakeError error, String message, 
                                                 TCConnection source, boolean isMaxConnectionsExceeded,

--- a/tc-messaging/src/main/java/com/tc/net/protocol/transport/TransportMessageFactoryImpl.java
+++ b/tc-messaging/src/main/java/com/tc/net/protocol/transport/TransportMessageFactoryImpl.java
@@ -22,6 +22,7 @@ import com.tc.exception.TCInternalError;
 import com.tc.io.TCByteBufferOutputStream;
 import com.tc.net.core.TCConnection;
 import com.tc.net.protocol.TCProtocolException;
+import static com.tc.net.protocol.transport.TransportHandshakeMessage.NO_CALLBACK_PORT;
 
 public class TransportMessageFactoryImpl implements TransportHandshakeMessageFactory, HealthCheckerProbeMessageFactory {
   @Override
@@ -43,22 +44,21 @@ public class TransportMessageFactoryImpl implements TransportHandshakeMessageFac
   }
 
   @Override
-  public TransportHandshakeMessage createSyn(ConnectionID connectionId, TCConnection source, short stackLayerFlags, int callbackPort) {
+  public TransportHandshakeMessage createSyn(ConnectionID connectionId, TCConnection source, short stackLayerFlags) {
     return createNewMessage(TransportMessageImpl.SYN, connectionId, null, null, source, false, 0,
-                            WireProtocolHeader.PROTOCOL_TRANSPORT_HANDSHAKE, stackLayerFlags, callbackPort);
+                            WireProtocolHeader.PROTOCOL_TRANSPORT_HANDSHAKE, stackLayerFlags);
   }
 
   @Override
   public TransportHandshakeMessage createAck(ConnectionID connectionId, TCConnection source) {
-    return createNewMessage(TransportMessageImpl.ACK, connectionId, null, null, source, false, 0,
-                            TransportHandshakeMessage.NO_CALLBACK_PORT);
+    return createNewMessage(TransportMessageImpl.ACK, connectionId, null, null, source, false, 0);
   }
 
   @Override
   public TransportHandshakeMessage createSynAck(ConnectionID connectionId, TCConnection source,
-                                                boolean isMaxConnectionsExceeded, int maxConnections, int callbackPort) {
+                                                boolean isMaxConnectionsExceeded, int maxConnections) {
     return createNewMessage(TransportMessageImpl.SYN_ACK, connectionId, null, null, source, isMaxConnectionsExceeded,
-                            maxConnections, callbackPort);
+                            maxConnections);
   }
 
   @Override
@@ -66,21 +66,21 @@ public class TransportMessageFactoryImpl implements TransportHandshakeMessageFac
                                                 TCConnection source, boolean isMaxConnectionsExceeded,
                                                 int maxConnections) {
     return createNewMessage(TransportMessageImpl.SYN_ACK, connectionId, errorContext, message, source, isMaxConnectionsExceeded,
-                            maxConnections, TransportHandshakeMessage.NO_CALLBACK_PORT);
+                            maxConnections);
   }
 
   private static TransportMessageImpl createNewMessage(byte type, ConnectionID connectionId,
                                                        TransportHandshakeError errorContext, String message, TCConnection source,
                                                        boolean isMaxConnectionsExceeded, int maxConnections, short protocol) {
     return createNewMessage(type, connectionId, errorContext, message, source, isMaxConnectionsExceeded, maxConnections,
-                            protocol, (short) -1, TransportHandshakeMessage.NO_CALLBACK_PORT);
+                            protocol, (short) -1);
   }
 
   private static TransportMessageImpl createNewMessage(byte type, ConnectionID connectionId,
                                                        TransportHandshakeError errorContext, String message, TCConnection source,
-                                                       boolean isMaxConnectionsExceeded, int maxConnections, int callbackPort) {
+                                                       boolean isMaxConnectionsExceeded, int maxConnections) {
     return createNewMessage(type, connectionId, errorContext, message, source, isMaxConnectionsExceeded, maxConnections,
-                            WireProtocolHeader.PROTOCOL_TRANSPORT_HANDSHAKE, (short) -1, callbackPort);
+                            WireProtocolHeader.PROTOCOL_TRANSPORT_HANDSHAKE, (short) -1);
   }
 
   /**
@@ -92,7 +92,7 @@ public class TransportMessageFactoryImpl implements TransportHandshakeMessageFac
   private static TransportMessageImpl createNewMessage(byte type, ConnectionID connectionId,
                                                        TransportHandshakeError errorContext, String message, TCConnection source,
                                                        boolean isMaxConnectionsExceeded, int maxConnections, short protocol,
-                                                       short stackLayerFlags, int callbackPort) {
+                                                       short stackLayerFlags) {
     TCByteBufferOutputStream bbos = new TCByteBufferOutputStream();
 
     bbos.write(TransportMessageImpl.VERSION);
@@ -101,7 +101,7 @@ public class TransportMessageFactoryImpl implements TransportHandshakeMessageFac
     bbos.writeBoolean(isMaxConnectionsExceeded);
     bbos.writeInt(maxConnections);
     bbos.writeShort(stackLayerFlags);
-    bbos.writeInt(callbackPort);
+    bbos.writeInt(NO_CALLBACK_PORT);  //  unused callback port for compatibility
     bbos.writeBoolean(errorContext != null);
     if (errorContext != null) {
       short errorType = errorContext.getErrorType();

--- a/tc-messaging/src/test/java/com/tc/net/protocol/transport/TransportHandshakeMessageTest.java
+++ b/tc-messaging/src/test/java/com/tc/net/protocol/transport/TransportHandshakeMessageTest.java
@@ -40,7 +40,7 @@ public class TransportHandshakeMessageTest {
     boolean isMaxConnectionsExceeded = true;
     int maxConnections = 13;
     ConnectionID connectionId = new ConnectionID("abc", 1L);
-    message = factory.createSynAck(connectionId, null, isMaxConnectionsExceeded, maxConnections, 43);
+    message = factory.createSynAck(connectionId, null, isMaxConnectionsExceeded, maxConnections);
     TCReference payload = message.getPayload();
 
     WireProtocolHeader header = new WireProtocolHeader();


### PR DESCRIPTION
Removing handshake negotiated callback ports.  They don't work in heterogeneous networks such as when using containers.  Clients will still try and do socket connects as a last ditch effort to test server liveliness.  Servers will never try and socket connect clients.  