### PR TITLE
replicated cluster state no longer replies

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,5 +37,5 @@ jobs:
     jdkVersion: '17'
     jobName: 'WindowsJava17'
     timeoutInMinutes: 60
-    options: '--no-daemon --no-parallel --no-watch-fs'
+    options: '--no-daemon --no-parallel --no-watch-fs --info'
     gradleOptions: ''

--- a/galvan/build.gradle
+++ b/galvan/build.gradle
@@ -28,6 +28,7 @@ configurations {
 
 dependencies {
     api project(":test-interfaces")
+    api project(":server-api")
     implementation "org.terracotta:ipc-eventbus:1.1.4"
     api "org.terracotta:terracotta-utilities-port-chooser:0.0.19"
     api "junit:junit:$junitVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ mockitoVersion = 5.14.2
 junitVersion = 4.13.1
 hamcrestVersion = 1.3
 commonsIOVersion = 2.7
-logbackVersion = 1.2.11
+logbackVersion = 1.2.13
 
 publishApi = false
 


### PR DESCRIPTION
Replicated cluster state messages don't do anything with replies so here they are just erased as they are not needed.