### PR TITLE
Invoke Context for server messages

### DIFF
--- a/tc-messaging/src/main/java/com/tc/l2/msg/SyncReplicationActivity.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/SyncReplicationActivity.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -61,12 +61,12 @@ public class SyncReplicationActivity implements OrderedEventContext {
     DESTROY_ENTITY,
     FETCH_ENTITY,
     RELEASE_ENTITY,
-    
+
     /**
      * The SYNC_START message is special in that it tells the passive to setup the synchronization machinery.
      */
     SYNC_START,
-    
+
     /**
      * It is the SYNC_BEGIN message which actually contains the information to describe all the entities which will be
      *  synchronized, in order, and how to create them.
@@ -76,7 +76,7 @@ public class SyncReplicationActivity implements OrderedEventContext {
      */
     SYNC_BEGIN,
     SYNC_END,
-    
+
     /**
      * Tells the passive that the active is next going to begin syncing this entity.
      * NOTE:  This entity should have already been created in SYNC_BEGIN.
@@ -86,7 +86,7 @@ public class SyncReplicationActivity implements OrderedEventContext {
     SYNC_ENTITY_CONCURRENCY_BEGIN,
     SYNC_ENTITY_CONCURRENCY_PAYLOAD,
     SYNC_ENTITY_CONCURRENCY_END,
-    
+
     DISCONNECT_CLIENT;
   }
 
@@ -136,17 +136,17 @@ public class SyncReplicationActivity implements OrderedEventContext {
     int referenceCount = 0;
     return new SyncReplicationActivity(ActivityID.getNextID(), null, EntityID.NULL_ID, EntityDescriptor.INVALID_VERSION, fetch, src, instance, tid, oldest, ActivityType.ORDERING_PLACEHOLDER, null, 0, referenceCount, debugId);
   }
-  
+
   private static EnumSet<ActivityType> lifecycle = EnumSet.of(
-      ActivityType.CREATE_ENTITY, 
+      ActivityType.CREATE_ENTITY,
       ActivityType.DESTROY_ENTITY,
       ActivityType.FETCH_ENTITY,
       ActivityType.RELEASE_ENTITY,
       ActivityType.RECONFIGURE_ENTITY,
       ActivityType.DISCONNECT_CLIENT
     );
-      
-  
+
+
   public static SyncReplicationActivity createLifecycleMessage(EntityID eid, long version, FetchID fetch, ClientID src, ClientInstanceID instance, TransactionID tid, TransactionID oldest, ActivityType action, TCByteBuffer payload) {
     Assert.assertTrue(lifecycle.contains(action));
     return new SyncReplicationActivity(ActivityID.getNextID(),null,eid,version,fetch,src,instance,tid,oldest,action,payload,0,0,null);
@@ -186,7 +186,7 @@ public class SyncReplicationActivity implements OrderedEventContext {
   }
 
   public static SyncReplicationActivity createEndEntityKeyMessage(EntityID id, long version, FetchID fetchID, int concurrency) {
-    // We can only synchronize positive-number keys.    
+    // We can only synchronize positive-number keys.
     Assert.assertTrue(concurrency > 0);
     int referenceCount = 0;
     return new SyncReplicationActivity(ActivityID.getNextID(), null, id, version, fetchID, ClientID.NULL_ID, ClientInstanceID.NULL_ID, TransactionID.NULL_ID, TransactionID.NULL_ID, ActivityType.SYNC_ENTITY_CONCURRENCY_END, null, concurrency, referenceCount, null);
@@ -218,7 +218,7 @@ public class SyncReplicationActivity implements OrderedEventContext {
   final int concurrency;
   // NOTE:  referenceCount is only used by SYNC_ENTITY_BEGIN.
   final int referenceCount;
-  
+
   final FetchID fetchID;
 
   final String debugId;
@@ -235,7 +235,7 @@ public class SyncReplicationActivity implements OrderedEventContext {
     Assert.assertNotNull(src);
     Assert.assertNotNull(tid);
     Assert.assertNotNull(oldest);
-    
+
     this.id = id;
     this.action = action;
     this.entitiesForSyncStart = entitiesForSyncStart;
@@ -270,26 +270,26 @@ public class SyncReplicationActivity implements OrderedEventContext {
 //    Assert.assertTrue(ActivityType.SYNC_BEGIN != this.action);
     return payload == null ? TCByteBufferFactory.getInstance(0) : payload.duplicate();
   }
-  
+
   public ClientID getSource() {
     Assert.assertTrue(ActivityType.SYNC_BEGIN != this.action);
     return src;
   }
-  
+
   public ClientInstanceID getClientInstanceID() {
     Assert.assertTrue(ActivityType.SYNC_BEGIN != this.action);
     return instance;
-  }  
-  
+  }
+
   public TransactionID getTransactionID() {
     return tid;
   }
-  
+
   public TransactionID getOldestTransactionOnClient() {
     Assert.assertTrue(ActivityType.SYNC_BEGIN != this.action);
     return oldest;
   }
-  
+
   public EntityID getEntityID() {
     return entityID;
   }
@@ -298,14 +298,10 @@ public class SyncReplicationActivity implements OrderedEventContext {
     return version;
   }
 
-  public ClientID getSrc() {
-    return src;
-  }
-
   public FetchID getFetchID() {
     return fetchID;
   }
-  
+
   public int getConcurrency() {
     // SYNC_ENTITY_BEGIN contains reference-count, not concurrency.
     Assert.assertFalse(ActivityType.SYNC_ENTITY_BEGIN == this.action);
@@ -339,10 +335,10 @@ public class SyncReplicationActivity implements OrderedEventContext {
     Assert.assertTrue(ActivityType.FLUSH_LOCAL_PIPELINE != this.action);
     // We should NOT be serializing local flush activities.
     Assert.assertTrue(ActivityType.LOCAL_ENTITY_GC != this.action);
-        
+
     out.writeLong(this.id.id);
     out.writeInt(this.action.ordinal());
-    
+
     // We take very different paths depending on our type.
     if (ActivityType.SYNC_BEGIN == this.action) {
       out.writeInt(this.entitiesForSyncStart.length);
@@ -362,7 +358,7 @@ public class SyncReplicationActivity implements OrderedEventContext {
       out.writeLong(instance.getID());
       out.writeLong(tid.toLong());
       out.writeLong(oldest.toLong());
-      
+
       if (payload != null) {
 //        byte[] data = TCByteBufferFactory.unwrap(payload);
 //        out.writeInt(data.length);
@@ -391,7 +387,7 @@ public class SyncReplicationActivity implements OrderedEventContext {
   public static SyncReplicationActivity deserializeFrom(TCByteBufferInput in) throws IOException {
     ActivityID activityID = new ActivityID(in.readLong());
     ActivityType action = ActivityType.values()[in.readInt()];
-    
+
     // We take very different paths depending on our type.
     EntityCreationTuple[] entitiesForSyncStart = null;
     EntityID entityID = EntityID.NULL_ID;
@@ -423,12 +419,12 @@ public class SyncReplicationActivity implements OrderedEventContext {
       instance =  new ClientInstanceID(in.readLong());
       tid = new TransactionID(in.readLong());
       oldest = new TransactionID(in.readLong());
-      
+
       int length = in.readInt();
       if (length > 0) {
         payload = in.read(length);
       }
-      
+
       // Note that we only pass concurrency key or reference count in certain cases.
       concurrency = 0;
       referenceCount = 0;
@@ -459,8 +455,8 @@ public class SyncReplicationActivity implements OrderedEventContext {
     public final long consumerID;
     public final byte[] configPayload;
     public final boolean canDelete;
-    
-    
+
+
     public EntityCreationTuple(EntityID id, long version, long consumerID, byte[] configPayload, boolean canDelete) {
       this.id = id;
       this.version = version;
@@ -468,7 +464,7 @@ public class SyncReplicationActivity implements OrderedEventContext {
       this.configPayload = configPayload;
       this.canDelete = canDelete;
     }
-    
+
     public void serializeTo(TCByteBufferOutput out) {
       this.id.serializeTo(out);
       out.writeLong(this.version);

--- a/tc-messaging/src/main/java/com/tc/l2/msg/SyncReplicationActivity.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/SyncReplicationActivity.java
@@ -55,12 +55,37 @@ public class SyncReplicationActivity implements OrderedEventContext {
      *  run as a placeholder of ordering data (which matters for correctly ordering re-sends upon fail-over).
      */
     ORDERING_PLACEHOLDER,
-    CREATE_ENTITY,
-    RECONFIGURE_ENTITY,
+    CREATE_ENTITY {
+      @Override
+      public boolean isLifecycleActivity() {
+        return true;
+      }
+    },
+    RECONFIGURE_ENTITY {
+      @Override
+      public boolean isLifecycleActivity() {
+        return true;
+      }
+    },
     INVOKE_ACTION,
-    DESTROY_ENTITY,
-    FETCH_ENTITY,
-    RELEASE_ENTITY,
+    DESTROY_ENTITY {
+      @Override
+      public boolean isLifecycleActivity() {
+        return true;
+      }
+    },
+    FETCH_ENTITY {
+      @Override
+      public boolean isLifecycleActivity() {
+        return true;
+      }
+    },
+    RELEASE_ENTITY {
+      @Override
+      public boolean isLifecycleActivity() {
+        return true;
+      }
+    },
 
     /**
      * The SYNC_START message is special in that it tells the passive to setup the synchronization machinery.
@@ -88,6 +113,10 @@ public class SyncReplicationActivity implements OrderedEventContext {
     SYNC_ENTITY_CONCURRENCY_END,
 
     DISCONNECT_CLIENT;
+
+    public boolean isLifecycleActivity() {
+      return false;
+    }
   }
 
 

--- a/tc-server/src/main/java/com/tc/objectserver/core/impl/GuardianContext.java
+++ b/tc-server/src/main/java/com/tc/objectserver/core/impl/GuardianContext.java
@@ -45,7 +45,7 @@ public class GuardianContext {
   public static void setServer(TCServerImpl server) {
     GuardianContext.server = server;
   }
-  
+
   private static Properties createGuardContext(String callName) {
     return createGuardContext(callName, new Properties());
   }
@@ -64,7 +64,7 @@ public class GuardianContext {
       return props;
     }
   }
-  
+
   private static Properties createGuardContext(String callName, Properties props, MessageChannel c) {
     if (callName != null) {
       props.setProperty("id", callName);
@@ -88,7 +88,7 @@ public class GuardianContext {
     }
     return props;
   }
-  
+
   private static void translateMaptoProperty(Properties props, String root, Map<String, ?> map) {
     map.forEach((k, v) -> {
       if (v instanceof Map) {
@@ -106,11 +106,11 @@ public class GuardianContext {
   public static void channelRemoved(MessageChannel channel) {
     CONTEXT.remove(channel.getChannelID());
   }
-  
+
   public static void clientRemoved(ClientID removed) {
     CONTEXT.remove(removed.getChannelID());
   }
-  
+
   public static boolean attach(String name, Object data) {
     MessageChannel channel = CONTEXT.get(CURRENTID.get());
     if (channel != null) {
@@ -120,26 +120,30 @@ public class GuardianContext {
       return false;
     }
   }
-  
+
   public static void setCurrentChannelID(ChannelID cid) {
     CURRENTID.set(cid);
   }
-  
+
   public static void clearCurrentChannelID(ChannelID cid) {
     ChannelID current = CURRENTID.get();
     Assert.assertEquals(cid, current);
     CURRENTID.remove();
   }
-  
+
   public static Properties getCurrentChannelProperties() {
     return createGuardContext("context");
   }
 
   public static MessageChannel getCurrentMessageChannel() {
     ChannelID current = CURRENTID.get();
-    return CONTEXT.get(current);
+    if (current != null) {
+      return CONTEXT.get(current);
+    } else {
+      return null;
+    }
   }
-  
+
   private static Guardian getOperationGuardian() {
     if (server != null) {
       DistributedObjectServer dso = server.getDSOServer();
@@ -152,11 +156,11 @@ public class GuardianContext {
     }
     return (o, p)->true;
   }
-  
+
   public static boolean validate(Guardian.Op op, String id) {
     return getOperationGuardian().validate(op, createGuardContext(id));
   }
-  
+
   public static boolean validate(Guardian.Op op, String id, MessageChannel channel) {
     return validate(op, id, new Properties(), channel);
   }

--- a/tc-server/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/tc-server/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import com.tc.exception.TCServerRestartException;
 import com.tc.exception.TCShutdownServerException;
 import com.tc.l2.msg.SyncReplicationActivity;
 import com.tc.net.ClientID;
+import com.tc.net.protocol.tcm.MessageChannel;
 import com.tc.net.utils.L2Utils;
 import com.tc.object.ClientInstanceID;
 import com.tc.object.EntityDescriptor;
@@ -472,6 +473,12 @@ public class ManagedEntityImpl implements ManagedEntity {
     Lock read = reconnectAccessLock.readLock();
     logger.info("Client:" + request.getNodeID() + ":" + request.getClientInstance() + " Invoking lifecycle " + request.getAction() + " on " + getID() + ":" + this.fetchID);
     GuardianContext.setCurrentChannelID(request.getNodeID().getChannelID());
+    MessageChannel channel = GuardianContext.getCurrentMessageChannel();
+    if (channel != null) {
+      channel.addAttachment("TransactionID", request.getTransaction(), true);
+      channel.addAttachment("OldestTransactionID", request.getOldestTransactionOnClient(), true);
+      channel.addAttachment("ClientInstanceID", request.getClientInstance(), true);
+    }
     read.lock();
     try {
       switch (request.getAction()) {
@@ -534,7 +541,7 @@ public class ManagedEntityImpl implements ManagedEntity {
       logger.error("configuration error during a lifecyle operation ", ce);
       resp.failure(ServerException.createConfigurationException(id, ce));
     } catch (TCShutdownServerException | TCServerRestartException shutdown) {
-      throw shutdown;      
+      throw shutdown;
     } catch (RuntimeException rt) {
       throw rt;
     } catch (Exception e) {
@@ -577,6 +584,12 @@ public class ManagedEntityImpl implements ManagedEntity {
     response.received(); // call received locally
 
     GuardianContext.setCurrentChannelID(request.getNodeID().getChannelID());
+    MessageChannel channel = GuardianContext.getCurrentMessageChannel();
+    if (channel != null) {
+      channel.addAttachment("TransactionID", request.getTransaction(), true);
+      channel.addAttachment("OldestTransactionID", request.getOldestTransactionOnClient(), true);
+      channel.addAttachment("ClientInstanceID", request.getClientInstance(), true);
+    }
     Lock read = reconnectAccessLock.readLock();
     try {
       read.lock();
@@ -979,17 +992,17 @@ public class ManagedEntityImpl implements ManagedEntity {
       ClientID clientID = getEntityRequest.getNodeID();
       ClientDescriptorImpl descriptor = new ClientDescriptorImpl(clientID, getEntityRequest.getClientInstance());
       boolean added = clientEntityStateManager.addReference(descriptor, this.fetchID);
-      
+
       if (canDelete) {
         if (added) {
           clientReferenceCount += 1;
           Assert.assertTrue(clientReferenceCount > 0);
         } else {
-          // this should never happen.  Ther server is expecting sane things from the client. 
+          // this should never happen.  Ther server is expecting sane things from the client.
           logger.warn("the client has attempted to fetch the same entity instance twice {}", descriptor);
         }
       }
-      
+
       if (this.isInActiveState) {
         if (!added) {
           //  Exception the client.  Don't crash the server
@@ -1069,7 +1082,7 @@ public class ManagedEntityImpl implements ManagedEntity {
           response.failure(ServerException.createNotFoundException(id));
           return;
         }
-        
+
         this.activeServerEntity.disconnected(clientInstance);
         // Fire the event that the client released the entity.
         this.eventCollector.clientDidReleaseEntity(clientID, this.id, this.consumerID, request.getClientInstance());

--- a/tc-server/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/tc-server/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -96,6 +96,8 @@ import org.terracotta.tripwire.TripwireFactory;
 
 
 public class ManagedEntityImpl implements ManagedEntity {
+  public static final String REQUEST_CONTEXT_KEY = "RequestContext";
+
   private static final Logger logger   = LoggerFactory.getLogger(ManagedEntityImpl.class);
 
   private final RequestProcessor executor;
@@ -467,33 +469,31 @@ public class ManagedEntityImpl implements ManagedEntity {
     return null;
   }
 
-  private void setThreadLocalAttachment(MessageChannel channel, String name, Object value) {
-    @SuppressWarnings("unchecked")
-    ThreadLocal<Object> local = (ThreadLocal<Object>)channel.getAttachment(name);
-
-    if (local == null) {
-      local = (ThreadLocal<Object>)channel.getAttachment(name);
-      if (local == null) {
-        local = new ThreadLocal<>();
-        channel.addAttachment(name, local, false);
-      }
-    }
-
-    local.set(value);
-  }
-
-  private void clearThreadLocalAttachments(MessageChannel channel) {
+  private void setRequestContext(MessageChannel channel, ServerEntityRequest request) {
     if (channel == null) {
       return;
     }
 
-    String[] keys = {"TransactionID", "OldestTransactionID", "ClientInstanceID"};
-    for (String key : keys) {
-      @SuppressWarnings("unchecked")
-      ThreadLocal<Object> local = (ThreadLocal<Object>) channel.getAttachment(key);
-      if (local != null) {
-        local.remove();
-      }
+    @SuppressWarnings("unchecked")
+    ThreadLocal<ServerEntityRequest> local = (ThreadLocal<ServerEntityRequest>) channel.getAttachment(REQUEST_CONTEXT_KEY);
+
+    if (local == null) {
+      channel.addAttachment(REQUEST_CONTEXT_KEY, new ThreadLocal<>(), false);
+      local = (ThreadLocal<ServerEntityRequest>) channel.getAttachment(REQUEST_CONTEXT_KEY);
+    }
+
+    local.set(request);
+  }
+
+  private void clearRequestContext(MessageChannel channel) {
+    if (channel == null) {
+      return;
+    }
+
+    @SuppressWarnings("unchecked")
+    ThreadLocal<ServerEntityRequest> local = (ThreadLocal<ServerEntityRequest>) channel.getAttachment(REQUEST_CONTEXT_KEY);
+    if (local != null) {
+      local.remove();
     }
   }
 
@@ -504,11 +504,7 @@ public class ManagedEntityImpl implements ManagedEntity {
     logger.info("Client:" + request.getNodeID() + ":" + request.getClientInstance() + " Invoking lifecycle " + request.getAction() + " on " + getID() + ":" + this.fetchID);
     GuardianContext.setCurrentChannelID(request.getNodeID().getChannelID());
     MessageChannel channel = GuardianContext.getCurrentMessageChannel();
-    if (channel != null) {
-      setThreadLocalAttachment(channel, "TransactionID", request.getTransaction());
-      setThreadLocalAttachment(channel, "OldestTransactionID", request.getOldestTransactionOnClient());
-      setThreadLocalAttachment(channel, "ClientInstanceID", request.getClientInstance());
-    }
+    setRequestContext(channel, request);
     read.lock();
     try {
       switch (request.getAction()) {
@@ -581,8 +577,8 @@ public class ManagedEntityImpl implements ManagedEntity {
       throw uncaught;
     } finally {
       read.unlock();
-      clearThreadLocalAttachments(channel);
       GuardianContext.clearCurrentChannelID(request.getNodeID().getChannelID());
+      clearRequestContext(channel);
       if (this.isInActiveState) {
         interop.finishLifecycle();
       }
@@ -616,11 +612,7 @@ public class ManagedEntityImpl implements ManagedEntity {
 
     GuardianContext.setCurrentChannelID(request.getNodeID().getChannelID());
     MessageChannel channel = GuardianContext.getCurrentMessageChannel();
-    if (channel != null) {
-      setThreadLocalAttachment(channel, "TransactionID", request.getTransaction());
-      setThreadLocalAttachment(channel, "OldestTransactionID", request.getOldestTransactionOnClient());
-      setThreadLocalAttachment(channel, "ClientInstanceID", request.getClientInstance());
-    }
+    setRequestContext(channel, request);
     Lock read = reconnectAccessLock.readLock();
     try {
       read.lock();
@@ -659,8 +651,8 @@ public class ManagedEntityImpl implements ManagedEntity {
       throw new RuntimeException(e);
     } finally {
       read.unlock();
-      clearThreadLocalAttachments(channel);
       GuardianContext.clearCurrentChannelID(request.getNodeID().getChannelID());
+      clearRequestContext(channel);
     }
     trace.end();
   }

--- a/tc-server/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/tc-server/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -467,6 +467,36 @@ public class ManagedEntityImpl implements ManagedEntity {
     return null;
   }
 
+  private void setThreadLocalAttachment(MessageChannel channel, String name, Object value) {
+    @SuppressWarnings("unchecked")
+    ThreadLocal<Object> local = (ThreadLocal<Object>)channel.getAttachment(name);
+
+    if (local == null) {
+      local = (ThreadLocal<Object>)channel.getAttachment(name);
+      if (local == null) {
+        local = new ThreadLocal<>();
+        channel.addAttachment(name, local, false);
+      }
+    }
+
+    local.set(value);
+  }
+
+  private void clearThreadLocalAttachments(MessageChannel channel) {
+    if (channel == null) {
+      return;
+    }
+
+    String[] keys = {"TransactionID", "OldestTransactionID", "ClientInstanceID"};
+    for (String key : keys) {
+      @SuppressWarnings("unchecked")
+      ThreadLocal<Object> local = (ThreadLocal<Object>) channel.getAttachment(key);
+      if (local != null) {
+        local.remove();
+      }
+    }
+  }
+
   private void invokeLifecycleOperation(final ServerEntityRequest request, MessagePayload payload, ResultCapture resp) {
     Trace trace = new Trace(request.getTraceID(), "ManagedEntityImpl.invokeLifecycleOperation");
     trace.start();
@@ -475,9 +505,9 @@ public class ManagedEntityImpl implements ManagedEntity {
     GuardianContext.setCurrentChannelID(request.getNodeID().getChannelID());
     MessageChannel channel = GuardianContext.getCurrentMessageChannel();
     if (channel != null) {
-      channel.addAttachment("TransactionID", request.getTransaction(), true);
-      channel.addAttachment("OldestTransactionID", request.getOldestTransactionOnClient(), true);
-      channel.addAttachment("ClientInstanceID", request.getClientInstance(), true);
+      setThreadLocalAttachment(channel, "TransactionID", request.getTransaction());
+      setThreadLocalAttachment(channel, "OldestTransactionID", request.getOldestTransactionOnClient());
+      setThreadLocalAttachment(channel, "ClientInstanceID", request.getClientInstance());
     }
     read.lock();
     try {
@@ -551,6 +581,7 @@ public class ManagedEntityImpl implements ManagedEntity {
       throw uncaught;
     } finally {
       read.unlock();
+      clearThreadLocalAttachments(channel);
       GuardianContext.clearCurrentChannelID(request.getNodeID().getChannelID());
       if (this.isInActiveState) {
         interop.finishLifecycle();
@@ -586,9 +617,9 @@ public class ManagedEntityImpl implements ManagedEntity {
     GuardianContext.setCurrentChannelID(request.getNodeID().getChannelID());
     MessageChannel channel = GuardianContext.getCurrentMessageChannel();
     if (channel != null) {
-      channel.addAttachment("TransactionID", request.getTransaction(), true);
-      channel.addAttachment("OldestTransactionID", request.getOldestTransactionOnClient(), true);
-      channel.addAttachment("ClientInstanceID", request.getClientInstance(), true);
+      setThreadLocalAttachment(channel, "TransactionID", request.getTransaction());
+      setThreadLocalAttachment(channel, "OldestTransactionID", request.getOldestTransactionOnClient());
+      setThreadLocalAttachment(channel, "ClientInstanceID", request.getClientInstance());
     }
     Lock read = reconnectAccessLock.readLock();
     try {
@@ -628,6 +659,7 @@ public class ManagedEntityImpl implements ManagedEntity {
       throw new RuntimeException(e);
     } finally {
       read.unlock();
+      clearThreadLocalAttachments(channel);
       GuardianContext.clearCurrentChannelID(request.getNodeID().getChannelID());
     }
     trace.end();

--- a/tc-server/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/tc-server/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -543,8 +543,8 @@ public class ReplicatedTransactionHandler {
 
   private ServerEntityRequest activityToLocalRequest(SyncReplicationActivity activity) {
     ActivityType activityType = activity.getActivityType();
-    ClientID source = isReplica ? activity.getSource() : ClientID.NULL_ID;
-    ClientInstanceID instance = isReplica ? activity.getClientInstanceID() : ClientInstanceID.NULL_ID;
+    ClientID source = isReplica && activityType == ActivityType.INVOKE_ACTION ? ClientID.NULL_ID : activity.getSource();
+    ClientInstanceID instance = isReplica && activityType == ActivityType.INVOKE_ACTION ? ClientInstanceID.NULL_ID : activity.getClientInstanceID();
     TransactionID transactionID = activity.getTransactionID();
     TransactionID oldestTransactionID = activity.getOldestTransactionOnClient();
     Assert.assertTrue(ActivityType.SYNC_BEGIN != activityType);

--- a/tc-server/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/tc-server/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -81,14 +81,16 @@ import org.terracotta.tripwire.TripwireFactory;
 public class ReplicatedTransactionHandler {
   private static final Logger PLOGGER = LoggerFactory.getLogger(MessagePayload.class);
   private static final Logger LOGGER = LoggerFactory.getLogger(ReplicatedTransactionHandler.class);
-  
+
   private final PassiveAckSender ackMessenger;
-  
+
   private final EntityManager entityManager;
   private final Persistor persistor;
   private final StateManager stateManager;
   private final ManagedEntity platform;
-  
+
+  private final boolean isReplica;
+
   private final SyncState state = new SyncState();
 
   private volatile long currentSequence = 0;
@@ -96,9 +98,9 @@ public class ReplicatedTransactionHandler {
   public long getCurrentSequence() {
     return currentSequence;
   }
-  
-  public ReplicatedTransactionHandler(StateManager state, Stage<Runnable> sendToActive, Persistor persistor, 
-      EntityManager manager, GroupManager<AbstractGroupMessage> groupManager) {
+
+  public ReplicatedTransactionHandler(StateManager state, Stage<Runnable> sendToActive, Persistor persistor,
+      EntityManager manager, GroupManager<AbstractGroupMessage> groupManager, boolean isReplica) {
     this.stateManager = state;
     this.entityManager = manager;
     this.persistor = persistor;
@@ -108,6 +110,7 @@ public class ReplicatedTransactionHandler {
     } catch (ServerException ee) {
       throw new RuntimeException(ee);
     }
+    this.isReplica = isReplica;
   }
 
   private final EventHandler<ReplicationMessage> eventHorizon = new AbstractEventHandler<ReplicationMessage>() {
@@ -181,15 +184,15 @@ public class ReplicatedTransactionHandler {
         BarrierCompletion latch = new BarrierCompletion();
         me.clearQueue();
         me.addRequestMessage(req,
-            MessagePayload.emptyPayload(), 
+            MessagePayload.emptyPayload(),
             new ResultCaptureImpl(null, (result)->latch.complete(), null, exception->latch.failure(exception)));
         latch.waitForCompletion();
       }
       BarrierCompletion latch = new BarrierCompletion();
-      platform.addRequestMessage(req, MessagePayload.emptyPayload(), 
+      platform.addRequestMessage(req, MessagePayload.emptyPayload(),
           new ResultCaptureImpl(null, (result)->latch.complete(), null, exception->latch.failure(exception)));
 
-    }    
+    }
   };
 
   public EventHandler<ReplicationMessage> getEventHandler() {
@@ -256,7 +259,7 @@ public class ReplicatedTransactionHandler {
       long consumerID = tuple.consumerID;
       byte[] config = tuple.configPayload;
       boolean canDelete = tuple.canDelete;
-      
+
       if (!this.entityManager.getEntity(EntityDescriptor.createDescriptorForLifecycle(eid, version)).isPresent()) {
         ManagedEntity entity = this.entityManager.createEntity(eid, version, consumerID);
         Assert.assertTrue(entity.canDelete() == canDelete);
@@ -271,7 +274,7 @@ public class ReplicatedTransactionHandler {
     ackMessenger.acknowledge(activeSender, activity, ReplicationResultCode.SUCCESS);
   }
 
-//  don't need to worry about resends here for lifecycle messages.  active will filer them  
+//  don't need to worry about resends here for lifecycle messages.  active will filer them
   private void replicatedActivityReceived(ServerID activeSender, SyncReplicationActivity activity) throws ServerException {
     Trace trace = new Trace(String.valueOf(activity.getActivityID().id), "Replication");
     trace.start();
@@ -328,7 +331,7 @@ public class ReplicatedTransactionHandler {
         ManagedEntity entityInstance = entity.get();
         MessagePayload payload = MessagePayload.syncPayloadNormal(extendedData, activity.getConcurrency());
         if (null != request.getAction()) switch (request.getAction()) {
-          case RECONFIGURE_ENTITY:  
+          case RECONFIGURE_ENTITY:
             entityInstance.addRequestMessage(request, payload, createCapture(()->ackMessenger.ackReceived(activeSender, activity, transactionOrderPersistenceFuture),
               (result)->{
                 //  store the new configuration in the persistor
@@ -380,7 +383,7 @@ public class ReplicatedTransactionHandler {
             break;
           default:
             entityInstance.addRequestMessage(request, payload, createCapture(()->ackMessenger.ackReceived(activeSender, activity, transactionOrderPersistenceFuture),
-                (result)-> ackMessenger.acknowledge(activeSender, activity, ReplicationResultCode.SUCCESS), 
+                (result)-> ackMessenger.acknowledge(activeSender, activity, ReplicationResultCode.SUCCESS),
                 (exception) -> ackMessenger.acknowledge(activeSender, activity, ReplicationResultCode.FAIL)));
             break;
         }
@@ -391,11 +394,11 @@ public class ReplicatedTransactionHandler {
     }
     trace.end();
   }
-  
+
   private ResultCapture createCapture(Runnable received, Consumer<byte[]> completed, Consumer<ServerException> failure) {
     return new PassiveResultCapture(received, completed, failure);
   }
-  
+
   private void establishNewPassive(ActivityID sequence) {
     ServerID local = ackMessenger.getLocalNodeID();
     Event event = TripwireFactory.createPrimeEvent(local.getName(), local.getUID(), SessionID.NULL_ID.toLong(), sequence.id);
@@ -409,40 +412,40 @@ public class ReplicatedTransactionHandler {
     moveToPassiveUnitialized(node);
     LOGGER.info("Requesting Passive Sync from " + node);
     ackMessenger.requestPassiveSync(node);
-  }  
-  
+  }
+
   private void syncActivityReceived(ServerID activeSender, SyncReplicationActivity activity) {
     Trace trace = new Trace(String.valueOf(activity.getActivityID().id), "Sync");
     trace.start();
     SyncReplicationActivity.ActivityType thisActivityType = activity.getActivityType();
     FetchID fetch = activity.getFetchID();
     EntityDescriptor descriptor = EntityDescriptor.createDescriptorForInvoke(fetch, ClientInstanceID.NULL_ID);
-    
+
     // This should have been handled in its own path.
     Assert.assertTrue(SyncReplicationActivity.ActivityType.SYNC_BEGIN != thisActivityType);
-    
+
     beforeSyncAction(activity);
-    
+
     if ((SyncReplicationActivity.ActivityType.SYNC_ENTITY_BEGIN == thisActivityType) && !fetch.isNull()) {
       try {
         // This should have already been created.
         Assert.assertTrue(this.entityManager.getEntity(descriptor).isPresent());
-        
+
         // Now we can actually start synchronizing the entity.
         // NOTE:  We need to update the reference count at this point.
         int referenceCount = activity.getReferenceCount();
         MessagePayload payload = MessagePayload.syncPayloadCreation(activity.getExtendedData(), referenceCount);
         BasicServerEntityRequest request = new BasicServerEntityRequest(ServerEntityAction.RECEIVE_SYNC_CREATE_ENTITY, activity.getSource(), activity.getClientInstanceID(), activity.getTransactionID(), activity.getOldestTransactionOnClient());
         this.entityManager.getEntity(descriptor).get().addRequestMessage(request, payload, createCapture(
-          null, 
-          (result)->{/* do nothing - this in-between state is temporary*/}, 
+          null,
+          (result)->{/* do nothing - this in-between state is temporary*/},
           (exception)->{ackMessenger.acknowledge(activeSender, activity, ReplicationResultCode.FAIL);}));
       } catch (ServerException exception) {
-//  TODO: this needs to be controlled.  
+//  TODO: this needs to be controlled.
         LOGGER.warn("entity has already been created", exception);
       }
     }
