### PR TITLE
TDB-19412: Fix properties object returned without the incoming properties when cif is null

### DIFF
--- a/tc-server/src/main/java/com/tc/objectserver/core/impl/GuardianContext.java
+++ b/tc-server/src/main/java/com/tc/objectserver/core/impl/GuardianContext.java
@@ -57,7 +57,7 @@ public class GuardianContext {
       props.setProperty("clientID", Long.toString(cid.toLong()));
       return props;
     } else {
-      Properties props = new Properties();
+      Properties props = new Properties(existing);
       if (callName != null) {
         props.setProperty("id", callName);
       }


### PR DESCRIPTION
This is a proposed fix for https://github.com/Terracotta-OSS/terracotta-platform/pull/1268#issuecomment-4127830174 but I have no clue how much it can impact other places