### PR TITLE
Fixes for zapping replica when out of sync

### DIFF
--- a/common/src/main/java/com/tc/lang/ThrowableHandlerImpl.java
+++ b/common/src/main/java/com/tc/lang/ThrowableHandlerImpl.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/common/src/main/java/com/tc/lang/ThrowableHandlerImpl.java
+++ b/common/src/main/java/com/tc/lang/ThrowableHandlerImpl.java
@@ -33,7 +33,6 @@ import com.tc.util.concurrent.ThreadUtil;
 import com.tc.util.startuplock.FileNotCreatedException;
 import com.tc.util.startuplock.LocationNotCreatedException;
 
-import java.lang.reflect.Field;
 import java.net.BindException;
 import java.util.HashMap;
 import java.util.List;
@@ -68,7 +67,7 @@ public class ThrowableHandlerImpl implements ThrowableHandler {
 
   /**
    * Construct a new ThrowableHandler with a logger
-   * 
+   *
    * @param logger Logger
    */
   public ThrowableHandlerImpl(Logger logger) {
@@ -105,7 +104,7 @@ public class ThrowableHandlerImpl implements ThrowableHandler {
 
   /**
    * Handle throwable occurring on thread
-   * 
+   *
    * @param thread Thread receiving Throwable
    * @param t Throwable
    */

--- a/common/src/main/java/com/tc/net/basic/BasicConnection.java
+++ b/common/src/main/java/com/tc/net/basic/BasicConnection.java
@@ -446,7 +446,7 @@ public class BasicConnection implements TCConnection {
     if (socket instanceof PrettyPrintable) {
       state.put("buffer", ((PrettyPrintable)this.socket).getStateMap());
     } else {
-      state.put("buffer", this.socket.toString());
+      state.put("buffer", Objects.toString(this.socket));
     }
     return state;
   }  

--- a/common/src/main/java/com/tc/net/basic/BasicConnection.java
+++ b/common/src/main/java/com/tc/net/basic/BasicConnection.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -68,11 +68,11 @@ import java.util.Set;
  */
 public class BasicConnection implements TCConnection {
   private static final Logger LOGGER = LoggerFactory.getLogger(BasicConnection.class);
-  
+
   private long connect = 0;
   private volatile long last = System.currentTimeMillis();
   private volatile long received = System.currentTimeMillis();
-  
+
   private final Consumer<TCConnection> closeRunnable;
   private final Consumer<WireProtocolMessage> write;
   private final TCProtocolAdaptor adaptor;
@@ -85,8 +85,8 @@ public class BasicConnection implements TCConnection {
   private volatile Thread serviceThread;
   private volatile ExecutorService readerExec;
   private final String id;
-  
-  
+
+
   public BasicConnection(String id, TCProtocolAdaptor adapter, SocketEndpointFactory buffers, Consumer<TCConnection> close) {
     this.id = id;
     this.socketEndpointFactory = buffers;
@@ -157,7 +157,7 @@ public class BasicConnection implements TCConnection {
   public long getIdleReceiveTime() {
     return System.currentTimeMillis() - received;
   }
-  
+
   void markReceived() {
     received = System.currentTimeMillis();
   }
@@ -204,7 +204,7 @@ public class BasicConnection implements TCConnection {
       fireClosed();
     }
   }
-  
+
   private void close(Closeable c) {
     try {
       c.close();
@@ -212,15 +212,15 @@ public class BasicConnection implements TCConnection {
       LOGGER.debug("failed", t);
     }
   }
-  
+
   private void tryOp(Callable op) {
     try {
       op.call();
     } catch (Exception t) {
       LOGGER.debug("failed", t);
     }
-  }  
-    
+  }
+
   private Future<Void> shutdownAndAwaitTermination() {
     ExecutorService reader = readerExec;
     if (reader != null) {
@@ -256,34 +256,34 @@ public class BasicConnection implements TCConnection {
           reader.awaitTermination(timeout, unit);
         }
         return null;
-      } 
+      }
     };
   }
 
   private synchronized List<TCConnectionEventListener> getListeners() {
     return new ArrayList<>(listeners);
   }
-  
+
   private void fireClosed() {
     TCConnectionEvent event = new TCConnectionEvent(this);
     getListeners().forEach(l->l.closeEvent(event));
   }
-  
+
   private void fireConnect() {
     TCConnectionEvent event = new TCConnectionEvent(this);
     getListeners().forEach(l->l.connectEvent(event));
   }
-  
+
   private void fireEOF() {
     TCConnectionEvent event = new TCConnectionEvent(this);
     getListeners().forEach(l->l.endOfFileEvent(event));
   }
-  
+
   private void fireError(Exception err, TCNetworkMessage cxt) {
     TCConnectionErrorEvent event = new TCConnectionErrorEvent(this, err, cxt);
     getListeners().forEach(l->l.errorEvent(event));
   }
-  
+
   @Override
   public synchronized Socket connect(InetSocketAddress addr, int timeout) throws IOException, TCTimeoutException {
     boolean interrupted = Thread.interrupted();
@@ -360,7 +360,7 @@ public class BasicConnection implements TCConnection {
       this.write.accept(msg);
     }
   }
-  
+
   private void readMessages() {
     Assert.assertNull(readerExec);
     readerExec = Executors.newFixedThreadPool(1, (r) -> {
@@ -405,7 +405,7 @@ public class BasicConnection implements TCConnection {
       LOGGER.debug("EXITED {} connected:{} established:{}", System.identityHashCode(this), connected, established);
     });
   }
-    
+
   private WireProtocolMessage buildWireProtocolMessage(TCNetworkMessage message) {
     Objects.requireNonNull(message);
     if (message instanceof WireProtocolMessage) {
@@ -415,9 +415,9 @@ public class BasicConnection implements TCConnection {
       if (action.load() && action.commit()) {
         WireProtocolMessage wireMessage = WireProtocolMessageImpl.wrapMessage(action, this);
         return finalizeWireProtocolMessage(wireMessage);
-      } 
+      }
     }
-    
+
     return null;
   }
 
@@ -430,7 +430,7 @@ public class BasicConnection implements TCConnection {
     hdr.setMessageCount(1);
     hdr.computeChecksum();
     return message;
-  } 
+  }
 
   @Override
   public Map<String, ?> getState() {
@@ -449,5 +449,5 @@ public class BasicConnection implements TCConnection {
       state.put("buffer", Objects.toString(this.socket));
     }
     return state;
-  }  
+  }
 }

--- a/common/src/main/java/com/tc/net/core/TCConnectionImpl.java
+++ b/common/src/main/java/com/tc/net/core/TCConnectionImpl.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/common/src/main/java/com/tc/net/core/TCConnectionImpl.java
+++ b/common/src/main/java/com/tc/net/core/TCConnectionImpl.java
@@ -65,6 +65,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import com.tc.net.protocol.tcm.TCActionNetworkMessage;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -201,7 +202,7 @@ final class TCConnectionImpl implements TCConnection, TCChannelReader, TCChannel
     if (socket instanceof PrettyPrintable) {
       state.put("buffer", ((PrettyPrintable)this.socket).getStateMap());
     } else {
-      state.put("buffer", this.socket.toString());
+      state.put("buffer", Objects.toString(this.socket));
     }
     return state;
   }
@@ -463,13 +464,13 @@ final class TCConnectionImpl implements TCConnection, TCChannelReader, TCChannel
       long bytesWritten = context.write();
       messageBatch.increment();
       if (debug) {
-        logger.debug("Wrote " + bytesWritten + " bytes on connection " + this.channel.toString() + " with batch size " + context.getBatchSize());
+        logger.debug("Wrote " + bytesWritten + " bytes on connection " + this.channel + " with batch size " + context.getBatchSize());
       }
       totalBytesWritten += bytesWritten;
 
       Assert.assertTrue(context.done());
       if (debug) {
-        logger.debug("Complete message sent on connection " + this.channel.toString());
+        logger.debug("Complete message sent on connection " + this.channel);
       }
       context.writeComplete();
       context = writeContexts.poll();
@@ -500,7 +501,7 @@ final class TCConnectionImpl implements TCConnection, TCChannelReader, TCChannel
     }
 
     if (debug) {
-      logger.debug("Connection (" + this.channel.toString() + ") has " + this.writeMessages.size() + " messages queued");
+      logger.debug("Connection (" + this.channel + ") has " + this.writeMessages.size() + " messages queued");
     }
 
     if (newData) {
@@ -792,14 +793,14 @@ final class TCConnectionImpl implements TCConnection, TCChannelReader, TCChannel
   public void closeReadOnException(IOException ioe) throws IOException {
     if (ioe instanceof EOFException) {
       if (logger.isDebugEnabled()) {
-        logger.debug("EOF reading from channel " + this.channel.toString());
+        logger.debug("EOF reading from channel " + this.channel);
       }
       this.eventCaller.fireEndOfFileEvent(this.eventListeners, this);
     } else {
       if (!isClosed()) {
-        logger.info("error reading from channel " + this.channel.toString() + ": " + ioe.getMessage());
+        logger.info("error reading from channel " + this.channel + ": " + ioe.getMessage());
       } else if  (logger.isDebugEnabled()) {
-        logger.debug("error reading from channel " + this.channel.toString() + ": " + ioe.getMessage());
+        logger.debug("error reading from channel " + this.channel + ": " + ioe.getMessage());
       }
 
       this.eventCaller.fireErrorEvent(this.eventListeners, this, ioe, null);
@@ -809,12 +810,12 @@ final class TCConnectionImpl implements TCConnection, TCChannelReader, TCChannel
   public void closeWriteOnException(IOException ioe) throws IOException {
     if (ioe instanceof EOFException) {
       if (logger.isDebugEnabled()) {
-        logger.debug("EOF writing to channel " + this.channel.toString());
+        logger.debug("EOF writing to channel " + this.channel);
       }
       this.eventCaller.fireEndOfFileEvent(this.eventListeners, this);
     } else {
       if (logger.isInfoEnabled()) {
-        logger.info("error writing to channel " + this.channel.toString() + ": " + ioe.getMessage());
+        logger.info("error writing to channel " + this.channel + ": " + ioe.getMessage());
       }
 
       this.eventCaller.fireErrorEvent(this.eventListeners, this, ioe, null);

--- a/tc-server/src/main/java/com/tc/handler/CallbackZapServerNodeExceptionAdapter.java
+++ b/tc-server/src/main/java/com/tc/handler/CallbackZapServerNodeExceptionAdapter.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/tc-server/src/main/java/com/tc/handler/CallbackZapServerNodeExceptionAdapter.java
+++ b/tc-server/src/main/java/com/tc/handler/CallbackZapServerNodeExceptionAdapter.java
@@ -25,7 +25,7 @@ import com.tc.objectserver.persistence.ClusterStatePersistor;
 public class CallbackZapServerNodeExceptionAdapter extends CallbackDirtyDatabaseCleanUpAdapter {
 
   private final Logger consoleLogger;
-  private String         consoleMessage = "This Terracotta server instance restarted because of a "
+  private final String         consoleMessage = "This Terracotta server instance restarted because of a "
                                           + "conflict or communication failure with another Terracotta "
                                           + "server instance.";
 

--- a/tc-server/src/main/java/com/tc/l2/ha/L2HAZapNodeRequestProcessor.java
+++ b/tc-server/src/main/java/com/tc/l2/ha/L2HAZapNodeRequestProcessor.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -152,7 +152,7 @@ public class L2HAZapNodeRequestProcessor implements ZapNodeRequestProcessor {
       props.setProperty("reason", reason);
       props.setProperty("weights", Arrays.toString(weights));
       GuardianContext.validate(Guardian.Op.SECURITY_OP, "zap request received", props);
-      
+
       logger.warn(StateManager.ACTIVE_COORDINATOR + " received Zap Node request from another "
                   + StateManager.ACTIVE_COORDINATOR + "\n" + getFormatedError(nodeID, zapNodeType, reason));
       handleSplitBrainScenario(nodeID, zapNodeType, reason, weights);
@@ -162,7 +162,6 @@ public class L2HAZapNodeRequestProcessor implements ZapNodeRequestProcessor {
         String message = "Terminating due to Zap request from " + getFormatedError(nodeID, zapNodeType, reason);
         logger.error(message);
         if (zapNodeType == NODE_JOINED_WITH_DIRTY_DB) {
-          clusterStatePersistor.setDBClean(false);
           throw new ZapDirtyDbServerNodeException(message);
         } else if (zapNodeType == INSUFFICIENT_RESOURCES) {
           throw new TCShutdownServerException(message);

--- a/tc-server/src/main/java/com/tc/l2/state/StateManagerImpl.java
+++ b/tc-server/src/main/java/com/tc/l2/state/StateManagerImpl.java
@@ -33,7 +33,7 @@ import com.tc.async.api.EventHandler;
 import com.tc.async.api.Sink;
 import com.tc.async.api.StageManager;
 import com.tc.async.impl.StageController;
-import com.tc.exception.TCServerRestartException;
+import com.tc.exception.ZapDirtyDbServerNodeException;
 import com.tc.l2.context.StateChangedEvent;
 import com.tc.l2.ha.L2HAZapNodeRequestProcessor;
 import com.tc.l2.ha.WeightGeneratorFactory;
@@ -618,8 +618,7 @@ public class StateManagerImpl implements StateManager {
   }
 
   private void zapAndResyncLocalNode(String msg) {
-    clusterStatePersistor.setDBClean(false);
-    throw new TCServerRestartException("Clear and resync - " + msg);
+    throw new ZapDirtyDbServerNodeException("Clear and resync - " + msg);
   }
 
   private synchronized void handleElectionResultMessage(L2StateMessage msg) throws GroupException {

--- a/tc-server/src/main/java/com/tc/objectserver/api/ManagedEntity.java
+++ b/tc-server/src/main/java/com/tc/objectserver/api/ManagedEntity.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -38,56 +38,56 @@ import org.terracotta.entity.EntityResponse;
  */
 public interface ManagedEntity {
   public final static int UNDELETABLE_ENTITY = -1;
-  
+
   public EntityID getID();
-  
+
   public long getVersion();
- /** 
+ /**
   * Schedules the request with the entity on the execution queue.
-  * 
+  *
   * @param request translated request for execution on the server
    * @param data the payload data of the message
-   * @param results capture the results for upper layer to communicate to the clients or 
+   * @param results capture the results for upper layer to communicate to the clients or
    * the active server
    * @return a token which can be waited on
-  */ 
+  */
   void addRequestMessage(ServerEntityRequest request, MessagePayload data, ResultCapture results);
 
   /**
-   * Called to sync an entity.  Caller initiates sync of an entity through this method.  
-   * 
+   * Called to sync an entity.  Caller initiates sync of an entity through this method.
+   *
    * @param passive target passive
    */
   void sync(SessionID passive);
   /**
   * Called when passive sync wants to start sync on this entity.
-  * 
+  *
   * @return The message tuple describing how to instantiate this entity (or null if it can't be synced).
   */
   SyncReplicationActivity.EntityCreationTuple startSync();
-  
+
   void loadEntity(byte[] configuration) throws ConfigurationException;
-  
+
   Runnable promoteEntity() throws ConfigurationException;
-    
+
   boolean isDestroyed();
-  
+
   boolean isActive();
-  
+
   boolean isRemoveable();
 
   boolean canDelete();
-  
+
   boolean clearQueue();
 
   boolean isCompatibleEntity(EntityID type);
-  
+
   void resetReferences(int count);
 
   /**
    * Used when an external component (such as CommunicatorService) needs to translate to/from something specific to this
    * entity's dialect.
-   * 
+   *
    * @return The codec which can translate to/from this entity's message dialect.
    */
   MessageCodec<? extends EntityMessage, ? extends EntityResponse> getCodec();
@@ -95,18 +95,25 @@ public interface ManagedEntity {
   /**
    * Of specific interest to the EntityMessengerService since it may need to install dependencies between messages to this
    * entity.
-   * 
+   *
    * @return The entity's local RetirementManager instance.
    */
   public RetirementManager getRetirementManager();
 
   /**
+   *
+   * @return the current active request message
+   *
+   */
+  public ServerEntityRequest getCurrentRequestMessage();
+
+  /**
    * Called in cases where the entities need to be sorted, for example.
-   * 
+   *
    * @return The unique ID associated with the receiver.
    */
   public long getConsumerID();
-  
+
   public Map<String, Object> getState();
 
   /**
@@ -116,14 +123,14 @@ public interface ManagedEntity {
    * @param listener The listener to notify when the receiver is finished being created or loaded.
    */
   public void addLifecycleListener(LifecycleListener listener);
-  
+
   /**
    * Interface used to describe the argument to setSuccessfulCreateListener.
    */
   public interface LifecycleListener {
     /**
      * Called by sender when it is finished being created from new or loaded from existing.
-     * 
+     *
      * @param sender The entity which is ready.
      */
     public void entityCreated(ManagedEntity sender);

--- a/tc-server/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/tc-server/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -469,6 +469,19 @@ public class ManagedEntityImpl implements ManagedEntity {
     return null;
   }
 
+  @Override
+  public ServerEntityRequest getCurrentRequestMessage() {
+    MessageChannel channel = GuardianContext.getCurrentMessageChannel();
+    if (channel == null) {
+      return null;
+    }
+    ThreadLocal<ServerEntityRequest> tl = (ThreadLocal<ServerEntityRequest>)channel.getAttachment(REQUEST_CONTEXT_KEY);
+    if (tl == null) {
+      return null;
+    }
+    return (ServerEntityRequest)tl.get();
+  }
+
   private void setRequestContext(MessageChannel channel, ServerEntityRequest request) {
     if (channel == null) {
       return;

--- a/tc-server/src/main/java/com/tc/objectserver/entity/PlatformEntity.java
+++ b/tc-server/src/main/java/com/tc/objectserver/entity/PlatformEntity.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public class PlatformEntity implements ManagedEntity {
     // We always start in the passive state.
     this.isActive = false;
   }
-  
+
   @Override
   public EntityID getID() {
     return PLATFORM_ID;
@@ -64,7 +64,7 @@ public class PlatformEntity implements ManagedEntity {
   public void addRequestMessage(ServerEntityRequest request, MessagePayload payload, ResultCapture capture) {
     // We don't actually invoke the message, only complete it, so make sure that it wasn't deserialized as something we
     // expect to use.
-    processor.scheduleRequest(false, PLATFORM_ID, VERSION, PLATFORM_FETCH_ID, request, payload, (w)-> {capture.complete(payload.getRawPayload());}, false, payload.getConcurrency());    
+    processor.scheduleRequest(false, PLATFORM_ID, VERSION, PLATFORM_FETCH_ID, request, payload, (w)-> {capture.complete(payload.getRawPayload());}, false, payload.getConcurrency());
   }
 
   @Override
@@ -94,12 +94,12 @@ public class PlatformEntity implements ManagedEntity {
   public void sync(SessionID passive) {
   //  never sync
   }
-  
+
   @Override
   public SyncReplicationActivity.EntityCreationTuple  startSync() {
     return null;
   }
-  
+
   @Override
   public void loadEntity(byte[] configuration) {
     throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
@@ -140,6 +140,11 @@ public class PlatformEntity implements ManagedEntity {
   public RetirementManager getRetirementManager() {
     // The platform entity doesn't expose this since it isn't expecting message interdependencies, internally.
     Assert.fail();
+    return null;
+  }
+
+  @Override
+  public ServerEntityRequest getCurrentRequestMessage() {
     return null;
   }
 

--- a/tc-server/src/main/java/com/tc/objectserver/handler/DuplicationTransactionHandler.java
+++ b/tc-server/src/main/java/com/tc/objectserver/handler/DuplicationTransactionHandler.java
@@ -23,7 +23,7 @@ import com.tc.async.api.EventHandler;
 import com.tc.async.api.EventHandlerException;
 import com.tc.async.api.Stage;
 import com.tc.exception.ServerException;
-import com.tc.exception.TCServerRestartException;
+import com.tc.exception.ZapDirtyDbServerNodeException;
 import com.tc.l2.dup.RelayMessage;
 import com.tc.objectserver.entity.MessagePayload;
 import com.tc.l2.msg.ReplicationMessage;
@@ -68,10 +68,10 @@ public class DuplicationTransactionHandler {
                 groupManager.sendTo(nodeID, RelayMessage.createResumeMessage(currentSequence));
                 break;
               default:
-                throw new TCServerRestartException("invalid state for duplication " + stateMgr.getCurrentMode());
+                throw new ZapDirtyDbServerNodeException("invalid state for duplication " + stateMgr.getCurrentMode());
             }
           } else {
-            throw new TCServerRestartException("resyncing duplicate");
+            throw new ZapDirtyDbServerNodeException("resyncing duplicate");
           }
         } catch (GroupException ge) {
 
@@ -92,7 +92,7 @@ public class DuplicationTransactionHandler {
     public void handleEvent(RelayMessage message) throws EventHandlerException {
      switch (message.getType()) {
        case RelayMessage.RELAY_INVALID:
-         throw new TCServerRestartException("duplicate server is no longer in sync with relay");
+         throw new ZapDirtyDbServerNodeException("duplicate server is no longer in sync with relay");
        case RelayMessage.RELAY_SUCCESS:
          TCLogging.getConsoleLogger().info("relay resume is successful");
          break;

--- a/tc-server/src/main/java/com/tc/services/EntityMessengerService.java
+++ b/tc-server/src/main/java/com/tc/services/EntityMessengerService.java
@@ -23,7 +23,6 @@ import com.tc.bytes.TCByteBufferFactory;
 import com.tc.entity.VoltronEntityMessage;
 import com.tc.exception.ServerException;
 import com.tc.net.ClientID;
-import com.tc.net.protocol.tcm.MessageChannel;
 import com.tc.object.ClientInstanceID;
 import com.tc.object.EntityDescriptor;
 import com.tc.object.FetchID;
@@ -31,10 +30,9 @@ import com.tc.object.tx.TransactionID;
 import com.tc.objectserver.api.ManagedEntity;
 import com.tc.objectserver.api.ManagedEntity.LifecycleListener;
 import com.tc.objectserver.api.ServerEntityRequest;
-import com.tc.objectserver.core.impl.GuardianContext;
 import com.tc.objectserver.entity.CreateMessage;
 import com.tc.objectserver.entity.DestroyMessage;
-import static com.tc.objectserver.entity.ManagedEntityImpl.REQUEST_CONTEXT_KEY;
+import com.tc.objectserver.entity.ManagedEntityImpl;
 import com.tc.objectserver.entity.ReconfigureMessage;
 import com.tc.objectserver.handler.RetirementManager;
 import com.tc.util.Assert;
@@ -48,6 +46,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.terracotta.entity.EntityResponse;
 
 /**
@@ -64,6 +63,7 @@ public class EntityMessengerService<M extends EntityMessage, R extends EntityRes
   private final EntityDescriptor fakeDescriptor;
   private final EntityDescriptor lifecycleDescriptor;
   private final ConcurrentHashMap<ExplicitRetirementHandle, Handle> retirementHandles = new ConcurrentHashMap<>();
+  private final Supplier<ServerEntityRequest> parentContext;
 
   @SuppressWarnings("unchecked")
   public EntityMessengerService(Sink<VoltronEntityMessage> messageSink,
@@ -84,6 +84,7 @@ public class EntityMessengerService<M extends EntityMessage, R extends EntityRes
 
     this.fakeDescriptor = EntityDescriptor.createDescriptorForInvoke(new FetchID(owningEntity.getConsumerID()),ClientInstanceID.NULL_ID);
     this.lifecycleDescriptor = EntityDescriptor.createDescriptorForLifecycle(owningEntity.getID(), owningEntity.getVersion());
+    this.parentContext = ()->owningEntity.getCurrentRequestMessage();
   }
 
   @Override
@@ -184,14 +185,12 @@ public class EntityMessengerService<M extends EntityMessage, R extends EntityRes
       this.message = message.asReadOnlyBuffer();
       this.response = response;
       this.waitForReceived = waitForReceived;
-      MessageChannel channel = GuardianContext.getCurrentMessageChannel();
+      this.parent = parentContext.get();
 
-      if (channel != null) {
-        this.clientID = (ClientID)channel.getRemoteNodeID();
-        parent = (ServerEntityRequest)channel.getAttachment(REQUEST_CONTEXT_KEY);
+      if (parent != null) {
+        this.clientID = parent.getNodeID();
       } else {
         this.clientID = ClientID.NULL_ID;
-        this.parent = null;
       }
     }
 

--- a/tc-server/src/test/java/com/tc/services/EntityMessengerServiceContextTest.java
+++ b/tc-server/src/test/java/com/tc/services/EntityMessengerServiceContextTest.java
@@ -1,0 +1,191 @@
+/*
+ *  Copyright Terracotta, Inc.
+ *  Copyright IBM Corp. 2024, 2026
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.tc.services;
+
+import com.tc.async.api.Sink;
+import com.tc.entity.VoltronEntityMessage;
+import com.tc.net.ClientID;
+import com.tc.object.tx.TransactionID;
+import com.tc.objectserver.api.ServerEntityRequest;
+import com.tc.objectserver.entity.ManagedEntityImpl;
+import com.tc.objectserver.handler.RetirementManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.terracotta.entity.EntityMessage;
+import org.terracotta.entity.MessageCodec;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for EntityMessengerService parent context propagation.
+ * Verifies that the service correctly captures and uses parent request context
+ * when creating fake entity messages.
+ */
+public class EntityMessengerServiceContextTest {
+
+  private Sink<VoltronEntityMessage> sink;
+  private ManagedEntityImpl entity;
+  private RetirementManager retirementManager;
+  @SuppressWarnings("rawtypes")
+  private MessageCodec codec;
+  private EntityMessengerService<EntityMessage, ?> service;
+
+  @Before
+  public void setUp() throws Exception {
+    sink = mock(Sink.class);
+    entity = mock(ManagedEntityImpl.class);
+    retirementManager = mock(RetirementManager.class);
+    codec = mock(MessageCodec.class);
+
+    when(entity.getRetirementManager()).thenReturn(retirementManager);
+    doReturn(codec).when(entity).getCodec();
+    when(codec.encodeMessage(any())).thenReturn(new byte[0]);
+    when(entity.isDestroyed()).thenReturn(false);
+  }
+
+  @Test
+  public void testParentContextCapturedWhenPresent() throws Exception {
+    // Setup: Create a mock parent request context
+    ServerEntityRequest parentRequest = mock(ServerEntityRequest.class);
+    ClientID expectedClientID = new ClientID(42);
+    TransactionID expectedTxnID = new TransactionID(100);
+
+    when(parentRequest.getNodeID()).thenReturn(expectedClientID);
+    when(parentRequest.getTransaction()).thenReturn(expectedTxnID);
+    when(entity.getCurrentRequestMessage()).thenReturn(parentRequest);
+
+    // Create the service
+    service = new EntityMessengerService<>(sink, entity, false);
+    service.entityCreated(entity);
+
+    // Send a message
+    EntityMessage message = mock(EntityMessage.class);
+    service.messageSelf(message);
+
+    // Verify the message was sent to the sink
+    ArgumentCaptor<VoltronEntityMessage> captor = ArgumentCaptor.forClass(VoltronEntityMessage.class);
+    verify(sink).addToSink(captor.capture());
+
+    VoltronEntityMessage sentMessage = captor.getValue();
+    assertThat("Message should be sent", sentMessage, is(notNullValue()));
+
+    // Verify the parent context was used
+    assertThat("ClientID should match parent", sentMessage.getSource(), is(expectedClientID));
+    assertThat("TransactionID should match parent", sentMessage.getTransactionID(), is(expectedTxnID));
+  }
+
+  @Test
+  public void testNullParentContextHandledGracefully() throws Exception {
+    // Setup: No parent context available
+    when(entity.getCurrentRequestMessage()).thenReturn(null);
+
+    // Create the service
+    service = new EntityMessengerService<>(sink, entity, false);
+    service.entityCreated(entity);
+
+    // Send a message
+    EntityMessage message = mock(EntityMessage.class);
+    service.messageSelf(message);
+
+    // Verify the message was sent to the sink
+    ArgumentCaptor<VoltronEntityMessage> captor = ArgumentCaptor.forClass(VoltronEntityMessage.class);
+    verify(sink).addToSink(captor.capture());
+
+    VoltronEntityMessage sentMessage = captor.getValue();
+    assertThat("Message should be sent", sentMessage, is(notNullValue()));
+
+    // Verify defaults are used when no parent context
+    assertThat("ClientID should be NULL_ID", sentMessage.getSource(), is(ClientID.NULL_ID));
+    assertThat("TransactionID should be generated", sentMessage.getTransactionID(), is(notNullValue()));
+  }
+
+  @Test
+  public void testParentContextChangesReflectedInSubsequentMessages() throws Exception {
+    // Setup: Start with one parent context
+    ServerEntityRequest firstParent = mock(ServerEntityRequest.class);
+    ClientID firstClientID = new ClientID(1);
+    TransactionID firstTxnID = new TransactionID(10);
+
+    when(firstParent.getNodeID()).thenReturn(firstClientID);
+    when(firstParent.getTransaction()).thenReturn(firstTxnID);
+    when(entity.getCurrentRequestMessage()).thenReturn(firstParent);
+
+    // Create the service
+    service = new EntityMessengerService<>(sink, entity, false);
+    service.entityCreated(entity);
+
+    // Send first message
+    EntityMessage message1 = mock(EntityMessage.class);
+    service.messageSelf(message1);
+
+    // Change the parent context
+    ServerEntityRequest secondParent = mock(ServerEntityRequest.class);
+    ClientID secondClientID = new ClientID(2);
+    TransactionID secondTxnID = new TransactionID(20);
+
+    when(secondParent.getNodeID()).thenReturn(secondClientID);
+    when(secondParent.getTransaction()).thenReturn(secondTxnID);
+    when(entity.getCurrentRequestMessage()).thenReturn(secondParent);
+
+    // Send second message
+    EntityMessage message2 = mock(EntityMessage.class);
+    service.messageSelf(message2);
+
+    // Verify both messages were sent
+    ArgumentCaptor<VoltronEntityMessage> captor = ArgumentCaptor.forClass(VoltronEntityMessage.class);
+    verify(sink, times(2)).addToSink(captor.capture());
+
+    // Get all captured messages
+    List<VoltronEntityMessage> capturedMessages = captor.getAllValues();
+    assertThat("Should have captured 2 messages", capturedMessages.size(), is(2));
+
+    // The second message should use the second parent context
+    VoltronEntityMessage lastMessage = capturedMessages.get(1);
+    assertThat("Second message ClientID should match second parent",
+               lastMessage.getSource(), is(secondClientID));
+    assertThat("Second message TransactionID should match second parent",
+               lastMessage.getTransactionID(), is(secondTxnID));
+  }
+
+  @Test
+  public void testManagedEntityGetCurrentRequestMessageReturnsCorrectValue() {
+    // This test verifies the new getCurrentRequestMessage() method exists and is callable
+    // The actual implementation testing would require more complex setup with
+    // GuardianContext and MessageChannel, which is beyond unit test scope
+
+    ManagedEntityImpl realEntity = mock(ManagedEntityImpl.class);
+    when(realEntity.getCurrentRequestMessage()).thenReturn(null);
+
+    ServerEntityRequest result = realEntity.getCurrentRequestMessage();
+
+    // Verify the method can be called and returns expected null in this mock scenario
+    assertThat("getCurrentRequestMessage should be callable", result, is((ServerEntityRequest) null));
+    verify(realEntity).getCurrentRequestMessage();
+  }
+}


### PR DESCRIPTION
This PR fixes replica servers when they are out of sync.  These servers need to be Zapped (dirtydb) rather than simply restarted when it is out if sync with the relay.

Also fixes an NPE error in certain error conditions.