-        
+
     try {
       Optional<ManagedEntity> entity = entityManager.getEntity(descriptor);
       if (entity.isPresent()) {
@@ -457,8 +460,8 @@ public class ReplicatedTransactionHandler {
           payload = MessagePayload.syncPayloadNormal(activity.getExtendedData(), concurrencyKey);
         }
         entity.get().addRequestMessage(activityToLocalRequest(activity), payload, createCapture(
-            null, 
-            (result)->ackMessenger.acknowledge(activeSender, activity, ReplicationResultCode.SUCCESS), 
+            null,
+            (result)->ackMessenger.acknowledge(activeSender, activity, ReplicationResultCode.SUCCESS),
             (exception)->ackMessenger.acknowledge(activeSender, activity, ReplicationResultCode.FAIL)));
       } else {
         // We should have already created this.
@@ -488,31 +491,31 @@ public class ReplicatedTransactionHandler {
     }
     trace.end();
   }
-  
+
   private void start() {
     state.start();
   }
-  
+
   private void start(FetchID fetch) {
     state.startEntity(fetch);
   }
-  
+
   private void start(FetchID fetch, int concurrency) {
     state.startConcurrency(fetch, concurrency);
   }
-  
+
   private void finish() {
     scheduleDeferred(state.finish());
   }
-  
+
   private void finish(FetchID fetch) {
     state.endEntity(fetch);
   }
-  
+
   private void finish(FetchID fetch, int concurrency) {
     scheduleDeferred(state.endConcurrency(fetch, concurrency));
   }
-  
+
   private void scheduleDeferred(Deque<DeferredContainer> deferred) {
     if (deferred != null) {
       while(!deferred.isEmpty()) {
@@ -525,13 +528,13 @@ public class ReplicatedTransactionHandler {
       }
     }
   }
-  
+
   private void moveToPassiveUnitialized(NodeID connectedTo) {
     if (!stateManager.isActiveCoordinator()) {
       stateManager.moveToPassiveSyncing(connectedTo);
     }
   }
-  
+
   private void moveToPassiveStandBy() {
     if (!stateManager.isActiveCoordinator()) {
       stateManager.moveToPassiveStandbyState();
@@ -540,14 +543,14 @@ public class ReplicatedTransactionHandler {
 
   private ServerEntityRequest activityToLocalRequest(SyncReplicationActivity activity) {
     ActivityType activityType = activity.getActivityType();
-    ClientID source = activity.getSource();
-    ClientInstanceID instance = activity.getClientInstanceID();
+    ClientID source = isReplica ? activity.getSource() : ClientID.NULL_ID;
+    ClientInstanceID instance = isReplica ? activity.getClientInstanceID() : ClientInstanceID.NULL_ID;
     TransactionID transactionID = activity.getTransactionID();
     TransactionID oldestTransactionID = activity.getOldestTransactionOnClient();
     Assert.assertTrue(ActivityType.SYNC_BEGIN != activityType);
     return new BasicServerEntityRequest(decodeReplicationType(activityType), source, instance, transactionID, oldestTransactionID);
   }
-  
+
   private void beforeSyncAction(SyncReplicationActivity activity) {
     switch (activity.getActivityType()) {
       case SYNC_START:
@@ -623,23 +626,23 @@ public class ReplicatedTransactionHandler {
       default:
         throw new AssertionError("bad replication type: " + networkType);
     }
-  }  
-  
+  }
+
  private class SyncState {
     private LinkedList<DeferredContainer> defer = new LinkedList<>();
- //  at this point, id based checking is legacy.  Everything should have a fetchid.  TODO: remove 
+ //  at this point, id based checking is legacy.  Everything should have a fetchid.  TODO: remove
     private final Set<FetchID> syncdFetches = new HashSet<>();
     private final Set<Integer> syncdKeys = new HashSet<>();
- //  at this point, id based checking is legacy.  Everything should have a fetchid 
+ //  at this point, id based checking is legacy.  Everything should have a fetchid
     private FetchID syncingFetch = FetchID.NULL_ID;
     private int currentKey = -1;
     private boolean finished = false;
     private boolean started = false;
-    
+
     private void start() {
       started = true;
     }
-    
+
     private void startEntity(FetchID fetch) {
       assertStarted(null);
       Assert.assertTrue(syncingFetch.isNull());
@@ -649,7 +652,7 @@ public class ReplicatedTransactionHandler {
       syncdKeys.add(ConcurrencyStrategy.UNIVERSAL_KEY);
       LOGGER.debug("Starting " + fetch);
     }
-    
+
     private void endEntity(FetchID fetch) {
       assertStarted(null);
       Assert.assertEquals(syncingFetch, fetch);
@@ -658,7 +661,7 @@ public class ReplicatedTransactionHandler {
       syncingFetch = FetchID.NULL_ID;
       LOGGER.debug("Ending " + fetch);
     }
-    
+
     private void startConcurrency(FetchID fetch, int concurrency) {
       assertStarted(null);
       Assert.assertEquals(syncingFetch, fetch);
@@ -667,7 +670,7 @@ public class ReplicatedTransactionHandler {
         LOGGER.debug("Starting " + fetch + "/" + currentKey);
       }
     }
-    
+
     private Deque<DeferredContainer> endConcurrency(FetchID fetch, int concurrency) {
       assertStarted(null);
       try {
@@ -680,14 +683,14 @@ public class ReplicatedTransactionHandler {
         defer = new LinkedList<>();
       }
     }
-    
+
     private Deque<DeferredContainer> finish() {
       assertStarted(null);
       syncdFetches.clear();
       finished = true;
       return defer;
     }
-    
+
     private boolean ignore(SyncReplicationActivity activity) {
       if (!started) {
  // this passive has never been sync'd to anything, ignore all messages
@@ -697,7 +700,7 @@ public class ReplicatedTransactionHandler {
 //  done with sync, need to apply everything now
         return false;
       }
-      
+
       return false;
     }
 
@@ -711,8 +714,8 @@ public class ReplicatedTransactionHandler {
       FetchID fetch = activity.getFetchID();
       if (syncdFetches.contains(fetch)) {
         return false;
-      } 
-      
+      }
+
       SyncReplicationActivity.ActivityType activityType = activity.getActivityType();
 
       if (fetch.equals(syncingFetch)) {
@@ -731,8 +734,8 @@ public class ReplicatedTransactionHandler {
           defer.add(new DeferredContainer(activeSender, activity));
           return true;
         } else if (concurrencyKey == ConcurrencyStrategy.UNIVERSAL_KEY) {
-          // if a message comes on the universal key, make sure it lags at least one step by deferrign the 
-          // operation.  This prevents the invoke from possibly outracing the creation message at the start 
+          // if a message comes on the universal key, make sure it lags at least one step by deferrign the
+          // operation.  This prevents the invoke from possibly outracing the creation message at the start
           // of sync.  Consider deferring all universal key operations to the end of entity sync.
           defer.add(new DeferredContainer(activeSender, activity));
           return true;
@@ -740,18 +743,18 @@ public class ReplicatedTransactionHandler {
       }
       return false;
     }
-    
+
     /**
      * Note that this state machine the started flag can be used to assert consistency.
-     * 
-     * The start flag starts the valid stream for a passive.  A passive can only accept valid 
+     *
+     * The start flag starts the valid stream for a passive.  A passive can only accept valid
      * messages after sync has started on the server.  Prior to that, everything is invalid
      * and can be safely ignored.  Messages can be received prior to the start sync message
      * because replication started as soon as the active detects a connect from a passive.
-     * 
+     *
      * Sync start begins after the passive has successfully connected and requested to be sync'd
-     * 
-     * NOTE: it is possible in the multiple passive scenario, for a stream to start a new 
+     *
+     * NOTE: it is possible in the multiple passive scenario, for a stream to start a new
      * active but in this case, the server will have already been sync'd and thus valid
      */
     private void assertStarted(SyncReplicationActivity activity) {
@@ -759,7 +762,7 @@ public class ReplicatedTransactionHandler {
       Assert.assertTrue(activity, started);
     }
   }
- 
+
   public static class BasicServerEntityRequest implements ServerEntityRequest {
     private final ServerEntityAction action;
     private final ClientID source;
@@ -827,6 +830,6 @@ public class ReplicatedTransactionHandler {
   }
 
   public static class SedaToken {
-    
+
   }
 }

--- a/tc-server/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/tc-server/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -737,7 +737,7 @@ public class DistributedObjectServer {
     }
     // if no replcation events have been routed yet (not relay source) route them now
     if (replicationEvents == null) {
-      ReplicatedTransactionHandler replicatedTransactionHandler = new ReplicatedTransactionHandler(state, replicationResponseStage, this.persistor, entityManager, groupCommManager);
+      ReplicatedTransactionHandler replicatedTransactionHandler = new ReplicatedTransactionHandler(state, replicationResponseStage, this.persistor, entityManager, groupCommManager, configSetupManager.isRelayDestination());
       sequenceWeight.setReplicatedTransactionHandler(replicatedTransactionHandler);
       replicationEvents = replicatedTransactionHandler.getEventHandler();
     }

--- a/tc-server/src/main/java/com/tc/services/EntityMessengerService.java
+++ b/tc-server/src/main/java/com/tc/services/EntityMessengerService.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -23,12 +23,14 @@ import com.tc.bytes.TCByteBufferFactory;
 import com.tc.entity.VoltronEntityMessage;
 import com.tc.exception.ServerException;
 import com.tc.net.ClientID;
+import com.tc.net.protocol.tcm.MessageChannel;
 import com.tc.object.ClientInstanceID;
 import com.tc.object.EntityDescriptor;
 import com.tc.object.FetchID;
 import com.tc.object.tx.TransactionID;
 import com.tc.objectserver.api.ManagedEntity;
 import com.tc.objectserver.api.ManagedEntity.LifecycleListener;
+import com.tc.objectserver.core.impl.GuardianContext;
 import com.tc.objectserver.entity.CreateMessage;
 import com.tc.objectserver.entity.DestroyMessage;
 import com.tc.objectserver.entity.ReconfigureMessage;
@@ -107,7 +109,7 @@ public class EntityMessengerService<M extends EntityMessage, R extends EntityRes
     // Make sure we have started.
     scheduleMessage(message, response);
   }
-  
+
   @Override
   public ExplicitRetirementHandle deferRetirement(String tag,
                                                   M originalMessageToDefer,
@@ -117,12 +119,12 @@ public class EntityMessengerService<M extends EntityMessage, R extends EntityRes
     // return handle
     return new Handle(tag, futureMessage);
   }
-  
+
   @Override
   public void messageSelfAndDeferRetirement(M originalMessageToDefer,
                                             M newMessageToSchedule) throws MessageCodecException {
     this.messageSelfAndDeferRetirement(originalMessageToDefer, newMessageToSchedule, null);
-  }  
+  }
 
   @Override
   public void messageSelfAndDeferRetirement(M originalMessageToDefer,
@@ -132,7 +134,7 @@ public class EntityMessengerService<M extends EntityMessage, R extends EntityRes
     // Schedule the message, as per normal.
     scheduleMessage(newMessageToSchedule, response);
   }
-  
+
   @Override
   public synchronized void entityCreated(ManagedEntity sender) {
 
@@ -149,7 +151,7 @@ public class EntityMessengerService<M extends EntityMessage, R extends EntityRes
     FakeEntityMessage interEntityMessage = encodeAsFake(message, response);
     // if the entity isDestroyed(), this message could be being sent during the create sequence
 
-    // register this server message with the retirement manager.  Once the message is retired, 
+    // register this server message with the retirement manager.  Once the message is retired,
     // the retirement manager will take care off tracking.  This is needed so the entity is not
     // destroyed from under the server initiated message
     this.retirementManager.registerServerMessage(message);
@@ -170,6 +172,9 @@ public class EntityMessengerService<M extends EntityMessage, R extends EntityRes
     private final TCByteBuffer message;
     private final Consumer<MessageResponse<R>> response;
     private final boolean waitForReceived;
+    private final ClientID clientID;
+    private final TransactionID transactionID;
+    private final TransactionID oldestTransactionID;
 
     public FakeEntityMessage(EntityDescriptor descriptor, EntityMessage identityMessage, TCByteBuffer message, Consumer<MessageResponse<R>> response, boolean waitForReceived) {
       Assert.assertNotNull(message);
@@ -178,16 +183,33 @@ public class EntityMessengerService<M extends EntityMessage, R extends EntityRes
       this.message = message.asReadOnlyBuffer();
       this.response = response;
       this.waitForReceived = waitForReceived;
+      MessageChannel channel = GuardianContext.getCurrentMessageChannel();
+      ClientID cid = null;
+      TransactionID tid = null;
+      TransactionID oid = null;
+
+      if (channel != null) {
+        cid = (ClientID)channel.getRemoteNodeID();
+        tid = (TransactionID)channel.getAttachment("TransactionID");
+        oid = (TransactionID)channel.getAttachment("OldestTransactionID");
+      }
+      if (cid == null) cid = ClientID.NULL_ID;
+      if (tid == null) tid = new TransactionID(NEXT_FAKE_TXN_ID.incrementAndGet());
+      if (oid == null) oid = TransactionID.NULL_ID;
+
+      this.clientID = cid;
+      this.transactionID = tid;
+      this.oldestTransactionID = oid;
     }
 
     @Override
     public ClientID getSource() {
-      return ClientID.NULL_ID;
+      return clientID;
     }
 
     @Override
     public TransactionID getTransactionID() {
-      return new TransactionID(NEXT_FAKE_TXN_ID.incrementAndGet());
+      return this.transactionID;
     }
 
     @Override
@@ -209,7 +231,7 @@ public class EntityMessengerService<M extends EntityMessage, R extends EntityRes
     public boolean doesRequestRetired() {
       return false;
     }
-  
+
     @Override
     public Type getVoltronType() {
       return Type.INVOKE_ACTION;
@@ -222,14 +244,14 @@ public class EntityMessengerService<M extends EntityMessage, R extends EntityRes
 
     @Override
     public TransactionID getOldestTransactionOnClient() {
-      return TransactionID.NULL_ID;
+      return this.oldestTransactionID;
     }
 
     @Override
     public EntityMessage getEntityMessage() {
       return this.identityMessage;
     }
-    
+
     public Consumer<byte[]> getCompletionHandler() {
       return response == null ? null : (raw)->this.response.accept(new MessageResponse() {
         @Override
@@ -252,7 +274,7 @@ public class EntityMessengerService<M extends EntityMessage, R extends EntityRes
         }
       });
     }
-    
+
     public Consumer<ServerException> getExceptionHandler() {
       return response == null ? null : (exception)->this.response.accept(new MessageResponse() {
         @Override
@@ -304,7 +326,7 @@ public class EntityMessengerService<M extends EntityMessage, R extends EntityRes
         EntityMessengerService.this.messageSelf(futureMessage, consumer);
       }
     }
-    
+
     public boolean isActive() {
       return active;
     }

--- a/tc-server/src/main/java/com/tc/services/EntityMessengerService.java
+++ b/tc-server/src/main/java/com/tc/services/EntityMessengerService.java
@@ -30,9 +30,11 @@ import com.tc.object.FetchID;
 import com.tc.object.tx.TransactionID;
 import com.tc.objectserver.api.ManagedEntity;
 import com.tc.objectserver.api.ManagedEntity.LifecycleListener;
+import com.tc.objectserver.api.ServerEntityRequest;
 import com.tc.objectserver.core.impl.GuardianContext;
 import com.tc.objectserver.entity.CreateMessage;
 import com.tc.objectserver.entity.DestroyMessage;
+import static com.tc.objectserver.entity.ManagedEntityImpl.REQUEST_CONTEXT_KEY;
 import com.tc.objectserver.entity.ReconfigureMessage;
 import com.tc.objectserver.handler.RetirementManager;
 import com.tc.util.Assert;
@@ -173,8 +175,7 @@ public class EntityMessengerService<M extends EntityMessage, R extends EntityRes
     private final Consumer<MessageResponse<R>> response;
     private final boolean waitForReceived;
     private final ClientID clientID;
-    private final TransactionID transactionID;
-    private final TransactionID oldestTransactionID;
+    private final ServerEntityRequest parent;
 
     public FakeEntityMessage(EntityDescriptor descriptor, EntityMessage identityMessage, TCByteBuffer message, Consumer<MessageResponse<R>> response, boolean waitForReceived) {
       Assert.assertNotNull(message);
@@ -184,22 +185,14 @@ public class EntityMessengerService<M extends EntityMessage, R extends EntityRes
       this.response = response;
       this.waitForReceived = waitForReceived;
       MessageChannel channel = GuardianContext.getCurrentMessageChannel();
-      ClientID cid = null;
-      TransactionID tid = null;
-      TransactionID oid = null;
 
       if (channel != null) {
-        cid = (ClientID)channel.getRemoteNodeID();
-        tid = (TransactionID)channel.getAttachment("TransactionID");
-        oid = (TransactionID)channel.getAttachment("OldestTransactionID");
+        this.clientID = (ClientID)channel.getRemoteNodeID();
+        parent = (ServerEntityRequest)channel.getAttachment(REQUEST_CONTEXT_KEY);
+      } else {
+        this.clientID = ClientID.NULL_ID;
+        this.parent = null;
       }
-      if (cid == null) cid = ClientID.NULL_ID;
-      if (tid == null) tid = new TransactionID(NEXT_FAKE_TXN_ID.incrementAndGet());
-      if (oid == null) oid = TransactionID.NULL_ID;
-
-      this.clientID = cid;
-      this.transactionID = tid;
-      this.oldestTransactionID = oid;
     }
 
     @Override
@@ -209,7 +202,7 @@ public class EntityMessengerService<M extends EntityMessage, R extends EntityRes
 
     @Override
     public TransactionID getTransactionID() {
-      return this.transactionID;
+      return this.parent == null ? new TransactionID(NEXT_FAKE_TXN_ID.incrementAndGet()) : parent.getTransaction();
     }
 
     @Override
@@ -244,7 +237,7 @@ public class EntityMessengerService<M extends EntityMessage, R extends EntityRes
 
     @Override
     public TransactionID getOldestTransactionOnClient() {
-      return this.oldestTransactionID;
+      return this.parent == null ? TransactionID.NULL_ID : parent.getOldestTransactionOnClient();
     }
 
     @Override

--- a/tc-server/src/main/java/com/tc/services/TerracottaServiceProviderRegistry.java
+++ b/tc-server/src/main/java/com/tc/services/TerracottaServiceProviderRegistry.java
@@ -18,7 +18,6 @@
 package com.tc.services;
 
 import com.tc.config.ServerConfigurationManager;
-import org.terracotta.configuration.Configuration;
 
 import org.terracotta.entity.PlatformConfiguration;
 import org.terracotta.entity.ServiceProvider;

--- a/tc-server/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
+++ b/tc-server/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -90,19 +90,19 @@ public class ReplicatedTransactionHandlerTest {
   private EntityManager entityManager;
   private ManagedEntity platform;
   private GroupManager<AbstractGroupMessage> groupManager;
-  
+
   private long rid = 0;
-  
+
   @SuppressWarnings("unchecked")
   @Before
   public void setUp() throws Exception {
     this.entityPersistor = mock(EntityPersistor.class);
     this.transactionOrderPersistor = mock(TransactionOrderPersistor.class);
-    
+
     Persistor persistor = mock(Persistor.class);
     when(persistor.getEntityPersistor()).thenReturn(this.entityPersistor);
     when(persistor.getTransactionOrderPersistor()).thenReturn(this.transactionOrderPersistor);
-    
+
     this.stateManager = mock(StateManager.class);
     this.entityManager = mock(EntityManager.class);
     this.groupManager = mock(GroupManager.class);
@@ -125,26 +125,26 @@ public class ReplicatedTransactionHandlerTest {
       return null;
     }).when(sink).addToSink(any(Runnable.class));
 
-    this.rth = new ReplicatedTransactionHandler(stateManager, runner, persistor, this.entityManager, this.groupManager);
+    this.rth = new ReplicatedTransactionHandler(stateManager, runner, persistor, this.entityManager, this.groupManager, false);
     // We need to do things like serialize/deserialize this so we can't easily use a mocked source.
     this.source = new ClientID(1);
     this.instance = new ClientInstanceID(1);
-    
+
     MessageChannel messageChannel = mock(MessageChannel.class);
     when(messageChannel.createMessage(TCMessageType.VOLTRON_ENTITY_COMPLETED_RESPONSE)).thenReturn(mock(VoltronEntityAppliedResponse.class));
     when(messageChannel.createMessage(TCMessageType.VOLTRON_ENTITY_RECEIVED_RESPONSE)).thenReturn(mock(VoltronEntityReceivedResponse.class));
-    
+
     DSOChannelManager channelManager = mock(DSOChannelManager.class);
     when(channelManager.getActiveChannel(this.source)).thenReturn(messageChannel);
-        
+
     this.loopbackSink = new ForwardingSink<ReplicationMessage>(this.rth.getEventHandler());
   }
-    
+
   private void sendNoop(EntityID eid, FetchID fetch, ServerEntityAction action) {
     ReplicationMessage flush = ReplicationMessage.createLocalContainer(SyncReplicationActivity.createFlushLocalPipelineMessage(fetch, action.replicationType()));
     loopbackSink.addToSink(flush);
   }
-  
+
   @Test
   public void testEntityNoIgnoresDuringSyncOfKey() throws Exception {
     EntityID eid = new EntityID("foo", "bar");
@@ -191,8 +191,8 @@ public class ReplicatedTransactionHandlerTest {
     verify(activity).getExtendedData();
     // Note that we want to verify 2 ACK messages:  RECEIVED and COMPLETED.
     verify(groupManager, times(2)).sendToWithSentCallback(eq(sid), any(), any());
-  }  
-  
+  }
+
   @Test
   public void testEntityGetsConcurrencyKey() throws Exception {
     EntityID eid = new EntityID("foo", "bar");
@@ -229,13 +229,13 @@ public class ReplicatedTransactionHandlerTest {
     // Note that we want to verify 2 ACK messages:  RECEIVED and COMPLETED.
     verify(groupManager, times(2)).sendToWithSentCallback(eq(sid), any(), any());
   }
-  
+
   @Test
   public void testDestroy() throws Exception {
     this.rth.getEventHandler().destroy();
     verify(platform).addRequestMessage(any(ServerEntityRequest.class), any(MessagePayload.class), any());
   }
-  
+
   @Test
   public void testLifecycleGetsJournaled() throws Exception {
     EntityID eid = new EntityID("test","test");
@@ -264,7 +264,7 @@ public class ReplicatedTransactionHandlerTest {
     this.rth.getEventHandler().handleEvent(create);
     verify(entityPersistor).entityCreated(eq(cid), eq(tid.toLong()), eq(old.toLong()), eq(eid), eq(1L), eq(1L), eq(true), any(byte[].class));
   }
-  
+
   @Test
   public void testManagedEntityGC() throws Exception {
     EntityID entityID = new EntityID("TEST", "TEST");
@@ -288,7 +288,7 @@ public class ReplicatedTransactionHandlerTest {
         return Optional.empty();
       }
     });
-    
+
     when(this.entityManager.createEntity(Mockito.eq(entityID), Mockito.anyLong(), anyLong())).thenReturn(entity);
     this.rth.getEventHandler().handleEvent(ReplicationMessage.createLocalContainer(SyncReplicationActivity.createStartSyncMessage(new SyncReplicationActivity.EntityCreationTuple[0])));
     ByteArrayOutputStream bout = new ByteArrayOutputStream();
@@ -308,7 +308,7 @@ public class ReplicatedTransactionHandlerTest {
     this.rth.getEventHandler().handleEvent(destroy);
     verify(entityManager).removeDestroyed(eq(fetchID));
   }
-  
+
   @Test
   public void testTestDefermentDuringSync() throws Exception {
     ManagedEntity entity = mock(ManagedEntity.class);
@@ -321,7 +321,7 @@ public class ReplicatedTransactionHandlerTest {
     when(this.entityManager.getMessageCodec(any())).thenReturn(codec);
     when(entity.getCodec()).thenReturn(codec);
     when(entity.canDelete()).thenReturn(true);
-    
+
     Mockito.doAnswer(invocation->{
       ServerEntityRequest req = (ServerEntityRequest)invocation.getArguments()[0];
       // We will ignore the EntityMessage at index [1].
@@ -340,12 +340,12 @@ public class ReplicatedTransactionHandlerTest {
     }).when(entity).addRequestMessage(any(), any(), any());
     mockPassiveSync(rth);
   }
-  
+
   private ServerEntityRequest last;
   private int lastSid = 0;
   private int concurrency = 0;
   private boolean invoked = false;
-  
+
   private void verifySequence(ServerEntityRequest req, byte[] payload, int c) {
     switch(req.getAction()) {
       case RECEIVE_SYNC_CREATE_ENTITY:
@@ -396,7 +396,7 @@ public class ReplicatedTransactionHandlerTest {
         break;
     }
   }
-  
+
   private void mockPassiveSync(ReplicatedTransactionHandler rth) throws EventHandlerException {
 //  start passive sync
     EntityID eid = new EntityID("foo", "bar");
@@ -414,10 +414,10 @@ public class ReplicatedTransactionHandlerTest {
     send(SyncReplicationActivity.createEndEntityKeyMessage(eid, VERSION, new FetchID(10L), 1));
     send(SyncReplicationActivity.createStartEntityKeyMessage(eid, VERSION, new FetchID(10L), 2));
     send(SyncReplicationActivity.createPayloadMessage(eid, VERSION, new FetchID(10L), 2, TCByteBufferFactory.wrap(config), ""));
-    send(SyncReplicationActivity.createEndEntityKeyMessage(eid, VERSION, new FetchID(10L), 2));  
+    send(SyncReplicationActivity.createEndEntityKeyMessage(eid, VERSION, new FetchID(10L), 2));
     send(SyncReplicationActivity.createStartEntityKeyMessage(eid, VERSION, new FetchID(10L), 3));
     send(SyncReplicationActivity.createPayloadMessage(eid, VERSION, new FetchID(10L), 3, TCByteBufferFactory.wrap(config), ""));
-    send(SyncReplicationActivity.createEndEntityKeyMessage(eid, VERSION, new FetchID(10L), 3));  
+    send(SyncReplicationActivity.createEndEntityKeyMessage(eid, VERSION, new FetchID(10L), 3));
     send(SyncReplicationActivity.createStartEntityKeyMessage(eid, VERSION, new FetchID(10L), 4));
 //  defer a few replicated messages with sequence as payload
     send(createMockReplicationMessage(fetch, ByteBuffer.wrap(new byte[Integer.BYTES]).putInt(1).array(), 4));
@@ -428,7 +428,7 @@ public class ReplicatedTransactionHandlerTest {
     send(createMockReplicationMessage(fetch, ByteBuffer.wrap(new byte[Integer.BYTES]).putInt(4).array(), 4));
     send(createMockReplicationMessage(fetch, ByteBuffer.wrap(new byte[Integer.BYTES]).putInt(5).array(), 4));
     send(createMockReplicationMessage(fetch, ByteBuffer.wrap(new byte[Integer.BYTES]).putInt(6).array(), 4));
-    send(SyncReplicationActivity.createEndEntityKeyMessage(eid, 1, new FetchID(10L), 4)); 
+    send(SyncReplicationActivity.createEndEntityKeyMessage(eid, 1, new FetchID(10L), 4));
     send(SyncReplicationActivity.createEndEntityMessage(eid, VERSION, new FetchID(10L)));
     send(SyncReplicationActivity.createEndSyncMessage(TCByteBufferFactory.wrap(new byte[0])));
   }
@@ -443,7 +443,7 @@ public class ReplicatedTransactionHandlerTest {
   public void tearDown() throws Exception {
     this.rth.getEventHandler().destroy();
   }
-  
+
   private SyncReplicationActivity createMockReplicationMessage(FetchID fetchID, byte[] payload, int concurrency) {
     return SyncReplicationActivity.createInvokeMessage(fetchID,
         source, instance, TransactionID.NULL_ID, TransactionID.NULL_ID, SyncReplicationActivity.ActivityType.INVOKE_ACTION, TCByteBufferFactory.wrap(payload), concurrency, "");
@@ -490,8 +490,8 @@ public class ReplicatedTransactionHandlerTest {
       }
       return receiving;
     }
-  }  
-  
+  }
+
   ReplicationMessage createMockRequest(SyncReplicationActivity act) {
     ReplicationMessage msg = ReplicationMessage.createLocalContainer(act);
     return msg;

--- a/tc-server/src/test/java/com/tc/services/EntityMessengerServiceTest.java
+++ b/tc-server/src/test/java/com/tc/services/EntityMessengerServiceTest.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -53,7 +53,6 @@ public class EntityMessengerServiceTest {
     // Create the service.
     EntityMessengerService service = new EntityMessengerService(sink, entity, true);
     when(entity.isDestroyed()).thenReturn(false);
-    ActiveServerEntity ae = mock(ActiveServerEntity.class);
     service.entityCreated(entity);
 
     EntityMessage deferrableMessage = mock(EntityMessage.class);
@@ -66,7 +65,7 @@ public class EntityMessengerServiceTest {
     // verify that got scheduled.
     verify(sink).addToSink(any());
   }
-  
+
   @Test
   public void testEarlySend() throws Exception {
     ISimpleTimer timer = mock(ISimpleTimer.class);


### PR DESCRIPTION
Server messages should inherit its invoke context from the calling context.  

Replica invokes should not use client's as they will never reconnect.