### PR TITLE
backpressure replica message unroll to mimic connection to an active

### DIFF
--- a/common/src/main/java/com/tc/exception/ZapDirtyDbServerNodeException.java
+++ b/common/src/main/java/com/tc/exception/ZapDirtyDbServerNodeException.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,11 +18,15 @@
 package com.tc.exception;
 
 /**
- * RMP-309 : Zap Node which joined with dirty db 
+ * RMP-309 : Zap Node which joined with dirty db
  */
 
 public class ZapDirtyDbServerNodeException extends TCServerRestartException {
   public ZapDirtyDbServerNodeException(String message) {
     super(message);
+  }
+
+  public  ZapDirtyDbServerNodeException(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/common/src/main/java/com/tc/stats/AbstractNotifyingMBean.java
+++ b/common/src/main/java/com/tc/stats/AbstractNotifyingMBean.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 package com.tc.stats;
 
 import com.tc.management.AbstractTerracottaMBean;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.management.AttributeChangeNotification;
 import javax.management.MBeanNotificationInfo;
@@ -35,7 +36,7 @@ public abstract class AbstractNotifyingMBean extends AbstractTerracottaMBean {
 
   }
 
-  private long                                 nextSequenceNumber = 1;
+  private final AtomicLong                                 nextSequenceNumber = new AtomicLong(1);
 
   protected AbstractNotifyingMBean(Class<?> mBeanInterface) throws NotCompliantMBeanException {
     super(mBeanInterface, true);
@@ -46,22 +47,22 @@ public abstract class AbstractNotifyingMBean extends AbstractTerracottaMBean {
     return NOTIFICATION_INFO;
   }
 
-  protected synchronized void sendNotification(String type, Object source) {
-    sendNotification(new Notification(type, source, nextSequenceNumber++));
+  protected void sendNotification(String type, Object source) {
+    sendNotification(new Notification(type, source, nextSequenceNumber.getAndIncrement()));
   }
 
-  protected synchronized void sendNotification(String msg, String attr, String type,
+  protected void sendNotification(String msg, String attr, String type,
                                                Object oldVal, Object newVal) {
-    sendNotification(new AttributeChangeNotification(this, nextSequenceNumber++, System.currentTimeMillis(), msg, attr,
+    sendNotification(new AttributeChangeNotification(this, nextSequenceNumber.getAndIncrement(), System.currentTimeMillis(), msg, attr,
                                                      type, oldVal, newVal));
   }
-  
-  protected synchronized void sendNotification(String type, Object source, String message) {
-    sendNotification(new Notification(type, source, nextSequenceNumber++, message));
+
+  protected void sendNotification(String type, Object source, String message) {
+    sendNotification(new Notification(type, source, nextSequenceNumber.getAndIncrement(), message));
   }
-  
-  protected synchronized void sendNotification(String type, Object source, Object userData) {
-    Notification notification = new Notification(type, source, nextSequenceNumber++);
+
+  protected void sendNotification(String type, Object source, Object userData) {
+    Notification notification = new Notification(type, source, nextSequenceNumber.getAndIncrement());
     notification.setUserData(userData);
     sendNotification(notification);
   }

--- a/galvan-support/src/test/java/org/terracotta/functional/RelayFunctionIT.java
+++ b/galvan-support/src/test/java/org/terracotta/functional/RelayFunctionIT.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -41,7 +40,7 @@ import org.terracotta.testing.rules.Cluster;
 public class RelayFunctionIT {
 
   private static Logger LOGGER = LoggerFactory.getLogger(RelayFunctionIT.class);
-  
+
   @ClassRule
   public static final Cluster CLUSTER1 = BasicExternalClusterBuilder.newCluster(2)
           .startupBuilder(RelayStartupCommandBuilder::new)
@@ -90,18 +89,16 @@ public class RelayFunctionIT {
     CLUSTER2.getClusterControl().waitForRunningPassivesInStandby();
 // terminate all servers of the source cluster
     CLUSTER1.getClusterControl().terminateAllServers();
-// connect to the RELAY-REPLICA and clear relay status and leaveGroup to start election    
+// connect to the RELAY-REPLICA and clear relay status and leaveGroup to start election
     try (Diagnostics d = DiagnosticsFactory.connect(CLUSTER2.getClusterInfo().getServersInfo().get(1).getAddress(), null)) {
-      String rst = d.invoke("RelayManager", "clearRelay");
-      Assert.assertTrue(Boolean.parseBoolean(rst));
       String state = d.getState();
       while (!state.equals("ACTIVE-COORDINATOR")) {
-        System.out.println("leaving group in " + state + " state " + d.invoke("TerracottaServer", "leaveGroup"));
+        System.out.println("leaving group in " + state + " state " + d.invoke("TerracottaServer", "replicaFailoverToActive"));
         TimeUnit.SECONDS.sleep(2);
         state = d.getState();
       }
     }
-    
+
 //  wait for active of replica cluster
     CLUSTER2.getClusterControl().waitForActive();
     CLUSTER2.getClusterControl().startAllServers();

--- a/management/src/main/java/com/tc/management/beans/TCServerInfoMBean.java
+++ b/management/src/main/java/com/tc/management/beans/TCServerInfoMBean.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -54,9 +54,9 @@ public interface TCServerInfoMBean extends TerracottaMBean, RuntimeStatisticCons
   String getBuildID();
 
   boolean isPatched();
-  
+
   String getMonkier();
-  
+
   String getKitID();
 
   String getPatchLevel();
@@ -94,28 +94,30 @@ public interface TCServerInfoMBean extends TerracottaMBean, RuntimeStatisticCons
   String getState();
 
   boolean isVerboseGC();
-  
+
   boolean isReconnectWindow();
 
   boolean isAcceptingClients();
-  
+
   int getReconnectWindowTimeout();
 
   void setVerboseGC(boolean verboseGC);
 
   void gc();
-  
+
   void setPipelineMonitoring(boolean monitor);
-  
+
   boolean disconnectClient(String id);
-  
+
   String getClusterState(boolean shortForm);
 
   String getConnectedClients() throws IOException;
 
   String getCurrentChannelProperties() throws IOException;
-  
+
   void disconnectPeer(String nodeName);
-  
+
   void leaveGroup();
+
+  boolean replicaFailoverToActive();
 }

--- a/tc-messaging/src/main/java/com/tc/l2/dup/RelayMessage.java
+++ b/tc-messaging/src/main/java/com/tc/l2/dup/RelayMessage.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collection;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.function.Consumer;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -58,12 +59,12 @@ public class RelayMessage extends AbstractGroupMessage implements IBatchableGrou
       payloadMessages = new ArrayList<>();
     }
   }
-  
+
   RelayMessage(long lastSeen) {
     super(RELAY_RESUME);
     this.lastSeen = lastSeen;
   }
-  
+
   public long getLastSeen() {
     return lastSeen;
   }
@@ -97,27 +98,27 @@ public class RelayMessage extends AbstractGroupMessage implements IBatchableGrou
         break;
     }
   }
-  
+
   public static AbstractGroupMessage createStartSync() {
     return new RelayMessage(START_SYNC);
   }
-  
+
   public static RelayMessage createRelayBatch() {
     return new RelayMessage(RELAY_BATCH);
   }
-  
+
   public static RelayMessage createInvalid() {
     return new RelayMessage(RELAY_INVALID);
   }
-  
+
   public static RelayMessage createSuccess() {
     return new RelayMessage(RELAY_SUCCESS);
   }
-  
+
   public static AbstractGroupMessage createResumeMessage(long lastSeen) {
     return new RelayMessage(lastSeen);
   }
-  
+
   private void createReplicationBatch(TCByteBufferOutput output) {
     try (GZIPOutputStream compress = new GZIPOutputStream(new OutputWrapper(output));) {
       try (TCByteBufferOutputStream out = new TCByteBufferOutputStream()) {
@@ -132,11 +133,15 @@ public class RelayMessage extends AbstractGroupMessage implements IBatchableGrou
       throw new RuntimeException(io);
     }
   }
-  
+
   public long unwindBatch(Consumer<ReplicationMessage> next) {
     return payloadMessages.stream().peek(next).map(ReplicationMessage::getSequenceID).reduce(Long::max).orElse(Long.MIN_VALUE);
   }
-  
+
+  public Collection<ReplicationMessage> getMessages() {
+    return Collections.unmodifiableCollection(payloadMessages);
+  }
+
   private void loadReplicationBatch(TCByteBufferInput source) {
     TCByteBufferOutputStream output = new TCByteBufferOutputStream();
     try (GZIPInputStream decompress = new GZIPInputStream(new InputWrapper(source))) {
@@ -159,7 +164,7 @@ public class RelayMessage extends AbstractGroupMessage implements IBatchableGrou
       }
     }
   }
-  
+
   private static long transfer(InputStream in, OutputStream out) throws IOException {
     long transferred = 0;
     byte[] buffer = new byte[1024];
@@ -170,7 +175,7 @@ public class RelayMessage extends AbstractGroupMessage implements IBatchableGrou
     }
     return transferred;
   }
-  
+
   @Override
   public void addToBatch(ReplicationMessage element) {
     payloadMessages.add(element);

--- a/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
+++ b/tc-messaging/src/main/java/com/tc/l2/msg/ReplicationMessage.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -53,17 +53,17 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
   // (Note that this check can be removed in the future - it is mostly to validate during refactoring and buffering
   //  implementation).
   private boolean didCreateLocally;
-  
+
   public ReplicationMessage() {
     super(IGNORED);
     this.didCreateLocally = false;
   }
-  
+
   protected ReplicationMessage(int type) {
     super(type);
     this.didCreateLocally = false;
   }
-  
+
 //  a true replicated message
   private ReplicationMessage(SyncReplicationActivity activity) {
     super(IGNORED);
@@ -71,7 +71,7 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
     this.activities.add(activity);
     this.didCreateLocally = true;
   }
-  
+
   @Override
   public void setSequenceID(long rid) {
     this.rid = rid;
@@ -90,6 +90,7 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
   /**
    * @return The current number of activities batched in this message.
    */
+  @Override
   public int getBatchSize() {
     return this.activities.size();
   }
@@ -136,7 +137,7 @@ public class ReplicationMessage extends AbstractGroupMessage implements OrderedE
         break;
     }
   }
-  
+
   public String getDebugId() {
     return this.getType() + " " + ((this.activities != null) ? (this.activities.size() + " activities") : "no activities");
   }

--- a/tc-server/src/main/java/com/tc/config/ServerConfigurationManager.java
+++ b/tc-server/src/main/java/com/tc/config/ServerConfigurationManager.java
@@ -54,6 +54,7 @@ public class ServerConfigurationManager implements PrettyPrintable {
   private Configuration configuration;
   private ServerConfiguration serverConfiguration;
   private GroupConfiguration cachedGroupConfig = new GroupConfiguration(Collections.emptyList(), "");
+  private volatile boolean ignoreReplica;
 
   public ServerConfigurationManager(ConfigurationProvider configurationProvider,
                                     ServiceLocator classLoader,
@@ -112,7 +113,7 @@ public class ServerConfigurationManager implements PrettyPrintable {
       if (configuration.isRelaySource()) {
         InetSocketAddress relayName = configuration.getRelayPeer();
         cachedGroupConfig = new GroupConfiguration(serverConfigurationMap, this.serverConfiguration.getName(), relayName.getHostString(), relayName.getPort(), 0);
-      } else if (configuration.isRelayDestination()) {
+      } else if (!ignoreReplica && configuration.isRelayDestination()) {
         InetSocketAddress relay = configuration.getRelayPeerGroupPort();
         InetSocketAddress relayName = configuration.getRelayPeer();
         cachedGroupConfig = new GroupConfiguration(serverConfigurationMap, this.serverConfiguration.getName(), relayName.getHostString(), relayName.getPort(), relay.getPort());
@@ -184,11 +185,15 @@ public class ServerConfigurationManager implements PrettyPrintable {
   }
 
   public boolean isRelayDestination() {
-    return configuration.isRelayDestination();
+    return !ignoreReplica && configuration.isRelayDestination();
   }
 
   public boolean isConsistentStartup() {
     return configuration.isConsistentStartup();
+  }
+
+  public void ignoreReplicaSettings() {
+    ignoreReplica = true;
   }
 
   private static void processTcProperties(Properties tcProperties) {

--- a/tc-server/src/main/java/com/tc/l2/state/ElectionManagerImpl.java
+++ b/tc-server/src/main/java/com/tc/l2/state/ElectionManagerImpl.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -87,11 +87,11 @@ public class ElectionManagerImpl implements ElectionManager {
     state = ELECTION_SHUTDOWN;
     notifyAll();
   }
-  
+
   private synchronized boolean isShutdown() {
     return state == ELECTION_SHUTDOWN;
   }
-  
+
   public EventHandler<ElectionContext> getEventHandler() {
     return new AbstractEventHandler<ElectionContext> () {
       @Override
@@ -107,7 +107,7 @@ public class ElectionManagerImpl implements ElectionManager {
       }
     };
   }
-  
+
   public Set<ServerID> passiveStandbys() {
     return passiveStandbys;
   }
@@ -239,7 +239,7 @@ public class ElectionManagerImpl implements ElectionManager {
     }
     return winnerID;
   }
-  
+
   private synchronized void sendToNewMember(NodeID node) {
     if (state == ELECTION_IN_PROGRESS) {
       L2StateMessage msg = L2StateMessage.createElectionStartedMessage(this.myVote, this.serverState);
@@ -250,13 +250,13 @@ public class ElectionManagerImpl implements ElectionManager {
         logger.error("Error during election : ", ge);
       }
     } else {
-      debugInfo("no election in progress not sending to " + node);      
+      debugInfo("no election in progress not sending to " + node);
     }
   }
 
   private synchronized void electionStarted(Enrollment e, State serverState, int expectedServers) {
     if (this.state == ELECTION_IN_PROGRESS) { throw new AssertionError("Election Already in Progress"); }
-    this.state = ELECTION_IN_PROGRESS;
+    this.state = expectedServers > 1 ? ELECTION_IN_PROGRESS : ELECTION_VOTED;
     this.expectedServers = expectedServers;
     this.myVote = e;
     this.serverState = serverState;

--- a/tc-server/src/main/java/com/tc/l2/state/StateManagerImpl.java
+++ b/tc-server/src/main/java/com/tc/l2/state/StateManagerImpl.java
@@ -52,6 +52,7 @@ import com.tc.objectserver.impl.TopologyManager;
 import com.tc.objectserver.persistence.ServerPersistentState;
 import com.tc.util.Assert;
 import com.tc.util.State;
+import java.util.Collections;
 
 
 public class StateManagerImpl implements StateManager {
@@ -225,7 +226,9 @@ public class StateManagerImpl implements StateManager {
     boolean isNew = isFreshServer();
     if (getActiveNodeID().isNull()) {
       debugInfo("Running election - isNew: " + isNew);
-      electionSink.addToSink(new ElectionContext(myNodeID, lockedTopology.getServers(), isNew, weightsFactory, state.getState(), (nodeid)-> {
+      // if a server is replica, it should not be communicating with any other servers even if they are configured
+      Set<String> peers = getCurrentMode() != ServerMode.REPLICA ? lockedTopology.getServers() : Collections.emptySet();
+      electionSink.addToSink(new ElectionContext(myNodeID,  peers, isNew, weightsFactory, state.getState(), (nodeid)-> {
         boolean rerun = false;
         if (nodeid == myNodeID) {
           debugInfo("Won Election, moving to active state. myNodeID/winner=" + myNodeID);
@@ -267,6 +270,12 @@ public class StateManagerImpl implements StateManager {
       }));
     } else {
       electionFinished();
+      // this should not be possible but replicas should never lose elections
+      if (getCurrentMode() == ServerMode.REPLICA) {
+        logger.warn("replicas should not lose elections");
+        electionMgr.reset(ServerID.NULL_ID, null);
+        runElection();
+      }
     }
   }
 
@@ -660,7 +669,7 @@ public class StateManagerImpl implements StateManager {
   }
 
   private void verifyActiveDeclarationAndRespond(L2StateMessage clusterMsg) {
-    boolean verify = checkIfPeerWinsVerificationElection(clusterMsg) && !isActiveCoordinator();
+    boolean verify = checkIfPeerWinsVerificationElection(clusterMsg) && !isActiveCoordinator() && getCurrentMode() != ServerMode.REPLICA;
     boolean transition = verify && availabilityMgr.requestTransition(state, clusterMsg.getEnrollment().getNodeID(), ConsistencyManager.Transition.CONNECT_TO_ACTIVE);
 
     if (transition) {
@@ -713,7 +722,10 @@ public class StateManagerImpl implements StateManager {
             // will be zapped.  the only way to get here is because this server is active
             Assert.assertTrue(isActiveCoordinator());
           } else if (peerState.canBeActive()) {
-            zapAndResyncLocalNode("Passive has more recent data compared to active, node is restarting");
+            // a replica server should not be reponding to any actives
+            if (getCurrentMode() != ServerMode.REPLICA) {
+              zapAndResyncLocalNode("Passive has more recent data compared to active, node is restarting");
+            }
           } else {
             logger.info("Node peer has more current data yet cannot be active.  Server is going dormant until next election.");
           }
@@ -755,7 +767,6 @@ public class StateManagerImpl implements StateManager {
         //  need to zap and start over.  The active being synced to is gone.
         logger.error("Passive only partially synced when active disappeared.");
         elect = true;
-//        zapAndResyncLocalNode("Passive only partially synced when active disappeared.  Restarting");
       } else if (state != ServerMode.ACTIVE && activeNode.isNull()) {
         elect = true;
       }

--- a/tc-server/src/main/java/com/tc/management/beans/TCServerInfo.java
+++ b/tc-server/src/main/java/com/tc/management/beans/TCServerInfo.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -162,7 +162,7 @@ public class TCServerInfo extends AbstractTerracottaMBean implements TCServerInf
     server.stop(StopAction.IMMEDIATE);
     return server.waitUntilShutdown();
   }
-  
+
   @Override
   public boolean isShutdownable() {
     return server.canShutdown();
@@ -189,18 +189,23 @@ public class TCServerInfo extends AbstractTerracottaMBean implements TCServerInf
     };
     timer.schedule(task, 1000);
   }
-  
+
   @Override
   public void disconnectPeer(String nodeName) {
     server.disconnectPeer(nodeName);
   }
-  
-  
+
+
   @Override
   public void leaveGroup() {
     server.leaveGroup();
   }
-  
+
+  @Override
+  public boolean replicaFailoverToActive() {
+    return server.replicaFailoverToActive();
+  }
+
   @Override
   public MBeanNotificationInfo[] getNotificationInfo() {
     return Arrays.asList(NOTIFICATION_INFO).toArray(EMPTY_NOTIFICATION_INFO);
@@ -241,8 +246,8 @@ public class TCServerInfo extends AbstractTerracottaMBean implements TCServerInf
   public String getBuildID() {
     return buildID;
   }
-  
-  
+
+
 
   @Override
   public boolean isPatched() {
@@ -494,7 +499,7 @@ public class TCServerInfo extends AbstractTerracottaMBean implements TCServerInf
     if (found.isPresent()) {
       return true;
     }
-    
+
     long lid = Long.parseLong(id);
     found = server.getConnectedClients().stream().filter(c->c.getClientID() == lid).findFirst();
     found.ifPresent(Client::killClient);

--- a/tc-server/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
+++ b/tc-server/src/main/java/com/tc/objectserver/entity/ManagedEntityImpl.java
@@ -333,14 +333,14 @@ public class ManagedEntityImpl implements ManagedEntity {
 
     for (SchedulingRunnable msg : runnables) {
       if (logger.isDebugEnabled()) {
-      logger.debug("Starting action: {} entity: {}-{} from {}-{} ({})", next.request.getAction(), getID(), getConsumerID(), request.getNodeID(), request.getTransaction(), request.getTraceID());
+        logger.debug("Starting action: {} entity: {}-{} from {}-{} ({})", next.request.getAction(), getID(), getConsumerID(), request.getNodeID(), request.getTransaction(), request.getTraceID());
       }
       msg.start();
     }
 
     if (!runnables.offer(next)) {
       if (logger.isDebugEnabled()) {
-      logger.debug("Starting Offered action: {} entity: {}-{} from {}-{} ({})", next.request.getAction(), getID(), getConsumerID(), request.getNodeID(), request.getTransaction(), request.getTraceID());
+        logger.debug("Starting Offered action: {} entity: {}-{} from {}-{} ({})", next.request.getAction(), getID(), getConsumerID(), request.getNodeID(), request.getTransaction(), request.getTraceID());
       }
       Assert.assertTrue(next, runnables.isEmpty() && runnables.deferCleared);
       next.start();

--- a/tc-server/src/main/java/com/tc/objectserver/handler/DuplicationTransactionHandler.java
+++ b/tc-server/src/main/java/com/tc/objectserver/handler/DuplicationTransactionHandler.java
@@ -27,15 +27,25 @@ import com.tc.exception.ZapDirtyDbServerNodeException;
 import com.tc.l2.dup.RelayMessage;
 import com.tc.objectserver.entity.MessagePayload;
 import com.tc.l2.msg.ReplicationMessage;
+import com.tc.l2.msg.ReplicationResultCode;
+import com.tc.l2.msg.SyncReplicationActivity;
+import com.tc.l2.msg.SyncReplicationActivity.ActivityID;
 import com.tc.l2.state.StateManager;
 import com.tc.logging.TCLogging;
 import com.tc.net.NodeID;
+import com.tc.net.ServerID;
 import com.tc.net.groups.AbstractGroupMessage;
 import com.tc.net.groups.GroupEventsListener;
 import com.tc.net.groups.GroupException;
 import com.tc.net.groups.GroupManager;
 import com.tc.objectserver.core.api.ServerConfigurationContext;
 import com.tc.util.Assert;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.function.Predicate;
 
 import org.slf4j.Logger;
@@ -50,6 +60,7 @@ public class DuplicationTransactionHandler {
   private final GroupManager<AbstractGroupMessage> groupManager;
   private final GroupEventsListener listener;
   private volatile long currentSequence = 0L;
+  private final Map<ActivityID, CompletableFuture<ReplicationResultCode>> waitFors = new ConcurrentHashMap<>();
 
   public DuplicationTransactionHandler(StateManager stateMgr, Predicate<NodeID> duplicator, GroupManager<AbstractGroupMessage> groupManager) {
     this.groupManager = groupManager;
@@ -129,10 +140,41 @@ public class DuplicationTransactionHandler {
 
   private void processMessage(Stage<ReplicationMessage> sendToNext, RelayMessage rep) throws ServerException {
     if (rep.getType() == RelayMessage.RELAY_BATCH) {
-      long last = rep.unwindBatch(m->sendToNext.getSink().addToSink(m));
-      currentSequence = Long.max(currentSequence, last);
+      for (ReplicationMessage msg : rep.getMessages()) {
+        for (SyncReplicationActivity a : msg.getActivities()) {
+          if (a.getActivityType() == SyncReplicationActivity.ActivityType.SYNC_ENTITY_BEGIN) {
+            waitFors.put(a.getActivityID(), new CompletableFuture<>());
+          }
+        }
+        currentSequence = Long.max(currentSequence, msg.getSequenceID());
+        sendToNext.getSink().addToSink(msg);
+
+        for (ActivityID a : waitFors.keySet()) {
+          try {
+            if (waitFors.get(a).get() == ReplicationResultCode.FAIL) {
+              throw new ZapDirtyDbServerNodeException("create entity failed");
+            }
+          } catch (ExecutionException | InterruptedException ee) {
+            throw new ZapDirtyDbServerNodeException("create entity failed", ee);
+          }
+        }
+        waitFors.clear();
+      }
     } else {
       throw new UnsupportedOperationException("relay message:" + rep);
     }
+  }
+
+  public void acknowledge(ServerID activeSender, SyncReplicationActivity activity, ReplicationResultCode code) {
+    CompletableFuture<ReplicationResultCode> result = waitFors.get(activity.getActivityID());
+    if (result != null) {
+      result.complete(code);
+    } else if (code == ReplicationResultCode.FAIL) {
+      throw new ZapDirtyDbServerNodeException("replication action failed. type:" + activity.getActivityType());
+    }
+  }
+
+  public void ackReceived(ServerID activeSender, SyncReplicationActivity activity, Future<Void> future) {
+
   }
 }

--- a/tc-server/src/main/java/com/tc/objectserver/handler/PassiveAckSender.java
+++ b/tc-server/src/main/java/com/tc/objectserver/handler/PassiveAckSender.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,6 +22,25 @@ import com.tc.l2.msg.ReplicationAckTuple;
 import com.tc.l2.msg.ReplicationMessageAck;
 import com.tc.l2.msg.ReplicationResultCode;
 import com.tc.l2.msg.SyncReplicationActivity;
+import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.CREATE_ENTITY;
+import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.DESTROY_ENTITY;
+import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.DISCONNECT_CLIENT;
+import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.FETCH_ENTITY;
+import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.FLUSH_LOCAL_PIPELINE;
+import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.INVOKE_ACTION;
+import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.LOCAL_ENTITY_GC;
+import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.ORDERING_PLACEHOLDER;
+import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.RECONFIGURE_ENTITY;
+import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.RELEASE_ENTITY;
+import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.SYNC_BEGIN;
+import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.SYNC_END;
+import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.SYNC_ENTITY_BEGIN;
+import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.SYNC_ENTITY_CONCURRENCY_BEGIN;
+import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.SYNC_ENTITY_CONCURRENCY_END;
+import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.SYNC_ENTITY_CONCURRENCY_PAYLOAD;
+import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.SYNC_ENTITY_END;
+import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.SYNC_START;
+import com.tc.net.ClientID;
 import com.tc.net.NodeID;
 import com.tc.net.ServerID;
 import com.tc.net.groups.AbstractGroupMessage;
@@ -29,7 +48,12 @@ import com.tc.net.groups.GroupException;
 import com.tc.net.groups.GroupManager;
 import com.tc.net.groups.GroupMessage;
 import com.tc.net.utils.L2Utils;
+import com.tc.object.ClientInstanceID;
+import com.tc.object.tx.TransactionID;
+import com.tc.objectserver.api.ServerEntityAction;
+import com.tc.objectserver.api.ServerEntityRequest;
 import com.tc.properties.TCPropertiesImpl;
+import com.tc.util.Assert;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.Predicate;
@@ -39,7 +63,7 @@ import org.slf4j.LoggerFactory;
 /**
  *
  */
-public class PassiveAckSender {
+public class PassiveAckSender implements PassiveMessageResultCollector {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RelayTransactionHandler.class);
 
@@ -64,6 +88,7 @@ public class PassiveAckSender {
     this.local = groupManager.getLocalNodeID();
   }
 
+  @Override
   public void acknowledge(ServerID activeSender, SyncReplicationActivity activity, ReplicationResultCode code) {
 //  when is the right time to send the ack?
     if (!activeSender.equals(ServerID.NULL_ID)) {
@@ -72,6 +97,7 @@ public class PassiveAckSender {
     }
   }
 
+  @Override
   public void ackReceived(ServerID activeSender, SyncReplicationActivity activity, Future<Void> future) {
     if (!activeSender.equals(ServerID.NULL_ID)) {
       if (future != null) {
@@ -123,16 +149,72 @@ public class PassiveAckSender {
       }
     });
   }
-  
+
+  @Override
   public ServerID getLocalNodeID() {
     return local;
   }
 
+  @Override
   public void requestPassiveSync(NodeID target) {
     try {
       groupManager.sendTo(target, ReplicationMessageAck.createSyncRequestMessage());
     } catch (GroupException ge) {
       LOGGER.warn("can't request passive sync", ge);
+    }
+  }
+
+  @Override
+  public ServerEntityRequest transform(SyncReplicationActivity activity) {
+    SyncReplicationActivity.ActivityType activityType = activity.getActivityType();
+    ClientID source = activity.getSource();
+    ClientInstanceID instance = activity.getClientInstanceID();
+    TransactionID transactionID = activity.getTransactionID();
+    TransactionID oldestTransactionID = activity.getOldestTransactionOnClient();
+    Assert.assertTrue(SyncReplicationActivity.ActivityType.SYNC_BEGIN != activityType);
+    return new ReplicatedTransactionHandler.BasicServerEntityRequest(decodeReplicationType(activityType), source, instance, transactionID, oldestTransactionID);
+  }
+
+
+  public static ServerEntityAction decodeReplicationType(SyncReplicationActivity.ActivityType networkType) {
+    switch(networkType) {
+      case SYNC_BEGIN:
+        throw Assert.failure("Shouldn't decode this type into an internal action");
+      case SYNC_START:
+      case SYNC_END:
+      case ORDERING_PLACEHOLDER:
+        return ServerEntityAction.ORDER_PLACEHOLDER_ONLY;
+      case LOCAL_ENTITY_GC:
+        return ServerEntityAction.MANAGED_ENTITY_GC;
+      case FLUSH_LOCAL_PIPELINE:
+        // Note that these are never replicated from the active but we do synthesize them, internally, in some cases.
+        return ServerEntityAction.LOCAL_FLUSH;
+      case CREATE_ENTITY:
+        return ServerEntityAction.CREATE_ENTITY;
+      case RECONFIGURE_ENTITY:
+        return ServerEntityAction.RECONFIGURE_ENTITY;
+      case INVOKE_ACTION:
+        return ServerEntityAction.INVOKE_ACTION;
+      case DESTROY_ENTITY:
+        return ServerEntityAction.DESTROY_ENTITY;
+      case FETCH_ENTITY:
+        return ServerEntityAction.FETCH_ENTITY;
+      case RELEASE_ENTITY:
+        return ServerEntityAction.RELEASE_ENTITY;
+      case SYNC_ENTITY_BEGIN:
+        return ServerEntityAction.RECEIVE_SYNC_ENTITY_START_SYNCING;
+      case SYNC_ENTITY_CONCURRENCY_BEGIN:
+        return ServerEntityAction.RECEIVE_SYNC_ENTITY_KEY_START;
+      case SYNC_ENTITY_CONCURRENCY_PAYLOAD:
+        return ServerEntityAction.RECEIVE_SYNC_PAYLOAD;
+      case SYNC_ENTITY_CONCURRENCY_END:
+        return ServerEntityAction.RECEIVE_SYNC_ENTITY_KEY_END;
+      case SYNC_ENTITY_END:
+        return ServerEntityAction.RECEIVE_SYNC_ENTITY_END;
+      case DISCONNECT_CLIENT:
+        return ServerEntityAction.DISCONNECT_CLIENT;
+      default:
+        throw new AssertionError("bad replication type: " + networkType);
     }
   }
 }

--- a/tc-server/src/main/java/com/tc/objectserver/handler/PassiveMessageResultCollector.java
+++ b/tc-server/src/main/java/com/tc/objectserver/handler/PassiveMessageResultCollector.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright Terracotta, Inc.
+ *  Copyright IBM Corp. 2024, 2026
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.tc.objectserver.handler;
+
+import com.tc.l2.msg.ReplicationResultCode;
+import com.tc.l2.msg.SyncReplicationActivity;
+import com.tc.net.NodeID;
+import com.tc.net.ServerID;
+import com.tc.objectserver.api.ServerEntityRequest;
+import java.util.concurrent.Future;
+
+/**
+ *
+ */
+public interface PassiveMessageResultCollector {
+
+
+  void acknowledge(ServerID activeSender, SyncReplicationActivity activity, ReplicationResultCode code);
+
+  void ackReceived(ServerID activeSender, SyncReplicationActivity activity, Future<Void> future);
+
+  ServerID getLocalNodeID();
+
+  void requestPassiveSync(NodeID target);
+
+  ServerEntityRequest transform(SyncReplicationActivity activity);
+}

--- a/tc-server/src/main/java/com/tc/objectserver/handler/RelaySender.java
+++ b/tc-server/src/main/java/com/tc/objectserver/handler/RelaySender.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import com.tc.l2.msg.ReplicationAckTuple;
 import com.tc.l2.msg.ReplicationMessageAck;
 import com.tc.l2.msg.ReplicationResultCode;
 import com.tc.l2.msg.SyncReplicationActivity;
-import com.tc.net.NodeID;
 import com.tc.net.ServerID;
 import com.tc.net.groups.AbstractGroupMessage;
 import com.tc.net.groups.GroupException;
@@ -122,16 +121,8 @@ public class RelaySender {
       }
     });
   }
-  
+
   public ServerID getLocalNodeID() {
     return local;
-  }
-
-  public void requestPassiveSync(NodeID target) {
-    try {
-      groupManager.sendTo(target, ReplicationMessageAck.createSyncRequestMessage());
-    } catch (GroupException ge) {
-      LOGGER.warn("can't request passive sync", ge);
-    }
   }
 }

--- a/tc-server/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
+++ b/tc-server/src/main/java/com/tc/objectserver/handler/ReplicatedTransactionHandler.java
@@ -25,7 +25,6 @@ import com.tc.async.api.Stage;
 import com.tc.bytes.TCByteBuffer;
 import com.tc.bytes.TCByteBufferFactory;
 import com.tc.exception.ServerException;
-import com.tc.l2.api.L2Coordinator;
 import com.tc.objectserver.entity.MessagePayload;
 import com.tc.l2.msg.ReplicationMessage;
 import com.tc.l2.msg.ReplicationResultCode;
@@ -82,14 +81,12 @@ public class ReplicatedTransactionHandler {
   private static final Logger PLOGGER = LoggerFactory.getLogger(MessagePayload.class);
   private static final Logger LOGGER = LoggerFactory.getLogger(ReplicatedTransactionHandler.class);
 
-  private final PassiveAckSender ackMessenger;
+  private final PassiveMessageResultCollector ackMessenger;
 
   private final EntityManager entityManager;
   private final Persistor persistor;
   private final StateManager stateManager;
   private final ManagedEntity platform;
-
-  private final boolean isReplica;
 
   private final SyncState state = new SyncState();
 
@@ -99,18 +96,17 @@ public class ReplicatedTransactionHandler {
     return currentSequence;
   }
 
-  public ReplicatedTransactionHandler(StateManager state, Stage<Runnable> sendToActive, Persistor persistor,
-      EntityManager manager, GroupManager<AbstractGroupMessage> groupManager, boolean isReplica) {
+  public ReplicatedTransactionHandler(StateManager state, Persistor persistor,
+      EntityManager manager, PassiveMessageResultCollector collector) {
     this.stateManager = state;
     this.entityManager = manager;
     this.persistor = persistor;
-    this.ackMessenger = new PassiveAckSender(groupManager, m->!stateManager.isActiveCoordinator(), sendToActive.getSink());
+    this.ackMessenger = collector;
     try {
       platform = entityManager.getEntity(EntityDescriptor.createDescriptorForLifecycle(PlatformEntity.PLATFORM_ID, PlatformEntity.VERSION)).get();
     } catch (ServerException ee) {
       throw new RuntimeException(ee);
     }
-    this.isReplica = isReplica;
   }
 
   private final EventHandler<ReplicationMessage> eventHorizon = new AbstractEventHandler<ReplicationMessage>() {
@@ -128,7 +124,6 @@ public class ReplicatedTransactionHandler {
 
     @Override
     protected void initialize(ConfigurationContext context) {
-      ServerConfigurationContext scxt = (ServerConfigurationContext)context;
   //  when this spins up, send  request to active and ask for sync
       if (stateManager.getCurrentMode() == ServerMode.UNINITIALIZED) {
         try {
@@ -542,13 +537,7 @@ public class ReplicatedTransactionHandler {
   }
 
   private ServerEntityRequest activityToLocalRequest(SyncReplicationActivity activity) {
-    ActivityType activityType = activity.getActivityType();
-    ClientID source = isReplica && activityType == ActivityType.INVOKE_ACTION ? ClientID.NULL_ID : activity.getSource();
-    ClientInstanceID instance = isReplica && activityType == ActivityType.INVOKE_ACTION ? ClientInstanceID.NULL_ID : activity.getClientInstanceID();
-    TransactionID transactionID = activity.getTransactionID();
-    TransactionID oldestTransactionID = activity.getOldestTransactionOnClient();
-    Assert.assertTrue(ActivityType.SYNC_BEGIN != activityType);
-    return new BasicServerEntityRequest(decodeReplicationType(activityType), source, instance, transactionID, oldestTransactionID);
+    return ackMessenger.transform(activity);
   }
 
   private void beforeSyncAction(SyncReplicationActivity activity) {
@@ -583,48 +572,6 @@ public class ReplicatedTransactionHandler {
         break;
       default:
         break;
-    }
-  }
-
-  private static ServerEntityAction decodeReplicationType(SyncReplicationActivity.ActivityType networkType) {
-    switch(networkType) {
-      case SYNC_BEGIN:
-        throw Assert.failure("Shouldn't decode this type into an internal action");
-      case SYNC_START:
-      case SYNC_END:
-      case ORDERING_PLACEHOLDER:
-        return ServerEntityAction.ORDER_PLACEHOLDER_ONLY;
-      case LOCAL_ENTITY_GC:
-        return ServerEntityAction.MANAGED_ENTITY_GC;
-      case FLUSH_LOCAL_PIPELINE:
-        // Note that these are never replicated from the active but we do synthesize them, internally, in some cases.
-        return ServerEntityAction.LOCAL_FLUSH;
-      case CREATE_ENTITY:
-        return ServerEntityAction.CREATE_ENTITY;
-      case RECONFIGURE_ENTITY:
-        return ServerEntityAction.RECONFIGURE_ENTITY;
-      case INVOKE_ACTION:
-        return ServerEntityAction.INVOKE_ACTION;
-      case DESTROY_ENTITY:
-        return ServerEntityAction.DESTROY_ENTITY;
-      case FETCH_ENTITY:
-        return ServerEntityAction.FETCH_ENTITY;
-      case RELEASE_ENTITY:
-        return ServerEntityAction.RELEASE_ENTITY;
-      case SYNC_ENTITY_BEGIN:
-        return ServerEntityAction.RECEIVE_SYNC_ENTITY_START_SYNCING;
-      case SYNC_ENTITY_CONCURRENCY_BEGIN:
-        return ServerEntityAction.RECEIVE_SYNC_ENTITY_KEY_START;
-      case SYNC_ENTITY_CONCURRENCY_PAYLOAD:
-        return ServerEntityAction.RECEIVE_SYNC_PAYLOAD;
-      case SYNC_ENTITY_CONCURRENCY_END:
-        return ServerEntityAction.RECEIVE_SYNC_ENTITY_KEY_END;
-      case SYNC_ENTITY_END:
-        return ServerEntityAction.RECEIVE_SYNC_ENTITY_END;
-      case DISCONNECT_CLIENT:
-        return ServerEntityAction.DISCONNECT_CLIENT;
-      default:
-        throw new AssertionError("bad replication type: " + networkType);
     }
   }
 

--- a/tc-server/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/tc-server/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -618,10 +618,22 @@ public class DistributedObjectServer {
 
     ServerPersistentState serverPersistentState = configSetupManager.isRelaySource() ? new RelayPersistentState() : new ClusterPersistentState(this.persistor.getClusterStatePersistor());
 
-    if (serverPersistentState.getInitialMode() == ServerMode.ACTIVE && configSetupManager.isRelayDestination()) {
+    if (configSetupManager.isRelayDestination()) {
       // server can't revert back to replica.  Ignore replica setting
-      logger.warn("Server shutdown as ACTIVE.  Server is ignoring configuration as replica");
-      this.configSetupManager.ignoreReplicaSettings();
+      ServerMode initialState = serverPersistentState.getInitialMode();
+      switch (initialState) {
+        case ACTIVE:
+        case PASSIVE:
+        case UNINITIALIZED:
+          // protect these states for now.  There may be a way to leak after a replica has failed over
+          // through other states but these are the important ones.
+          logger.warn("Server shutdown as {}.  Server is ignoring configuration as replica", initialState);
+          this.configSetupManager.ignoreReplicaSettings();
+          break;
+        default:
+          logger.info("Server shutdown as {}.  Server is starting as replica due to configuration setting", initialState);
+          break;
+      }
     }
 
     final boolean availableMode = voteCount < 0;

--- a/tc-server/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/tc-server/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -619,7 +619,9 @@ public class DistributedObjectServer {
     ServerPersistentState serverPersistentState = configSetupManager.isRelaySource() ? new RelayPersistentState() : new ClusterPersistentState(this.persistor.getClusterStatePersistor());
 
     if (serverPersistentState.getInitialMode() == ServerMode.ACTIVE && configSetupManager.isRelayDestination()) {
-      throw new TCShutdownServerException("Unable to start as a relay destination.  The server was shutdown as active");
+      // server can't revert back to replica.  Ignore replica setting
+      logger.warn("Server shutdown as ACTIVE.  Server is ignoring configuration as replica");
+      this.configSetupManager.ignoreReplicaSettings();
     }
 
     final boolean availableMode = voteCount < 0;

--- a/tc-server/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
+++ b/tc-server/src/main/java/com/tc/objectserver/impl/DistributedObjectServer.java
@@ -88,6 +88,7 @@ import com.tc.l2.msg.L2StateMessage;
 import com.tc.l2.msg.PlatformInfoRequest;
 import com.tc.l2.msg.ReplicationMessage;
 import com.tc.l2.msg.ReplicationMessageAck;
+import com.tc.l2.msg.ReplicationResultCode;
 import com.tc.l2.msg.SyncReplicationActivity;
 import static com.tc.l2.msg.SyncReplicationActivity.ActivityType.FLUSH_LOCAL_PIPELINE;
 import static java.lang.Math.max;
@@ -236,7 +237,12 @@ import org.terracotta.configuration.FailoverBehavior;
 import org.terracotta.server.ServerEnv;
 import com.tc.net.protocol.tcm.TCAction;
 import com.tc.net.utils.ConnectionLogger;
+import com.tc.object.tx.TransactionID;
+import com.tc.objectserver.api.ServerEntityRequest;
 import com.tc.objectserver.handler.DuplicationTransactionHandler;
+import com.tc.objectserver.handler.PassiveAckSender;
+import static com.tc.objectserver.handler.PassiveAckSender.decodeReplicationType;
+import com.tc.objectserver.handler.PassiveMessageResultCollector;
 import com.tc.objectserver.handler.RelayTransactionHandler;
 import com.tc.objectserver.persistence.ClusterPersistentState;
 import com.tc.objectserver.persistence.RelayPersistentState;
@@ -245,6 +251,7 @@ import com.tc.productinfo.ProductInfo;
 import com.tc.productinfo.VersionCompatibility;
 import com.tc.util.version.CollectionVersionCompatibility;
 import com.tc.util.version.DefaultVersionCompatibility;
+import java.util.concurrent.Future;
 import org.terracotta.configuration.ConfigurationException;
 
 /**
@@ -726,18 +733,22 @@ public class DistributedObjectServer {
         new GenericHandler<>(), 1);
 //  routing for passive to receive replication
     EventHandler<ReplicationMessage> replicationEvents = null;
+    PassiveMessageResultCollector collector = null;
     if (configSetupManager.getRelayPeer() != null) {
       //  if the relay source, route the relay transaction handler
       if (configSetupManager.getRelayPeerGroupPort() == null) {
         replicationEvents = createAndRouteRelayTransactionHandler(replicationResponseStage);
       } else {
       //  if destination, route the relay messages coming in
-        routeRelayMessages(state, configSetupManager);
+        collector = routeRelayMessages(state, configSetupManager);
       }
     }
     // if no replcation events have been routed yet (not relay source) route them now
     if (replicationEvents == null) {
-      ReplicatedTransactionHandler replicatedTransactionHandler = new ReplicatedTransactionHandler(state, replicationResponseStage, this.persistor, entityManager, groupCommManager, configSetupManager.isRelayDestination());
+      if (collector == null) {
+        collector = new PassiveAckSender(groupCommManager, m->!state.isActiveCoordinator(), replicationResponseStage.getSink());
+      }
+      ReplicatedTransactionHandler replicatedTransactionHandler = new ReplicatedTransactionHandler(state, this.persistor, entityManager, collector);
       sequenceWeight.setReplicatedTransactionHandler(replicatedTransactionHandler);
       replicationEvents = replicatedTransactionHandler.getEventHandler();
     }
@@ -1379,9 +1390,41 @@ public class DistributedObjectServer {
     return handler.getEventHandler();
   }
 
-  private void routeRelayMessages(StateManager stateMgr, ServerConfigurationManager config) {
+  private PassiveMessageResultCollector routeRelayMessages(StateManager stateMgr, ServerConfigurationManager config) {
     DuplicationTransactionHandler handler = new DuplicationTransactionHandler(stateMgr, n->config.isRelayDestination(), groupCommManager);
     Stage<RelayMessage> relays = this.seda.getStageManager().createStage(ServerConfigurationContext.PASSIVE_REPLICA_STAGE, RelayMessage.class, handler.getEventHandler(), 1);
     this.groupCommManager.routeMessages(RelayMessage.class, relays.getSink());
+    return new PassiveMessageResultCollector() {
+      @Override
+      public void acknowledge(ServerID activeSender, SyncReplicationActivity activity, ReplicationResultCode code) {
+        handler.acknowledge(activeSender, activity, code);
+      }
+
+      @Override
+      public void ackReceived(ServerID activeSender, SyncReplicationActivity activity, Future<Void> future) {
+        handler.ackReceived(activeSender, activity, future);
+      }
+
+      @Override
+      public ServerID getLocalNodeID() {
+        return getServerNodeID();
+      }
+
+      @Override
+      public void requestPassiveSync(NodeID target) {
+        throw new UnsupportedOperationException("Not supported yet.");
+      }
+
+      @Override
+      public ServerEntityRequest transform(SyncReplicationActivity activity) {
+        SyncReplicationActivity.ActivityType activityType = activity.getActivityType();
+        ClientID source = (activityType == SyncReplicationActivity.ActivityType.INVOKE_ACTION) ? ClientID.NULL_ID : activity.getSource();
+        ClientInstanceID instance = (activityType == SyncReplicationActivity.ActivityType.INVOKE_ACTION) ? ClientInstanceID.NULL_ID : activity.getClientInstanceID();
+        TransactionID transactionID = activity.getTransactionID();
+        TransactionID oldestTransactionID = activity.getOldestTransactionOnClient();
+        Assert.assertTrue(SyncReplicationActivity.ActivityType.SYNC_BEGIN != activityType);
+        return new ReplicatedTransactionHandler.BasicServerEntityRequest(decodeReplicationType(activityType), source, instance, transactionID, oldestTransactionID);
+      }
+    };
   }
 }

--- a/tc-server/src/main/java/com/tc/server/TCServer.java
+++ b/tc-server/src/main/java/com/tc/server/TCServer.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright Terracotta, Inc.
- *  Copyright IBM Corp. 2024, 2025
+ *  Copyright IBM Corp. 2024, 2026
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -45,15 +45,15 @@ public interface TCServer extends Pauseable {
   boolean isActive();
 
   boolean isStopped();
-  
+
   boolean isPassiveUnitialized();
-  
+
   boolean isPassiveStandby();
-  
+
   boolean isReconnectWindow();
 
   boolean isAcceptingClients();
-    
+
   State getState();
 
   long getStartTime();
@@ -73,7 +73,7 @@ public interface TCServer extends Pauseable {
   int getTSAListenPort();
 
   int getTSAGroupPort();
-  
+
   int getReconnectWindowTimeout();
 
   boolean waitUntilShutdown();
@@ -87,8 +87,10 @@ public interface TCServer extends Pauseable {
   ProductInfo productInfo();
 
   List<Client> getConnectedClients();
-  
+
   void disconnectPeer(String nodeName);
-  
+
   void leaveGroup();
+
+  boolean replicaFailoverToActive();
 }

--- a/tc-server/src/main/java/com/tc/server/TCServerImpl.java
+++ b/tc-server/src/main/java/com/tc/server/TCServerImpl.java
@@ -504,6 +504,17 @@ public class TCServerImpl extends SEDA implements TCServer {
   }
 
   @Override
+  public boolean replicaFailoverToActive() {
+    if (getStateManager().getCurrentMode() == ServerMode.REPLICA) {
+      dsoServer.getConfigSetupManager().ignoreReplicaSettings();
+      leaveGroup();
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  @Override
   public void pause(String path) {
     if (path.equalsIgnoreCase("L1")) {
       try {

--- a/tc-server/src/test/java/com/tc/l2/state/StateManagerReplicaProtectionTest.java
+++ b/tc-server/src/test/java/com/tc/l2/state/StateManagerReplicaProtectionTest.java
@@ -1,0 +1,198 @@
+/*
+ *  Copyright Terracotta, Inc.
+ *  Copyright IBM Corp. 2024, 2026
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.tc.l2.state;
+
+import com.tc.async.api.StageManager;
+import com.tc.async.impl.StageController;
+import com.tc.async.impl.StageManagerImpl;
+import com.tc.l2.ha.RandomWeightGenerator;
+import com.tc.l2.ha.WeightGeneratorFactory;
+import com.tc.net.NodeID;
+import com.tc.net.ServerID;
+import com.tc.net.groups.AbstractGroupMessage;
+import com.tc.net.groups.GroupManager;
+import com.tc.objectserver.core.impl.ManagementTopologyEventCollector;
+import com.tc.objectserver.impl.TopologyManager;
+import com.tc.objectserver.persistence.ServerPersistentState;
+import com.tc.util.concurrent.QueueFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for replica protection logic added in commit e9f4287aa4.
+ * Verifies that replicas cannot participate in elections and are properly protected.
+ */
+public class StateManagerReplicaProtectionTest {
+
+  private StateManagerImpl stateManager;
+  private GroupManager<AbstractGroupMessage> groupManager;
+  private StageController stageController;
+  private ManagementTopologyEventCollector mgmtController;
+  private StageManager stageManager;
+  private WeightGeneratorFactory weightGeneratorFactory;
+  private ConsistencyManager consistencyManager;
+  private ServerPersistentState statePersistor;
+  private TopologyManager topologyManager;
+  private Logger logger;
+
+  @SuppressWarnings("unchecked")
+  @Before
+  public void setUp() throws Exception {
+    logger = mock(Logger.class);
+    groupManager = mock(GroupManager.class);
+    stageController = mock(StageController.class);
+    mgmtController = mock(ManagementTopologyEventCollector.class);
+    stageManager = new StageManagerImpl(new ThreadGroup("test"), new QueueFactory());
+    weightGeneratorFactory = RandomWeightGenerator.createTestingFactory(2);
+    consistencyManager = mock(ConsistencyManager.class);
+    statePersistor = mock(ServerPersistentState.class);
+    topologyManager = mock(TopologyManager.class);
+
+    ServerID localNode = new ServerID("test", "test".getBytes());
+    when(groupManager.getLocalNodeID()).thenReturn(localNode);
+    when(statePersistor.isDBClean()).thenReturn(true);
+    when(statePersistor.getInitialMode()).thenReturn(ServerMode.INITIAL);
+    when(topologyManager.getTopology()).thenReturn(mock(com.tc.objectserver.impl.Topology.class));
+    when(consistencyManager.requestTransition(any(ServerMode.class), any(NodeID.class), any(ConsistencyManager.Transition.class))).thenReturn(true);
+    when(consistencyManager.createVerificationEnrollment(any(NodeID.class), any(WeightGeneratorFactory.class)))
+        .thenAnswer(i -> EnrollmentFactory.createTrumpEnrollment((NodeID)i.getArguments()[0], weightGeneratorFactory));
+  }
+
+  @Test
+  public void testReplicaDoesNotParticipateInElection() throws Exception {
+    // Set up state manager in REPLICA mode
+    when(statePersistor.getInitialMode()).thenReturn(ServerMode.REPLICA);
+
+    stateManager = new StateManagerImpl(logger, (n) -> true, groupManager, stageController,
+        mgmtController, stageManager, 5, weightGeneratorFactory, consistencyManager,
+        statePersistor, topologyManager);
+
+    // Move to REPLICA mode
+    stateManager.moveToReplicaMode();
+    assertEquals(ServerMode.REPLICA_START, stateManager.getCurrentMode());
+
+    // Verify REPLICA_START mode properties that prevent election participation
+    assertFalse("Replica should not be able to start elections",
+        stateManager.getCurrentMode().canStartElection());
+    assertFalse("Replica should not be able to become active",
+        stateManager.getCurrentMode().canBeActive());
+  }
+
+  @Test
+  public void testReplicaStartModeProperties() throws Exception {
+    // Set up state manager in REPLICA mode
+    stateManager = new StateManagerImpl(logger, (n) -> true, groupManager, stageController,
+        mgmtController, stageManager, 5, weightGeneratorFactory, consistencyManager,
+        statePersistor, topologyManager);
+
+    stateManager.moveToReplicaMode();
+
+    // Verify REPLICA_START mode has correct properties
+    assertEquals(ServerMode.REPLICA_START, stateManager.getCurrentMode());
+    assertFalse("REPLICA_START should not be able to start elections",
+        stateManager.getCurrentMode().canStartElection());
+    assertFalse("REPLICA_START should not be able to become active",
+        stateManager.getCurrentMode().canBeActive());
+    assertFalse("REPLICA_START should not contain data",
+        stateManager.getCurrentMode().containsData());
+    assertTrue("REPLICA_START should be in startup mode",
+        stateManager.getCurrentMode().isStartup());
+    assertFalse("REPLICA_START should not require election",
+        stateManager.getCurrentMode().requiresElection());
+  }
+
+  @Test
+  public void testReplicaModeComparison() throws Exception {
+    stateManager = new StateManagerImpl(logger, (n) -> true, groupManager, stageController,
+        mgmtController, stageManager, 5, weightGeneratorFactory, consistencyManager,
+        statePersistor, topologyManager);
+
+    stateManager.moveToReplicaMode();
+
+    // Verify REPLICA_START is different from other passive modes
+    assertEquals(ServerMode.REPLICA_START, stateManager.getCurrentMode());
+    assertNotEquals("REPLICA_START should be different from PASSIVE",
+        ServerMode.PASSIVE, stateManager.getCurrentMode());
+    assertNotEquals("REPLICA_START should be different from RELAY",
+        ServerMode.RELAY, stateManager.getCurrentMode());
+    assertNotEquals("REPLICA_START should be different from SYNCING",
+        ServerMode.SYNCING, stateManager.getCurrentMode());
+  }
+
+  @Test
+  public void testReplicaDoesNotStartElection() throws Exception {
+    // Replicas should not participate in elections at all
+    stateManager = new StateManagerImpl(logger, (n) -> true, groupManager, stageController,
+        mgmtController, stageManager, 5, weightGeneratorFactory, consistencyManager,
+        statePersistor, topologyManager);
+
+    // Move to REPLICA_START mode
+    stateManager.moveToReplicaMode();
+    assertEquals(ServerMode.REPLICA_START, stateManager.getCurrentMode());
+
+    // Verify replica mode doesn't allow election start
+    assertFalse(stateManager.getCurrentMode().canStartElection());
+  }
+
+  @Test
+  public void testReplicaCannotBeActive() throws Exception {
+    // Test that REPLICA_START mode cannot become active
+    stateManager = new StateManagerImpl(logger, (n) -> true, groupManager, stageController,
+        mgmtController, stageManager, 5, weightGeneratorFactory, consistencyManager,
+        statePersistor, topologyManager);
+
+    stateManager.moveToReplicaMode();
+
+    // Verify REPLICA_START mode cannot be active
+    assertFalse(stateManager.getCurrentMode().canBeActive());
+
+    // Verify it doesn't contain data (fresh start)
+    assertFalse(stateManager.getCurrentMode().containsData());
+
+    // Verify it's in startup mode
+    assertTrue(stateManager.getCurrentMode().isStartup());
+  }
+
+  @Test
+  public void testReplicaModeTransitionsCorrectly() throws Exception {
+    stateManager = new StateManagerImpl(logger, (n) -> true, groupManager, stageController,
+        mgmtController, stageManager, 5, weightGeneratorFactory, consistencyManager,
+        statePersistor, topologyManager);
+
+    // Test transition from INITIAL to RELAY
+    assertEquals(ServerMode.INITIAL, stateManager.getCurrentMode());
+    stateManager.moveToRelayMode();
+    assertEquals(ServerMode.RELAY, stateManager.getCurrentMode());
+
+    // Test that RELAY can transition to REPLICA_START
+    stateManager.moveToReplicaMode();
+    assertEquals(ServerMode.REPLICA_START, stateManager.getCurrentMode());
+
+    // Verify RELAY and REPLICA_START share similar properties
+    assertFalse("Both RELAY and REPLICA_START should not require elections",
+        ServerMode.RELAY.requiresElection());
+    assertFalse("Both RELAY and REPLICA_START should not require elections",
+        ServerMode.REPLICA_START.requiresElection());
+  }
+}

--- a/tc-server/src/test/java/com/tc/management/beans/TCServerInfoReplicaFailoverTest.java
+++ b/tc-server/src/test/java/com/tc/management/beans/TCServerInfoReplicaFailoverTest.java
@@ -1,0 +1,165 @@
+/*
+ *  Copyright Terracotta, Inc.
+ *  Copyright IBM Corp. 2024, 2026
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.tc.management.beans;
+
+import com.tc.productinfo.ProductInfo;
+import com.tc.server.TCServer;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.management.NotCompliantMBeanException;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for replica failover to active diagnostic functionality added in commit 5b28bd26e3.
+ * Verifies the replicaFailoverToActive() method in TCServerInfo.
+ */
+public class TCServerInfoReplicaFailoverTest {
+
+  private TCServer server;
+  private TCServerInfo serverInfo;
+  private ProductInfo productInfo;
+
+  @Before
+  public void setUp() throws NotCompliantMBeanException {
+    server = mock(TCServer.class);
+    productInfo = mock(ProductInfo.class);
+
+    when(server.productInfo()).thenReturn(productInfo);
+    when(productInfo.buildID()).thenReturn("test-build");
+    when(productInfo.moniker()).thenReturn("Terracotta");
+    when(productInfo.kitID()).thenReturn("test-kit");
+    when(productInfo.toShortString()).thenReturn("1.0.0");
+    when(productInfo.copyright()).thenReturn("Copyright Test");
+
+    serverInfo = new TCServerInfo(server);
+  }
+
+  @Test
+  public void testReplicaFailoverToActiveSuccess() {
+    // Mock successful failover
+    when(server.replicaFailoverToActive()).thenReturn(true);
+
+    boolean result = serverInfo.replicaFailoverToActive();
+
+    assertTrue("Failover should succeed", result);
+    verify(server).replicaFailoverToActive();
+  }
+
+  @Test
+  public void testReplicaFailoverToActiveFailure() {
+    // Mock failed failover
+    when(server.replicaFailoverToActive()).thenReturn(false);
+
+    boolean result = serverInfo.replicaFailoverToActive();
+
+    assertFalse("Failover should fail", result);
+    verify(server).replicaFailoverToActive();
+  }
+
+  @Test
+  public void testReplicaFailoverToActiveCalledOnce() {
+    when(server.replicaFailoverToActive()).thenReturn(true);
+
+    serverInfo.replicaFailoverToActive();
+
+    // Verify the method is called exactly once
+    verify(server, times(1)).replicaFailoverToActive();
+  }
+
+  @Test
+  public void testReplicaFailoverToActiveWithException() {
+    // Mock exception during failover
+    when(server.replicaFailoverToActive()).thenThrow(new RuntimeException("Failover error"));
+
+    try {
+      serverInfo.replicaFailoverToActive();
+      fail("Expected RuntimeException");
+    } catch (RuntimeException e) {
+      assertEquals("Failover error", e.getMessage());
+    }
+
+    verify(server).replicaFailoverToActive();
+  }
+
+  @Test
+  public void testReplicaFailoverToActiveMultipleCalls() {
+    // Test multiple failover attempts
+    when(server.replicaFailoverToActive())
+        .thenReturn(false)  // First attempt fails
+        .thenReturn(true);  // Second attempt succeeds
+
+    boolean firstResult = serverInfo.replicaFailoverToActive();
+    assertFalse("First failover should fail", firstResult);
+
+    boolean secondResult = serverInfo.replicaFailoverToActive();
+    assertTrue("Second failover should succeed", secondResult);
+
+    verify(server, times(2)).replicaFailoverToActive();
+  }
+
+  @Test
+  public void testReplicaFailoverToActiveIntegrationWithServerState() {
+    // Test that failover respects server state
+    when(server.isActive()).thenReturn(false);
+    when(server.isPassiveStandby()).thenReturn(false);
+    when(server.replicaFailoverToActive()).thenReturn(true);
+
+    // Server should not be active before failover
+    assertFalse(serverInfo.isActive());
+    assertFalse(serverInfo.isPassiveStandby());
+
+    // Perform failover
+    boolean result = serverInfo.replicaFailoverToActive();
+    assertTrue("Failover should succeed", result);
+
+    // Simulate server becoming active after failover
+    when(server.isActive()).thenReturn(true);
+    assertTrue(serverInfo.isActive());
+  }
+
+  @Test
+  public void testReplicaFailoverToActiveWhenAlreadyActive() {
+    // Test failover when server is already active
+    when(server.isActive()).thenReturn(true);
+    when(server.replicaFailoverToActive()).thenReturn(false);
+
+    boolean result = serverInfo.replicaFailoverToActive();
+
+    // Should return false since already active
+    assertFalse("Failover should fail when already active", result);
+    verify(server).replicaFailoverToActive();
+  }
+
+  @Test
+  public void testReplicaFailoverToActiveNotAffectingOtherOperations() {
+    // Verify failover doesn't interfere with other server operations
+    when(server.isStarted()).thenReturn(true);
+    when(server.getStartTime()).thenReturn(System.currentTimeMillis());
+    when(server.replicaFailoverToActive()).thenReturn(true);
+
+    // Other operations should work normally
+    assertTrue(serverInfo.isStarted());
+    assertTrue(serverInfo.getStartTime() > 0);
+
+    // Failover should still work
+    assertTrue(serverInfo.replicaFailoverToActive());
+  }
+}

--- a/tc-server/src/test/java/com/tc/objectserver/handler/PassiveAckSenderTest.java
+++ b/tc-server/src/test/java/com/tc/objectserver/handler/PassiveAckSenderTest.java
@@ -1,0 +1,287 @@
+/*
+ *  Copyright Terracotta, Inc.
+ *  Copyright IBM Corp. 2024, 2026
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.tc.objectserver.handler;
+
+import com.tc.async.api.Sink;
+import com.tc.l2.msg.ReplicationMessageAck;
+import com.tc.l2.msg.ReplicationResultCode;
+import com.tc.l2.msg.SyncReplicationActivity;
+import com.tc.net.ClientID;
+import com.tc.net.ServerID;
+import com.tc.net.groups.AbstractGroupMessage;
+import com.tc.net.groups.GroupException;
+import com.tc.net.groups.GroupManager;
+import com.tc.net.groups.GroupMessage;
+import com.tc.object.ClientInstanceID;
+import com.tc.object.FetchID;
+import com.tc.object.tx.TransactionID;
+import com.tc.objectserver.api.ServerEntityAction;
+import com.tc.objectserver.api.ServerEntityRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for PassiveAckSender backpressure logic added in commit 453d3c50f2.
+ * Verifies batching, backpressure, and message flow control.
+ */
+public class PassiveAckSenderTest {
+
+  private GroupManager<AbstractGroupMessage> groupManager;
+  private Predicate<GroupMessage> sendConfirm;
+  private Sink<Runnable> sentToActive;
+  private PassiveAckSender passiveAckSender;
+  private ServerID activeServer;
+  private ServerID localServer;
+
+  @SuppressWarnings("unchecked")
+  @Before
+  public void setUp() {
+    groupManager = mock(GroupManager.class);
+    sendConfirm = mock(Predicate.class);
+    sentToActive = mock(Sink.class);
+    localServer = new ServerID("local", "local".getBytes());
+    activeServer = new ServerID("active", "active".getBytes());
+
+    when(groupManager.getLocalNodeID()).thenReturn(localServer);
+    when(sendConfirm.test(any())).thenReturn(true);
+
+    // Execute runnables immediately for testing
+    doAnswer(invocation -> {
+      Runnable r = invocation.getArgument(0);
+      r.run();
+      return null;
+    }).when(sentToActive).addToSink(any(Runnable.class));
+
+    passiveAckSender = new PassiveAckSender(groupManager, sendConfirm, sentToActive);
+  }
+
+  @Test
+  public void testAcknowledgeCreatesMessage() throws GroupException {
+    SyncReplicationActivity activity = createTestActivity();
+
+    passiveAckSender.acknowledge(activeServer, activity, ReplicationResultCode.SUCCESS);
+
+    // Verify that a message was sent to the active
+    verify(groupManager, atLeastOnce()).sendToWithSentCallback(eq(activeServer), any(ReplicationMessageAck.class), any());
+  }
+
+  @Test
+  public void testAckReceivedWithFuture() throws Exception {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    SyncReplicationActivity activity = createTestActivity();
+
+    // Start acknowledgment in separate thread
+    Thread ackThread = new Thread(() -> {
+      passiveAckSender.ackReceived(activeServer, activity, future);
+    });
+    ackThread.start();
+
+    // Complete the future
+    future.complete(null);
+    ackThread.join(1000);
+
+    // Verify message was sent after future completed
+    verify(groupManager, atLeastOnce()).sendToWithSentCallback(eq(activeServer), any(ReplicationMessageAck.class), any());
+  }
+
+  @Test
+  public void testAckReceivedWithFailedFuture() {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    future.completeExceptionally(new RuntimeException("Test exception"));
+    SyncReplicationActivity activity = createTestActivity();
+
+    try {
+      passiveAckSender.ackReceived(activeServer, activity, future);
+      fail("Expected RuntimeException");
+    } catch (RuntimeException e) {
+      assertTrue(e.getMessage().contains("Caught exception while persisting transaction order"));
+    }
+  }
+
+  @Test
+  public void testBatchingMultipleAcknowledgments() throws GroupException {
+    // Send multiple acknowledgments
+    for (int i = 0; i < 10; i++) {
+      SyncReplicationActivity activity = createTestActivity();
+      passiveAckSender.acknowledge(activeServer, activity, ReplicationResultCode.SUCCESS);
+    }
+
+    // Verify batching occurred - should be fewer sends than individual acks
+    ArgumentCaptor<ReplicationMessageAck> captor = ArgumentCaptor.forClass(ReplicationMessageAck.class);
+    verify(groupManager, atLeast(1)).sendToWithSentCallback(eq(activeServer), captor.capture(), any());
+  }
+
+  @Test
+  public void testBackpressureWithSendConfirm() throws GroupException {
+    AtomicInteger sendCount = new AtomicInteger(0);
+
+    // Simulate backpressure - only allow sends every other time
+    when(sendConfirm.test(any())).thenAnswer(invocation -> {
+      return sendCount.incrementAndGet() % 2 == 0;
+    });
+
+    // Send multiple acknowledgments
+    for (int i = 0; i < 20; i++) {
+      SyncReplicationActivity activity = createTestActivity();
+      passiveAckSender.acknowledge(activeServer, activity, ReplicationResultCode.SUCCESS);
+    }
+
+    // Verify that backpressure was applied
+    assertTrue("Send count should be greater than 0", sendCount.get() > 0);
+  }
+
+  @Test
+  public void testGetLocalNodeID() {
+    assertEquals(localServer, passiveAckSender.getLocalNodeID());
+  }
+
+  @Test
+  public void testRequestPassiveSync() throws GroupException {
+    ServerID target = new ServerID("target", "target".getBytes());
+
+    passiveAckSender.requestPassiveSync(target);
+
+    ArgumentCaptor<ReplicationMessageAck> captor = ArgumentCaptor.forClass(ReplicationMessageAck.class);
+    verify(groupManager).sendTo(eq(target), captor.capture());
+
+    // Verify it's a sync request message
+    assertNotNull(captor.getValue());
+  }
+
+  @Test
+  public void testTransformActivity() {
+    SyncReplicationActivity activity = SyncReplicationActivity.createInvokeMessage(
+        new FetchID(1L),
+        new ClientID(1L),
+        new ClientInstanceID(1L),
+        new TransactionID(1L),
+        new TransactionID(0L),
+        SyncReplicationActivity.ActivityType.INVOKE_ACTION,
+        null,
+        1,
+        ""
+    );
+
+    ServerEntityRequest request = passiveAckSender.transform(activity);
+
+    assertNotNull(request);
+    assertEquals(ServerEntityAction.INVOKE_ACTION, request.getAction());
+    assertEquals(new ClientID(1L), request.getNodeID());
+    assertEquals(new TransactionID(1L), request.getTransaction());
+  }
+
+  @Test
+  public void testDecodeReplicationTypeForAllActivityTypes() {
+    // Test all activity types can be decoded
+    assertEquals(ServerEntityAction.ORDER_PLACEHOLDER_ONLY,
+        PassiveAckSender.decodeReplicationType(SyncReplicationActivity.ActivityType.SYNC_START));
+    assertEquals(ServerEntityAction.ORDER_PLACEHOLDER_ONLY,
+        PassiveAckSender.decodeReplicationType(SyncReplicationActivity.ActivityType.SYNC_END));
+    assertEquals(ServerEntityAction.ORDER_PLACEHOLDER_ONLY,
+        PassiveAckSender.decodeReplicationType(SyncReplicationActivity.ActivityType.ORDERING_PLACEHOLDER));
+    assertEquals(ServerEntityAction.MANAGED_ENTITY_GC,
+        PassiveAckSender.decodeReplicationType(SyncReplicationActivity.ActivityType.LOCAL_ENTITY_GC));
+    assertEquals(ServerEntityAction.LOCAL_FLUSH,
+        PassiveAckSender.decodeReplicationType(SyncReplicationActivity.ActivityType.FLUSH_LOCAL_PIPELINE));
+    assertEquals(ServerEntityAction.CREATE_ENTITY,
+        PassiveAckSender.decodeReplicationType(SyncReplicationActivity.ActivityType.CREATE_ENTITY));
+    assertEquals(ServerEntityAction.RECONFIGURE_ENTITY,
+        PassiveAckSender.decodeReplicationType(SyncReplicationActivity.ActivityType.RECONFIGURE_ENTITY));
+    assertEquals(ServerEntityAction.INVOKE_ACTION,
+        PassiveAckSender.decodeReplicationType(SyncReplicationActivity.ActivityType.INVOKE_ACTION));
+    assertEquals(ServerEntityAction.DESTROY_ENTITY,
+        PassiveAckSender.decodeReplicationType(SyncReplicationActivity.ActivityType.DESTROY_ENTITY));
+    assertEquals(ServerEntityAction.FETCH_ENTITY,
+        PassiveAckSender.decodeReplicationType(SyncReplicationActivity.ActivityType.FETCH_ENTITY));
+    assertEquals(ServerEntityAction.RELEASE_ENTITY,
+        PassiveAckSender.decodeReplicationType(SyncReplicationActivity.ActivityType.RELEASE_ENTITY));
+    assertEquals(ServerEntityAction.RECEIVE_SYNC_ENTITY_START_SYNCING,
+        PassiveAckSender.decodeReplicationType(SyncReplicationActivity.ActivityType.SYNC_ENTITY_BEGIN));
+    assertEquals(ServerEntityAction.RECEIVE_SYNC_ENTITY_KEY_START,
+        PassiveAckSender.decodeReplicationType(SyncReplicationActivity.ActivityType.SYNC_ENTITY_CONCURRENCY_BEGIN));
+    assertEquals(ServerEntityAction.RECEIVE_SYNC_PAYLOAD,
+        PassiveAckSender.decodeReplicationType(SyncReplicationActivity.ActivityType.SYNC_ENTITY_CONCURRENCY_PAYLOAD));
+    assertEquals(ServerEntityAction.RECEIVE_SYNC_ENTITY_KEY_END,
+        PassiveAckSender.decodeReplicationType(SyncReplicationActivity.ActivityType.SYNC_ENTITY_CONCURRENCY_END));
+    assertEquals(ServerEntityAction.RECEIVE_SYNC_ENTITY_END,
+        PassiveAckSender.decodeReplicationType(SyncReplicationActivity.ActivityType.SYNC_ENTITY_END));
+    assertEquals(ServerEntityAction.DISCONNECT_CLIENT,
+        PassiveAckSender.decodeReplicationType(SyncReplicationActivity.ActivityType.DISCONNECT_CLIENT));
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testDecodeReplicationTypeThrowsForSyncBegin() {
+    PassiveAckSender.decodeReplicationType(SyncReplicationActivity.ActivityType.SYNC_BEGIN);
+  }
+
+  @Test
+  public void testNoAckSentForNullActiveServer() throws GroupException {
+    SyncReplicationActivity activity = createTestActivity();
+
+    passiveAckSender.acknowledge(ServerID.NULL_ID, activity, ReplicationResultCode.SUCCESS);
+
+    // Verify no message was sent when active server is NULL
+    verify(groupManager, never()).sendTo(any(ServerID.class), any(ReplicationMessageAck.class));
+  }
+
+  @Test
+  public void testMultipleActiveSwitching() throws GroupException {
+    ServerID active1 = new ServerID("active1", "active1".getBytes());
+    ServerID active2 = new ServerID("active2", "active2".getBytes());
+
+    // Send acks to first active
+    for (int i = 0; i < 5; i++) {
+      SyncReplicationActivity activity = createTestActivity();
+      passiveAckSender.acknowledge(active1, activity, ReplicationResultCode.SUCCESS);
+    }
+
+    // Switch to second active
+    for (int i = 0; i < 5; i++) {
+      SyncReplicationActivity activity = createTestActivity();
+      passiveAckSender.acknowledge(active2, activity, ReplicationResultCode.SUCCESS);
+    }
+
+    // Verify messages were sent to both actives
+    verify(groupManager, atLeastOnce()).sendToWithSentCallback(eq(active1), any(ReplicationMessageAck.class), any());
+    verify(groupManager, atLeastOnce()).sendToWithSentCallback(eq(active2), any(ReplicationMessageAck.class), any());
+  }
+
+  private SyncReplicationActivity createTestActivity() {
+    return SyncReplicationActivity.createInvokeMessage(
+        new FetchID(1L),
+        new ClientID(1L),
+        new ClientInstanceID(1L),
+        new TransactionID(System.nanoTime()), // Use unique transaction ID
+        new TransactionID(0L),
+        SyncReplicationActivity.ActivityType.INVOKE_ACTION,
+        null,
+        1,
+        ""
+    );
+  }
+}

--- a/tc-server/src/test/java/com/tc/objectserver/handler/PassiveMessageResultCollectorTest.java
+++ b/tc-server/src/test/java/com/tc/objectserver/handler/PassiveMessageResultCollectorTest.java
@@ -1,0 +1,211 @@
+/*
+ *  Copyright Terracotta, Inc.
+ *  Copyright IBM Corp. 2024, 2026
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.tc.objectserver.handler;
+
+import com.tc.l2.msg.ReplicationResultCode;
+import com.tc.l2.msg.SyncReplicationActivity;
+import com.tc.net.ClientID;
+import com.tc.net.NodeID;
+import com.tc.net.ServerID;
+import com.tc.object.ClientInstanceID;
+import com.tc.object.EntityID;
+import com.tc.object.FetchID;
+import com.tc.object.tx.TransactionID;
+import com.tc.objectserver.api.ServerEntityAction;
+import com.tc.objectserver.api.ServerEntityRequest;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for PassiveMessageResultCollector interface added in commit 453d3c50f2.
+ * Verifies the contract and basic implementations.
+ */
+public class PassiveMessageResultCollectorTest {
+
+  @Test
+  public void testPassiveMessageResultCollectorContract() {
+    // Create a simple implementation to test the interface contract
+    PassiveMessageResultCollector collector = new TestPassiveMessageResultCollector();
+
+    ServerID activeServer = new ServerID("active", "active".getBytes());
+    SyncReplicationActivity activity = createTestActivity();
+
+    // Test acknowledge method
+    collector.acknowledge(activeServer, activity, ReplicationResultCode.SUCCESS);
+
+    // Test ackReceived method
+    CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
+    collector.ackReceived(activeServer, activity, future);
+
+    // Test getLocalNodeID method
+    ServerID localNode = collector.getLocalNodeID();
+    assertNotNull("Local node ID should not be null", localNode);
+
+    // Test transform method
+    ServerEntityRequest request = collector.transform(activity);
+    assertNotNull("Transformed request should not be null", request);
+    assertEquals(ServerEntityAction.INVOKE_ACTION, request.getAction());
+  }
+
+  @Test
+  public void testTransformWithDifferentActivityTypes() {
+    PassiveMessageResultCollector collector = new TestPassiveMessageResultCollector();
+
+    // Test CREATE_ENTITY
+    SyncReplicationActivity createActivity = SyncReplicationActivity.createLifecycleMessage(
+        new EntityID("test", "test"),
+        1L,
+        new FetchID(1L),
+        new ClientID(1L),
+        new ClientInstanceID(1L),
+        new TransactionID(1L),
+        new TransactionID(0L),
+        SyncReplicationActivity.ActivityType.CREATE_ENTITY,
+        null
+    );
+    ServerEntityRequest createRequest = collector.transform(createActivity);
+    assertEquals(ServerEntityAction.CREATE_ENTITY, createRequest.getAction());
+
+    // Test DESTROY_ENTITY
+    SyncReplicationActivity destroyActivity = SyncReplicationActivity.createLifecycleMessage(
+        new EntityID("test", "test"),
+        1L,
+        new FetchID(1L),
+        new ClientID(1L),
+        new ClientInstanceID(1L),
+        new TransactionID(1L),
+        new TransactionID(0L),
+        SyncReplicationActivity.ActivityType.DESTROY_ENTITY,
+        null
+    );
+    ServerEntityRequest destroyRequest = collector.transform(destroyActivity);
+    assertEquals(ServerEntityAction.DESTROY_ENTITY, destroyRequest.getAction());
+
+    // Test FETCH_ENTITY
+    SyncReplicationActivity fetchActivity = SyncReplicationActivity.createLifecycleMessage(
+        new EntityID("test", "test"),
+        1L,
+        new FetchID(1L),
+        new ClientID(1L),
+        new ClientInstanceID(1L),
+        new TransactionID(1L),
+        new TransactionID(0L),
+        SyncReplicationActivity.ActivityType.FETCH_ENTITY,
+        null
+    );
+    ServerEntityRequest fetchRequest = collector.transform(fetchActivity);
+    assertEquals(ServerEntityAction.FETCH_ENTITY, fetchRequest.getAction());
+  }
+
+  @Test
+  public void testAckReceivedWithNullFuture() {
+    PassiveMessageResultCollector collector = new TestPassiveMessageResultCollector();
+    ServerID activeServer = new ServerID("active", "active".getBytes());
+    SyncReplicationActivity activity = createTestActivity();
+
+    // Should handle null future gracefully
+    collector.ackReceived(activeServer, activity, null);
+  }
+
+  @Test
+  public void testAcknowledgeWithDifferentResultCodes() {
+    PassiveMessageResultCollector collector = new TestPassiveMessageResultCollector();
+    ServerID activeServer = new ServerID("active", "active".getBytes());
+    SyncReplicationActivity activity = createTestActivity();
+
+    // Test all result codes
+    collector.acknowledge(activeServer, activity, ReplicationResultCode.SUCCESS);
+    collector.acknowledge(activeServer, activity, ReplicationResultCode.RECEIVED);
+    collector.acknowledge(activeServer, activity, ReplicationResultCode.FAIL);
+  }
+
+  @Test
+  public void testRequestPassiveSync() {
+    PassiveMessageResultCollector collector = new TestPassiveMessageResultCollector();
+    ServerID target = new ServerID("target", "target".getBytes());
+
+    // Should not throw exception
+    try {
+      collector.requestPassiveSync(target);
+    } catch (UnsupportedOperationException e) {
+      // Expected for test implementation
+      assertTrue(e.getMessage().contains("Not supported"));
+    }
+  }
+
+  private SyncReplicationActivity createTestActivity() {
+    return SyncReplicationActivity.createInvokeMessage(
+        new FetchID(1L),
+        new ClientID(1L),
+        new ClientInstanceID(1L),
+        new TransactionID(1L),
+        new TransactionID(0L),
+        SyncReplicationActivity.ActivityType.INVOKE_ACTION,
+        null,
+        1,
+        ""
+    );
+  }
+
+  /**
+   * Simple test implementation of PassiveMessageResultCollector
+   */
+  private static class TestPassiveMessageResultCollector implements PassiveMessageResultCollector {
+    private final ServerID localNode = new ServerID("local", "local".getBytes());
+
+    @Override
+    public void acknowledge(ServerID activeSender, SyncReplicationActivity activity, ReplicationResultCode code) {
+      // Test implementation - just verify parameters are not null
+      assertNotNull(activeSender);
+      assertNotNull(activity);
+      assertNotNull(code);
+    }
+
+    @Override
+    public void ackReceived(ServerID activeSender, SyncReplicationActivity activity, Future<Void> future) {
+      // Test implementation - just verify parameters are not null (except future which can be null)
+      assertNotNull(activeSender);
+      assertNotNull(activity);
+    }
+
+    @Override
+    public ServerID getLocalNodeID() {
+      return localNode;
+    }
+
+    @Override
+    public void requestPassiveSync(NodeID target) {
+      throw new UnsupportedOperationException("Not supported in test implementation");
+    }
+
+    @Override
+    public ServerEntityRequest transform(SyncReplicationActivity activity) {
+      return new ReplicatedTransactionHandler.BasicServerEntityRequest(
+          PassiveAckSender.decodeReplicationType(activity.getActivityType()),
+          activity.getSource(),
+          activity.getClientInstanceID(),
+          activity.getTransactionID(),
+          activity.getOldestTransactionOnClient()
+      );
+    }
+  }
+}

--- a/tc-server/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
+++ b/tc-server/src/test/java/com/tc/objectserver/handler/ReplicatedTransactionHandlerTest.java
@@ -125,7 +125,7 @@ public class ReplicatedTransactionHandlerTest {
       return null;
     }).when(sink).addToSink(any(Runnable.class));
 
-    this.rth = new ReplicatedTransactionHandler(stateManager, runner, persistor, this.entityManager, this.groupManager, false);
+    this.rth = new ReplicatedTransactionHandler(stateManager, persistor, this.entityManager, new PassiveAckSender(groupManager, m->true, sink));
     // We need to do things like serialize/deserialize this so we can't easily use a mocked source.
     this.source = new ClientID(1);
     this.instance = new ClientInstanceID(1);


### PR DESCRIPTION
We back pressure entity creation like it was connected to active If the server is operating in replica mode.  This prevents concurrent creation of entities.

Also implemented and resync on ResultCode.FAIL.  This is because relay servers always respond success and any failure here means some environment or configuration failure.