### PR TITLE
fixes to prevent client reconnection outside the server's reconnect window

### DIFF
--- a/common/src/main/java/com/tc/net/protocol/transport/ClientMessageTransport.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ClientMessageTransport.java
@@ -490,7 +490,7 @@ public class ClientMessageTransport extends MessageTransportBase {
     handleHandshakeError(result);
     initConnectionID(result.synAck.getConnectionId());
     sendAck();
-    log("Handshake is complete");
+    logger.debug("Handshake is complete");
   }
 
   private String getMaxConnectionsExceededMessage(int maxConnections) {

--- a/common/src/main/java/com/tc/net/protocol/transport/MessageTransportState.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/MessageTransportState.java
@@ -28,12 +28,15 @@ enum MessageTransportState {
       return false;
     }
   },
-  
-  STATE_START_OPEN("START_OPEN"),
-  
+    
   STATE_CONNECTED("CONNECTED"),
   
-  STATE_RESTART("RESTART"),
+  STATE_RESTART("RESTART") {
+    @Override
+    public boolean isAlive() {
+      return false;
+    }
+  },
 
   /**
    * XXX: Move to client state machine SYN message sent, waiting for reply

--- a/common/src/main/java/com/tc/net/protocol/transport/MessageTransportStatus.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/MessageTransportStatus.java
@@ -23,23 +23,19 @@ import org.slf4j.Logger;
 import com.tc.util.Assert;
 
 class MessageTransportStatus {
-  private final MessageTransportState initial;
   private MessageTransportState state;
   private final Logger logger;
-  private volatile boolean isEstablished = false;
 
   MessageTransportStatus(MessageTransportState initialState, Logger logger) {
-    this.initial = initialState;
     this.state = initialState;
     this.logger = logger;
   }
 
   void reset() {
-    stateChange(initial);
+    stateChange(MessageTransportState.STATE_START);
   }
 
   private synchronized void stateChange(MessageTransportState newState) {
-    isEstablished = false;
     if (logger.isDebugEnabled()) {
       logger.debug("Changing from " + state.toString() + " to " + newState.toString());
     }
@@ -78,18 +74,11 @@ class MessageTransportStatus {
   }
   
   private synchronized boolean checkState(MessageTransportState check) {
-    if (check == MessageTransportState.STATE_ESTABLISHED && state == MessageTransportState.STATE_ESTABLISHED) {
-      isEstablished = true;
-    }
     return this.state.equals(check);
   }
 
   boolean isStart() {
     return checkState(MessageTransportState.STATE_START);
-  }
-
-  boolean isStartOpen() {
-    return checkState(MessageTransportState.STATE_START_OPEN);
   }
   
   boolean isRestart() {
@@ -101,11 +90,7 @@ class MessageTransportStatus {
   }
 
   boolean isEstablished() {
-    if (isEstablished) {
-      return true;
-    } else {
-      return checkState(MessageTransportState.STATE_ESTABLISHED);
-    }
+    return checkState(MessageTransportState.STATE_ESTABLISHED);
   }
   
   boolean isDisconnected() {

--- a/common/src/main/java/com/tc/net/protocol/transport/ServerStackProvider.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ServerStackProvider.java
@@ -54,7 +54,7 @@ import java.net.InetSocketAddress;
 public class ServerStackProvider implements NetworkStackProvider, MessageTransportListener, ProtocolAdaptorFactory {
   private static final Logger logger = LoggerFactory.getLogger(ServerStackProvider.class);
 
-  private final Map<ClientID, ServerNetworkStackHarness> harnesses          = new ConcurrentHashMap<ClientID, ServerNetworkStackHarness>();
+  private final Map<ClientID, ServerNetworkStackHarness> harnesses          = new ConcurrentHashMap<>();
   private final NetworkStackHarnessFactory       harnessFactory;
   private final ServerMessageChannelFactory      channelFactory;
   private final TransportHandshakeMessageFactory handshakeMessageFactory;
@@ -63,7 +63,7 @@ public class ServerStackProvider implements NetworkStackProvider, MessageTranspo
   private final WireProtocolAdaptorFactory       wireProtocolAdaptorFactory;
   private final WireProtocolMessageSink          wireProtoMsgsink;
   private final MessageTransportFactory          messageTransportFactory;
-  private final List<MessageTransportListener>   transportListeners = new ArrayList<MessageTransportListener>();
+  private final List<MessageTransportListener>   transportListeners = new ArrayList<>();
   private final ReentrantLock                    licenseLock;
   private final RedirectAddressProvider                 activeProvider;
   private final Predicate<MessageTransport>                validateTransport;
@@ -213,7 +213,7 @@ public class ServerStackProvider implements NetworkStackProvider, MessageTranspo
       if (!connectionId.isJvmIDNull()) {
         boolean removed = this.connectionPolicy.clientDisconnected(connectionId);
         if (removed) {
-          logger.warn("connectionid not removed be transport disconnect");
+          logger.warn("connectionid not removed by transport disconnect");
         }
       }
     }

--- a/common/src/test/java/com/tc/net/protocol/transport/ServerMessageTransportTest.java
+++ b/common/src/test/java/com/tc/net/protocol/transport/ServerMessageTransportTest.java
@@ -78,18 +78,16 @@ public class ServerMessageTransportTest {
         return null;
       }
     }).when(connection).addListener(ArgumentMatchers.any(TCConnectionEventListener.class));
+    when(connection.isConnected()).thenReturn(Boolean.TRUE);
     TransportHandshakeErrorHandler errHdr = mock(TransportHandshakeErrorHandler.class);
     TransportHandshakeMessageFactory factory = mock(TransportHandshakeMessageFactory.class);
     ServerMessageTransport transport = new ServerMessageTransport(connection, errHdr, factory);
     transport.initConnectionID(id);
     transport.addTransportListener(checker);
 
-    Assert.assertTrue(transport.status.isStartOpen());
+    Assert.assertTrue(transport.status.isConnected());
     
     TCConnectionEvent event = new TCConnectionEvent(connection);
-    transport.connectEvent(event);
-
-    Assert.assertTrue(transport.status.isConnected());
 
     for (TCConnectionEventListener trigger : listeners) {
       trigger.closeEvent(event);

--- a/common/src/test/java/com/tc/net/protocol/transport/ServerMessageTransportTest.java
+++ b/common/src/test/java/com/tc/net/protocol/transport/ServerMessageTransportTest.java
@@ -21,6 +21,7 @@ package com.tc.net.protocol.transport;
 import com.tc.net.core.TCConnection;
 import com.tc.net.core.event.TCConnectionEvent;
 import com.tc.net.core.event.TCConnectionEventListener;
+import com.tc.net.protocol.IllegalReconnectException;
 import com.tc.util.Assert;
 import java.util.ArrayList;
 import java.util.List;
@@ -123,5 +124,48 @@ public class ServerMessageTransportTest {
 
     verify(checker, times(2)).notifyTransportDisconnected(eq(transport), eq(false));
     verify(checker, times(1)).notifyTransportDisconnected(eq(transport), eq(true));
+  }
+  
+  @Test
+  public void testDoubleAttachFails() throws Exception {
+    ConnectionID id = new ConnectionID("JVM", 1);
+    TCConnection connection = mock(TCConnection.class);
+    
+    MessageTransportListener checker = mock(MessageTransportListener.class);
+    
+    final List<TCConnectionEventListener> listeners = new ArrayList<TCConnectionEventListener>();
+    doAnswer(new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        listeners.add((TCConnectionEventListener)invocation.getArguments()[0]);
+        return null;
+      }
+    }).when(connection).addListener(ArgumentMatchers.any(TCConnectionEventListener.class));
+    when(connection.isConnected()).thenReturn(Boolean.TRUE);
+    TransportHandshakeErrorHandler errHdr = mock(TransportHandshakeErrorHandler.class);
+    TransportHandshakeMessageFactory factory = mock(TransportHandshakeMessageFactory.class);
+    ServerMessageTransport transport = new ServerMessageTransport(errHdr, factory);
+    transport.initConnectionID(id);
+    transport.addTransportListener(checker);
+
+    Assert.assertFalse(transport.status.isConnected());
+    
+    transport.attachNewConnection(connection);
+    Assert.assertTrue(transport.status.isConnected());
+        
+    try {
+      transport.attachNewConnection(connection);
+      Assert.fail();
+    } catch (IllegalReconnectException illegal) {
+      //  expected
+    }
+    transport.close();
+    Assert.assertFalse(transport.status.isConnected());
+    try {
+      transport.attachNewConnection(connection);
+      Assert.fail();
+    } catch (IllegalReconnectException illegal) {
+      //  expected
+    }
   }
 }

--- a/galvan-support/src/test/java/org/terracotta/functional/ReconnectRejectIT.java
+++ b/galvan-support/src/test/java/org/terracotta/functional/ReconnectRejectIT.java
@@ -1,0 +1,74 @@
+/*
+ *
+ *  The contents of this file are subject to the Terracotta Public License Version
+ *  2.0 (the "License"); You may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *
+ *  http://terracotta.org/legal/terracotta-public-license.
+ *
+ *  Software distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ *  the specific language governing rights and limitations under the License.
+ *
+ *  The Covered Software is Terracotta Core.
+ *
+ *  The Initial Developer of the Covered Software is
+ *  Terracotta, Inc., a Software AG company
+ *
+ */
+package org.terracotta.functional;
+
+
+import java.io.StringReader;
+import java.net.InetSocketAddress;
+import java.util.Properties;
+import junit.framework.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.terracotta.connection.Connection;
+import org.terracotta.connection.Diagnostics;
+import org.terracotta.connection.DiagnosticsFactory;
+import org.terracotta.connection.entity.EntityRef;
+import org.terracotta.entity.map.ConcurrentClusteredMap;
+import org.terracotta.entity.map.MapConfig;
+import org.terracotta.exception.ConnectionClosedException;
+import org.terracotta.testing.rules.BasicExternalClusterBuilder;
+import org.terracotta.testing.rules.Cluster;
+
+/**
+ *
+ */
+public class ReconnectRejectIT {
+
+  @Rule
+  public final Cluster CLUSTER = BasicExternalClusterBuilder.newCluster(1).withClientReconnectWindowTime(30)
+      .build();
+
+  @Test
+  public void testClusterHostPorts() throws Exception {
+    Connection connection = CLUSTER.newConnection();
+    String hp = CLUSTER.getClusterHostPorts()[0];
+    String[] shp = hp.split(":");
+    int port = Integer.parseInt(shp[1]);
+    String id = null;
+    try (Diagnostics d = DiagnosticsFactory.connect(InetSocketAddress.createUnresolved(shp[0], port), new Properties())) {
+      Properties clients = new Properties();
+      clients.load(new StringReader(d.invoke("Server", "getConnectedClients")));
+      id = clients.getProperty("clients.0.id");
+    }
+    try (Diagnostics d = DiagnosticsFactory.connect(InetSocketAddress.createUnresolved(shp[0], port), new Properties())) {
+      System.out.println(d.invokeWithArg("Server", "disconnectClient", id));
+    }
+    try {
+      EntityRef<ConcurrentClusteredMap, MapConfig, Void>  ref = connection.getEntityRef(ConcurrentClusteredMap.class, 1L, "ROOT");
+      ref.create(new MapConfig(1, "ROOT"));
+      ConcurrentClusteredMap map = ref.fetchEntity(null);
+      Assert.fail();
+    } catch (ConnectionClosedException e) {
+      //expected
+      // There should be TRANSPORT_RECONNECTION_REJECTED_EVENT in the client logs
+      e.printStackTrace();
+    }
+    
+  }
+}

--- a/management/src/main/java/com/tc/management/beans/TCServerInfoMBean.java
+++ b/management/src/main/java/com/tc/management/beans/TCServerInfoMBean.java
@@ -102,6 +102,8 @@ public interface TCServerInfoMBean extends TerracottaMBean, RuntimeStatisticCons
   
   void setPipelineMonitoring(boolean monitor);
   
+  boolean disconnectClient(String id);
+  
   String getClusterState(boolean shortForm);
 
   String getConnectedClients() throws IOException;

--- a/tc-client/src/main/java/com/tc/object/DistributedObjectClient.java
+++ b/tc-client/src/main/java/com/tc/object/DistributedObjectClient.java
@@ -240,7 +240,7 @@ public class DistributedObjectClient {
     
     final ProductInfo pInfo = ProductInfo.getInstance(getClass().getClassLoader());
     
-    ClientHandshakeMessageFactory chmf = (u, n, c, r)->{
+    ClientHandshakeMessageFactory chmf = (u, n, c, r, reconnect)->{
       ClientMessageChannel cmc = getClientMessageChannel();
       if (cmc != null) {
         final ClientHandshakeMessage rv = (ClientHandshakeMessage)cmc.createMessage(TCMessageType.CLIENT_HANDSHAKE_MESSAGE);
@@ -249,6 +249,7 @@ public class DistributedObjectClient {
         rv.setClientPID(getPID());
         rv.setUUID(u);
         rv.setName(n);
+        rv.setReconnect(reconnect);
         return rv;
       } else {
         return null;

--- a/tc-client/src/main/java/com/tc/object/handshakemanager/ClientHandshakeManagerImpl.java
+++ b/tc-client/src/main/java/com/tc/object/handshakemanager/ClientHandshakeManagerImpl.java
@@ -59,6 +59,7 @@ public class ClientHandshakeManagerImpl implements ClientHandshakeManager {
 
   private State state;
   private volatile boolean disconnected;
+  private volatile boolean wasConnected;
   private volatile boolean isShutdown = false;
 
   public ClientHandshakeManagerImpl(Logger logger, ClientHandshakeMessageFactory chmf,
@@ -73,6 +74,7 @@ public class ClientHandshakeManagerImpl implements ClientHandshakeManager {
     this.callBacks = entities;
     this.state = State.PAUSED;
     this.disconnected = true;
+    this.wasConnected = false;
     pauseCallbacks();
   }
 
@@ -106,7 +108,7 @@ public class ClientHandshakeManagerImpl implements ClientHandshakeManager {
     ClientHandshakeMessage handshakeMessage;
 
     changeToStarting();
-    handshakeMessage = this.chmf.newClientHandshakeMessage(this.uuid, this.name, this.clientVersion, this.clientRevision);
+    handshakeMessage = this.chmf.newClientHandshakeMessage(this.uuid, this.name, this.clientVersion, this.clientRevision, this.wasConnected);
     if (handshakeMessage != null) {
       notifyCallbackOnHandshake(handshakeMessage);
 
@@ -242,5 +244,6 @@ public class ClientHandshakeManagerImpl implements ClientHandshakeManager {
     state = State.RUNNING;
 
     this.disconnected = false;
+    this.wasConnected = true;
   }
 }

--- a/tc-client/src/test/java/com/tc/object/ClientEntityManagerTest.java
+++ b/tc-client/src/test/java/com/tc/object/ClientEntityManagerTest.java
@@ -579,6 +579,7 @@ public class ClientEntityManagerTest extends TestCase {
       result.get(1, TimeUnit.SECONDS);
       Assert.fail();
     } catch (TimeoutException to) {
+      assertTrue(!result.isDone());
       assertThat(System.currentTimeMillis() - start, Matchers.greaterThanOrEqualTo(1000L));
       //  expected
     }
@@ -587,6 +588,7 @@ public class ClientEntityManagerTest extends TestCase {
       result.get(2, TimeUnit.SECONDS);
       Assert.fail();
     } catch (TimeoutException to) {
+      assertTrue(!result.isDone());
       assertThat(System.currentTimeMillis() - start, Matchers.greaterThanOrEqualTo(2000L));
       //  expected
     }

--- a/tc-messaging/src/main/java/com/tc/object/msg/ClientHandshakeMessage.java
+++ b/tc-messaging/src/main/java/com/tc/object/msg/ClientHandshakeMessage.java
@@ -26,6 +26,10 @@ import com.tc.net.protocol.tcm.TCAction;
 
 public interface ClientHandshakeMessage extends TCAction {
   
+  void setReconnect(boolean isReconnect);
+  
+  boolean isReconnect();
+  
   void setUUID(String uuid);
   
   String getUUID();

--- a/tc-messaging/src/main/java/com/tc/object/msg/ClientHandshakeMessageFactory.java
+++ b/tc-messaging/src/main/java/com/tc/object/msg/ClientHandshakeMessageFactory.java
@@ -20,6 +20,6 @@ package com.tc.object.msg;
 
 public interface ClientHandshakeMessageFactory {
 
-  public ClientHandshakeMessage newClientHandshakeMessage(String uuid, String name, String clientVersion, String clientRevision);
+  public ClientHandshakeMessage newClientHandshakeMessage(String uuid, String name, String clientVersion, String clientRevision, boolean reconnect);
 
 }

--- a/tc-messaging/src/main/java/com/tc/object/msg/ClientHandshakeMessageImpl.java
+++ b/tc-messaging/src/main/java/com/tc/object/msg/ClientHandshakeMessageImpl.java
@@ -39,7 +39,7 @@ import java.util.Comparator;
 
 
 public class ClientHandshakeMessageImpl extends DSOMessageBase implements ClientHandshakeMessage {
-  private static final byte   UNUSED_1        = 1;
+  private static final byte   RECONNECT        = 1;
   private static final byte   CLIENT_VERSION           = 2;
   private static final byte   UNUSED_2        = 3;
   private static final byte   LOCAL_TIME_MILLS         = 4;
@@ -58,6 +58,7 @@ public class ClientHandshakeMessageImpl extends DSOMessageBase implements Client
   private String              clientRevision           = "";
   private String              clientAddress            = ""; 
   private int                 pid                      = -1;
+  private boolean             reconnect                = false;
   private final Set<ClientEntityReferenceContext> reconnectReferences = new HashSet<ClientEntityReferenceContext>();
   private final Set<ResendVoltronEntityMessage> resendMessages = new TreeSet<ResendVoltronEntityMessage>(new Comparator<ResendVoltronEntityMessage>() {
     @Override
@@ -78,6 +79,16 @@ public class ClientHandshakeMessageImpl extends DSOMessageBase implements Client
     super(sessionID, monitor, channel, header, data);
     // if this is on the server, it will be replaced by the dehydrate
     clientAddress = TCSocketAddress.getStringForm(channel.getLocalAddress());
+  }
+
+  @Override
+  public void setReconnect(boolean isReconnect) {
+    this.reconnect = isReconnect;
+  }
+
+  @Override
+  public boolean isReconnect() {
+    return this.reconnect;
   }
 
   @Override
@@ -142,7 +153,7 @@ public class ClientHandshakeMessageImpl extends DSOMessageBase implements Client
 
   @Override
   protected void dehydrateValues() {
-    putNVPair(UNUSED_1, false);  // unused but keep for compatibility
+    putNVPair(RECONNECT, reconnect);  // unused but keep for compatibility
     putNVPair(UNUSED_2, false);  // unused but keep for compatibility
     putNVPair(CLIENT_UUID, this.uuid);
     putNVPair(CLIENT_NAME, this.name);
@@ -162,8 +173,8 @@ public class ClientHandshakeMessageImpl extends DSOMessageBase implements Client
   @Override
   protected boolean hydrateValue(byte name) throws IOException {
     switch (name) {
-      case UNUSED_1:
-        getBooleanValue();  // unused but keep for compatibility
+      case RECONNECT:
+        this.reconnect = getBooleanValue();
         return true;
       case UNUSED_2:
         getBooleanValue();  // unused but keep for compatibility

--- a/tc-server/src/main/java/com/tc/management/beans/TCServerInfo.java
+++ b/tc-server/src/main/java/com/tc/management/beans/TCServerInfo.java
@@ -49,6 +49,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -452,6 +453,25 @@ public class TCServerInfo extends AbstractTerracottaMBean implements TCServerInf
     } else {
       MonitoringEventCreator.setPipelineMonitor(null);
     }
+  }
+
+  @Override
+  public boolean disconnectClient(String id) {
+    Optional<Client> found = server.getConnectedClients().stream().filter(c->c.getRemoteUUID().equals(id)).findFirst();
+    found.ifPresent(Client::killClient);
+    if (found.isPresent()) {
+      return true;
+    }
+    found = server.getConnectedClients().stream().filter(c->c.getRemoteName().equals(id)).findFirst();
+    found.ifPresent(Client::killClient);
+    if (found.isPresent()) {
+      return true;
+    }
+    
+    long lid = Long.parseLong(id);
+    found = server.getConnectedClients().stream().filter(c->c.getClientID() == lid).findFirst();
+    found.ifPresent(Client::killClient);
+    return found.isPresent();
   }
 
   @Override

--- a/tc-server/src/main/java/com/tc/objectserver/handler/ClientHandshakeHandler.java
+++ b/tc-server/src/main/java/com/tc/objectserver/handler/ClientHandshakeHandler.java
@@ -58,7 +58,9 @@ public class ClientHandshakeHandler extends AbstractEventHandler<ClientHandshake
     Version client = new Version(version);
 
     try {
-      if (!GuardianContext.validate(Guardian.Op.CONNECT_CLIENT, cid, clientMsg.getChannel())) {
+      if (clientMsg.isReconnect() && this.handshakeManager.isStarted()) {
+        this.handshakeManager.notifyClientRefused(clientMsg, "server is not accepting reconnections");
+      } else if (!GuardianContext.validate(Guardian.Op.CONNECT_CLIENT, cid, clientMsg.getChannel())) {
         this.handshakeManager.notifyClientRefused(clientMsg, "new connections not allowed");
       } else if (!versionCheck.isCompatibleClientServer(client.toString(), serverVersion.toString())) {
         this.handshakeManager.notifyClientRefused(clientMsg, "client version is not compatible than the server.  client version:" + client.toString() + " server version:" + serverVersion);

--- a/tc-server/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/tc-server/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -596,8 +596,10 @@ public class DistributedObjectServer {
     final InetSocketAddress dsoBind = new InetSocketAddress(l2DSOConfig.getTsaPort().getHostString(), l2DSOConfig.getTsaPort().getPort());
     this.l1Listener = this.communicationsManager.createListener(dsoBind, (MessageChannel c)->!c.getProductID().isReconnectEnabled() || !server.isReconnectWindow(),
                                                                 this.connectionIdFactory, (MessageTransport t)->{
-                                                                  return getContext().getClientHandshakeManager().isStarting() || t.getConnectionID().getProductId() == ProductID.DIAGNOSTIC || consistencyMgr.requestTransition(context.getL2Coordinator().getStateManager().getCurrentMode(),
-                                                                      t.getConnectionID().getClientID(), ConsistencyManager.Transition.ADD_CLIENT);
+                                                                  return getContext().getClientHandshakeManager().isStarting() 
+                                                                          || t.getConnectionID().getProductId() == ProductID.DIAGNOSTIC 
+                                                                          || consistencyMgr.requestTransition(context.getL2Coordinator().getStateManager().getCurrentMode(),
+                                                                                t.getConnectionID().getClientID(), ConsistencyManager.Transition.ADD_CLIENT);
                                                                 });
     this.l1Diagnostics = createDiagnosticsListener(dsoBind, infoConnections);
 


### PR DESCRIPTION
The server can only handle one connection per client.  There is no reconnection allowed outside the reconnect window.  Prevent clients from trying to reconnect with a previously connected server at both the transport layer as well as secondary handshake.  The instances of using the secondary handshake check should be zero but add this code as a sanity check and it does not break protocol and is good to have the added information during secondary handshake